### PR TITLE
Memoise hash calc

### DIFF
--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -174,6 +174,7 @@ class Star (object):
         self.starportSize = 0
         self.starportBudget = 0
         self.starportPop = 0
+        self._hash = None
         
     def __unicode__(self):
         return u"{} ({} {})".format(self.name, self.sector.name, self.position)
@@ -195,7 +196,9 @@ class Star (object):
             return False
 
     def __hash__(self):
-        return hash(self.__key())
+        if self._hash is None:
+            self._hash = hash(self.__key())
+        return self._hash
 
     def wiki_name(self):
         name = u" ".join(w.capitalize() for w in self.name.lower().split())
@@ -638,4 +641,3 @@ class Star (object):
         self.stars = self.stars[0:star_end].strip()
         if len(self.routes) > 0:
             self.logger.debug("{} - routes: {}".format(self, self.routes))
-        

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -191,6 +191,8 @@ class Star (object):
 
     def __eq__(self, y):
         if isinstance(y, Star):
+            if self.__hash__() != y.__hash__() :
+                return False
             return self.__key() == y.__key()
         else:
             return False

--- a/Tests/StarTests.py
+++ b/Tests/StarTests.py
@@ -143,6 +143,18 @@ class Test(unittest.TestCase):
         newHash = star1.__hash__()
         self.assertEqual(oldHash,  newHash)
 
+    def TestEquals(self):
+        star1 = Star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+             self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
+        star2 = Star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+             self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
+        star3 = Star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
+                     self.starline,  Sector('Core', ' 0, 0'), 'fixed',  None)
+        
+        self.assertEqual(star1,  star2)
+        self.assertNotEqual(star1,  star3)
+        self.assertNotEqual(star2,  star3)
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/Tests/StarTests.py
+++ b/Tests/StarTests.py
@@ -34,7 +34,7 @@ class Test(unittest.TestCase):
 
     def testParseIrkigkhan(self):
         star1 = Star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-                     self.starline, Sector('Core', ' 0, 0'), 'fixed')
+                     self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
         
         self.assertTrue(star1.position == '0103')
         self.assertTrue(star1.q == 0 and star1.r == 2, "%s, %s" % (star1.q, star1.r))
@@ -51,7 +51,7 @@ class Test(unittest.TestCase):
 
     def testParseShanaMa(self):
         star1 = Star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-                     self.starline,  Sector('Core', ' 0, 0'), 'fixed')
+                     self.starline,  Sector('Core', ' 0, 0'), 'fixed',  None)
         self.assertTrue(star1.position == '0104')
         self.assertTrue(star1.q == 0 and star1.r == 3, "%s, %s" % (star1.q, star1.r))
         self.assertTrue(star1.name == 'Shana Ma')

--- a/Tests/StarTests.py
+++ b/Tests/StarTests.py
@@ -134,7 +134,14 @@ class Test(unittest.TestCase):
         self.assertEqual(TradeCalculation.calc_passengers(14), 100)
         self.assertEqual(TradeCalculation.calc_passengers(15), 500)
 
-
+    def testHashValueSameAfterCaching(self):
+        star1 = Star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+             self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
+    
+        # Grabbing hash value twice, once to seed Star._hash, second to dig it out of that cache
+        oldHash = star1.__hash__()
+        newHash = star1.__hash__()
+        self.assertEqual(oldHash,  newHash)
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']


### PR DESCRIPTION
Memoise hash calculation of Star objects to speed up route generation.
- Star objects seem immutable once route generation starts, so calculate hash code once and cache it, rather than on each and every call.

Add hash-equality check to Star __eq__ method.
- Take advantage of the hash-calc speedup and check that two Star objects have the same hash code, before proceeding to the full key-equality check.  If hash codes are not equal, the two objects cannot be equal, so avoid pointlessly incurring the full key-equality cost.

As a result of those changes, I've been able to reduce route-generation time for Reft + the four orthogonally adjacent sectors on a 4x4.1 Ghz Intel i7-6700k by 38% - from 135 seconds to 83 seconds.  Memoising hash calculation saved ~33% of original route-gen time, while adding hash-equality checks saved the other 5%.

As those methods are repeatedly called during A* path generation, my (very untutored, coming from very little Python-fu) expectation is that speedup should persist during scale up - approx 1/3 of time saved whether doing one sector or one hundred.