### PR TITLE
Square up tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+PyRoute/__pycache__/
+Tests/__pycache__/
+PyRoute/*.pyc
+Tests/*.pyc
+
+# ignore IDE-related detritus
+.idea/

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -109,7 +109,7 @@ class Subsector(AreaItem):
 
 class Sector (AreaItem):
     def __init__ (self, name, position):
-        super(Sector, self).__init__(name[1:].strip())
+        super(Sector, self).__init__(name[0:].strip())
 
         self.x = int(position[1:].split(',')[0])
         self.y = int(position[1:].split(',')[1])

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -190,7 +190,7 @@ class Star (object):
         return u"{} ({} {})".format(self.name, self.sector.name, self.position)
         
     def __str__(self):
-        name = u"%s (%s %s)" % (self.name,self.sector.name, self.position)
+        name = u"%s (%s %s)" % (self.name, self.sector.name, self.position)
         return name.encode('utf-8')
 
     def __repr__(self):

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -19,9 +19,11 @@ class TestStar(unittest.TestCase):
         self.starline = re.compile(star_regex)
 
     def testParseIrkigkhan(self):
+        sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-                     self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
-        
+                     self.starline, sector, 'fixed',  None)
+
+        self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
         self.assertTrue(star1.position == '0103')
         self.assertTrue(star1.q == 0 and star1.r == 2, "%s, %s" % (star1.q, star1.r))
         self.assertTrue(star1.name == 'Irkigkhan')
@@ -37,8 +39,11 @@ class TestStar(unittest.TestCase):
         self.assertEqual(star1.star_list, ['M2 V'])
 
     def testParseShanaMa(self):
+        sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-                     self.starline,  Sector('Core', ' 0, 0'), 'fixed',  None)
+                     self.starline,  sector, 'fixed',  None)
+
+        self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
         self.assertTrue(star1.position == '0104')
         self.assertTrue(star1.q == 0 and star1.r == 3, "%s, %s" % (star1.q, star1.r))
         self.assertTrue(star1.name == 'Shana Ma')
@@ -55,8 +60,11 @@ class TestStar(unittest.TestCase):
         self.assertEqual(star1.star_list, ['K2 IV', 'M7 V'])
         
     def testParseSyss(self):
+        sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star("2323 Syss                 C400746-8 Na Va Pi                   { -1 } (A67-2) [6647] BD   S  - 510 5  ImDv M9 III D M5 V",
-                     self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
+                     self.starline, sector, 'fixed',  None)
+
+        self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
         self.assertEqual(star1.position, '2323')
         self.assertEqual(star1.name, 'Syss')
         self.assertEqual(star1.uwp, 'C400746-8')

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -11,7 +11,7 @@ from Star import Star
 from Galaxy import Sector,Galaxy
 from TradeCalculation import TradeCalculation
 
-class Test(unittest.TestCase):
+class TestStar(unittest.TestCase):
 
     def setUp(self):
 

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -34,7 +34,7 @@ class TestStar(unittest.TestCase):
         self.assertFalse(star1.tradeCode.poor)
         self.assertFalse(star1.tradeCode.rich)
         self.assertTrue(star1.ggCount == 3)
-        self.assertEqual(star1.star_list, 'M2 V')
+        self.assertEqual(star1.star_list, ['M2 V'])
 
     def testParseShanaMa(self):
         star1 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -7,7 +7,7 @@ from TradeCodes import TradeCodes
 from Star import Star
 from Galaxy import Sector, Galaxy
 
-class Test(unittest.TestCase):
+class TestTradeCode(unittest.TestCase):
 
     def setUp(self):
         star_regex = ''.join([line.rstrip('\n') for line in Galaxy.regex])


### PR DESCRIPTION
Make the test files easier to discover to run with unittest by renaming them to the conventional `test*.py` format.

In the process of doing that, I tripped over an apparent omission when creating a Sector object - eg, for the star Irkigkhan (Core 0103), it was being printed in the logger as:
`ERROR - Irkigkhan (ore 0103)-C9C4733-9 Calculated "Fl" not in trade codes ['Wa']`

After what I presume is the fix, that same line now displays as:
`ERROR - Irkigkhan (Core 0103)-C9C4733-9 Calculated "Fl" not in trade codes ['Wa']`

I'm not sure what should be happening with PyRoute/DrawArcsTest.py, so I've left it alone - should it also be moved into the Tests folder?