### PR TITLE
Fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Tests/*.class
 
 # ignore IDE-related detritus
 .idea/
+
+# ignore downloaded/generated files
+sectors/
+maps/

--- a/PyRoute/AllyGen.py
+++ b/PyRoute/AllyGen.py
@@ -108,7 +108,7 @@ class AllyGen(object):
             Create borders around various allegiances, Algorithm one.
             From the nroute.c generation system. Every world controls a
             two hex radius. Where the allegiances are the same, the area
-            of control is contigious. Every Non-aligned world is independent
+            of control is contiguous. Every Non-aligned world is independent
         """
         self.logger.info('Processing worlds for border drawing')
         for star in self.galaxy.stars:
@@ -306,7 +306,7 @@ class AllyGen(object):
 
         #self._output_map(allyMap, 0)
         
-        #Pass 1: generate initial allegiance arrays, 
+        # Pass 1: generate initial allegiance arrays,
         # with overlapping maps
         for star in stars:
             # skip the E/X ports 
@@ -446,7 +446,7 @@ class AllyGen(object):
         '''
         edgeMap = {}
         changed = False
-        # Create the edge map, of hexes on the borber
+        # Create the edge map, of hexes on the border
         for Hex in allyMap.iterkeys():
             for direction in xrange(6):
                 checkHex = AllyGen._get_neighbor(Hex, direction)

--- a/PyRoute/DrawArcsTest.py
+++ b/PyRoute/DrawArcsTest.py
@@ -106,7 +106,7 @@ class DrawArcsTest (GraphicSubsectorMap):
         return point
     
     def circle_center(self, start, end):
-        # Caluclate the center of an equlateral triangle  from start and end
+        # Calculate the center of an equilateral triangle  from start and end
         #root3 = math.sqrt(3)
         root3 = 2
         xm = 0.5 * (start.x + end.x)

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -42,7 +42,7 @@ class Nobles(object):
                        'Baronets': 0,
                        'Barons': 0,
                        'Marquis': 0,
-                       'Vicounts': 0,
+                       'Viscounts': 0,
                        'Counts': 0,
                        'Dukes': 0,
                        'Sector Dukes': 0,
@@ -52,7 +52,7 @@ class Nobles(object):
                       'c': 'Baronets',
                       'C': 'Barons',
                       'D': 'Marquis',
-                      'e': 'Vicounts',
+                      'e': 'Viscounts',
                       'E': 'Counts',
                       'f': 'Dukes',
                       'F': 'Sector Dukes',
@@ -86,10 +86,10 @@ class Star (object):
         if starline.match(line):
             data = starline.match(line).groups()
         elif '{Anomaly}' in line:
-            star.logger.info("Found Anomaly, skpping processing: {}".format(line))
+            star.logger.info("Found anomaly, skipping processing: {}".format(line))
             return None
         else:
-            star.logger.error(u"Unmatched Line: {}".format(line))
+            star.logger.error(u"Unmatched line: {}".format(line))
             return None
         
         star.logger.debug (data)
@@ -420,10 +420,10 @@ class Star (object):
         labor = self._ehex_to_int(self.economics[2])
         if self.economics[3] == '-' :
             infrastructure = self._ehex_to_int(self.economics[3:5])
-            efficency = int(self.economics[5:7])
+            efficiency = int(self.economics[5:7])
         else:
             infrastructure = self._ehex_to_int(self.economics[3])
-            efficency = int(self.economics[4:6])
+            efficiency = int(self.economics[4:6])
         
         resources = resources if resources != 0 else 1
         # No I in eHex, so J,K,L all -1
@@ -435,16 +435,16 @@ class Star (object):
         infrastructure = infrastructure if infrastructure != 0 else 1
         infrastructure += 0 if infrastructure < 18 else -1
         
-        efficency = efficency if efficency != 0 else 1
-        if efficency < 0: 
+        efficiency = efficiency if efficiency != 0 else 1
+        if efficiency < 0:
             if ru_calc == 'scaled':
-                efficency = 1 + (efficency * 0.1)
+                efficiency = 1 + (efficiency * 0.1)
             # else ru_calc == 'negative' -> use efficiency as written
-            self.ru = int(round(resources * labor * infrastructure * efficency))
+            self.ru = int(round(resources * labor * infrastructure * efficiency))
         else:
-            self.ru = resources * labor * infrastructure * efficency
+            self.ru = resources * labor * infrastructure * efficiency
         
-        self.logger.debug ("RU = {0} * {1} * {2} * {3} = {4}".format(resources, labor, infrastructure, efficency, self.ru) )
+        self.logger.debug ("RU = {0} * {1} * {2} * {3} = {4}".format(resources, labor, infrastructure, efficiency, self.ru) )
         
     def calculate_TCS(self):
         tax_rate = {'0': 0.50, '1': 0.8, '2': 1.0, '3': 0.9, '4': 0.85, 

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -327,7 +327,7 @@ class Star (object):
             self.mspr -= 1 if self.hydro in ['1','2','A'] else 0
             self.mspr -= 2 if self.hydro in ['0'] else 0
             self.mspr -= 1 if self.atmo in ['4','5','8','9'] else 0 # thin or dense
-            self.mspr -= 1 if self.atmo in ['4','7','9'] else 0 # poluted   
+            self.mspr -= 1 if self.atmo in ['4','7','9'] else 0 # polluted
         
         
     def calculate_wtn(self):
@@ -439,7 +439,7 @@ class Star (object):
         if efficency < 0: 
             if ru_calc == 'scaled':
                 efficency = 1 + (efficency * 0.1)
-            # else ru_calc == 'negative' -> use efficency as written
+            # else ru_calc == 'negative' -> use efficiency as written
             self.ru = int(round(resources * labor * infrastructure * efficency))
         else:
             self.ru = resources * labor * infrastructure * efficency

--- a/PyRoute/SubsectorMap2.py
+++ b/PyRoute/SubsectorMap2.py
@@ -435,7 +435,7 @@ class GraphicSubsectorMap (GraphicMap):
         self.draw_arc(doc, center, start, end, color)
         
     def circle_center(self, start, end):
-        # Caluclate the center of an equlateral triangle  from start and end
+        # Calculate the center of an equilateral triangle from start and end
         #root3 = math.sqrt(3)
         root3 = 2
         xm = 0.5 * (start.x + end.x)

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -23,7 +23,7 @@ class RouteCalculation (object):
     route_reuse = 10
     # BTN modifier for range. If the hex distance between two worlds 
     # or between two numbers in the jump range array, take jump modifier
-    # to the right. E.g distance 4 would be a btn modifer of -3.  
+    # to the right. E.g distance 4 would be a btn modifier of -3.
     btn_jump_range = [ 1,  2,  5,  9, 19, 29, 59, 99, 199, 299]
     btn_jump_mod   =[0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]
 
@@ -41,12 +41,12 @@ class RouteCalculation (object):
         raise NotImplementedError ("Base Class")
 
     def base_route_filter (self, star, neighbor):
-        ''' 
+        '''
             Used in the generate_base_routes to filter (i.e. skip making a route)
-            between the star and neighbor. Used to remove un-helpful world links, 
-            links across borders, etc. 
+            between the star and neighbor. Used to remove un-helpful world links,
+            links across borders, etc.
             Return True to filter (ie. skip) creating a link between these two worlds
-            Return False to accept (i.e. create) a link between these two worlds. 
+            Return False to accept (i.e. create) a link between these two worlds.
         '''
         raise NotImplementedError ("Base Class")
     
@@ -519,7 +519,7 @@ class TradeCalculation(RouteCalculation):
                 continue
             neighbor_routes = [(s,n,d) for (s,n,d) in self.galaxy.stars.edges([star], True)]
             # Need to do two sorts here:
-            # BTN low to high to gind them first
+            # BTN low to high to find them first
             # Range high to low to find them first 
             neighbor_routes.sort(key=lambda tn: tn[2]['btn'])
             neighbor_routes.sort(key=lambda tn: tn[2]['distance'], reverse=True)
@@ -685,7 +685,7 @@ class TradeCalculation(RouteCalculation):
                 dist += self.galaxy.stars[start][end]['distance']
                 weight += self.galaxy.stars[start][end]['weight']
             else:
-                print start, end, self.galaxy.routes.has_edge(start, end)
+                print(start, end, self.galaxy.routes.has_edge(start, end))
             start = end
             
         if len(route) > 6 and not usesJumpRoute:
@@ -703,7 +703,7 @@ class TradeCalculation(RouteCalculation):
         ''' 
         Unused: 
         Calculate the trade route between starting star and all potential target.
-        This was the direct copy algorthim from nroute for doing route calculation
+        This was the direct copy algorithm from nroute for doing route calculation
         It was replaced by the process above which works better with the 
         pythonic data structures. It remains for historical purposes.  
         '''
@@ -801,8 +801,8 @@ class CommCalculation(RouteCalculation):
         return star.tradeCode.capital
 
     def bases(self, star):                    
-        # if it has a Deopt, Way station, or XBoat station,
-        # or external naval base or (aslan) Tlaukhu nase
+        # if it has a Depot, Way station, or XBoat station,
+        # or external naval base or (aslan) Tlaukhu base
         return len(set(['D', 'W', 'K', 'T']) & set(star.baseCode)) > 0
                 
     def comm_bases(self, star):

--- a/PyRoute/WikiCreateWorlds.py
+++ b/PyRoute/WikiCreateWorlds.py
@@ -295,7 +295,7 @@ def set_logging(level):
 def process():
     parser = argparse.ArgumentParser(description='Traveller Wiki create world articles.', fromfile_prefix_chars='@')
     parser.add_argument('--skip-list', help='file of worlds to skip adding/updating')
-    parser.add_argument('-c', '--category', action='append', help='File wilth list of worlds to append different category')
+    parser.add_argument('-c', '--category', action='append', help='File with list of worlds to append different category')
     parser.add_argument('-s', '--source', action='append', help='File with list of worlds to append a source')
     parser.add_argument('--log-level', default='INFO')
 

--- a/PyRoute/WikiUploadPDF.py
+++ b/PyRoute/WikiUploadPDF.py
@@ -270,8 +270,8 @@ No information yet available.
                                     u','.join(sophonts),              # sophonts
                                     u','.join(sorted(list(dcode))),   # details
                                     sec[4].strip(u'{}'),              # ix (important)
-                                    sec[5].strip(u'()'),              # ex (Economiv)
-                                    sec[6].strip(u'[]'),              # cx (cultureal)
+                                    sec[5].strip(u'()'),              # ex (economic)
+                                    sec[6].strip(u'[]'),              # cx (cultural)
                                     sec[7].strip(),                   # nobility
                                     sec[8].strip(),                   # bases
                                     sec[9].strip(),                   # Zone
@@ -279,7 +279,7 @@ No information yet available.
                                     sec[10][1],                       # Belts
                                     sec[10][2],                       # GG Count
                                     sec[11],                          # Worlds
-                                    sec[12],                          # Alegiance
+                                    sec[12],                          # Allegiance
                                     u','.join(stars),                 # stars
                                     int(eco[5].strip()),              # wtn
                                     eco[6].strip(),                   # RU

--- a/PyRoute/wikistats.py
+++ b/PyRoute/wikistats.py
@@ -359,7 +359,7 @@ class WikiStats(object):
             nlist.append(self.get_count(nobles.nobles['Baronets'], 'Baronet', False))
             nlist.append(self.get_count(nobles.nobles['Barons'], 'Baron', False))
             nlist.append(self.get_count(nobles.nobles['Marquis'], 'Marquis', False))
-            nlist.append(self.get_count(nobles.nobles['Vicounts'], 'Viscount', False))
+            nlist.append(self.get_count(nobles.nobles['Viscounts'], 'Viscount', False))
             nlist.append(self.get_count(nobles.nobles['Counts'], 'Count', False))
             nlist.append(self.get_count(nobles.nobles['Dukes'], 'Duke', False))
             if nobles.nobles['Sector Dukes'] > 0:

--- a/Tests/testNobles.py
+++ b/Tests/testNobles.py
@@ -19,7 +19,7 @@ class TestNobles(unittest.TestCase):
 
     def testStringWithOneViscount(self):
         nobles = Nobles()
-        nobles.nobles['Vicounts'] = 1
+        nobles.nobles['Viscounts'] = 1
 
         expected = 'e'
         self.assertEqual(expected, nobles.__str__())
@@ -29,18 +29,18 @@ class TestNobles(unittest.TestCase):
         nobles.count(['e'])
 
         expected = 1
-        actual = nobles.nobles['Vicounts']
+        actual = nobles.nobles['Viscounts']
 
         self.assertEqual(expected, actual)
 
     def testAccumulateSelf(self):
         nobles = Nobles()
-        nobles.nobles['Vicounts'] = 1
+        nobles.nobles['Viscounts'] = 1
 
         nobles.accumulate(nobles)
 
         expected = 2
-        actual = nobles.nobles['Vicounts']
+        actual = nobles.nobles['Viscounts']
 
         self.assertEqual(expected, actual)
 

--- a/Tests/testNobles.py
+++ b/Tests/testNobles.py
@@ -1,0 +1,49 @@
+"""
+Created on Jan 1, 2019
+
+@author: CyberiaResurrection
+"""
+
+import unittest
+import re
+import sys
+sys.path.append('../PyRoute')
+from Star import Nobles
+
+
+class TestNobles(unittest.TestCase):
+    def testDefaultString(self):
+        nobles = Nobles()
+        expected = ''
+        self.assertEqual(expected, nobles.__str__())
+
+    def testStringWithOneViscount(self):
+        nobles = Nobles()
+        nobles.nobles['Vicounts'] = 1
+
+        expected = 'e'
+        self.assertEqual(expected, nobles.__str__())
+
+    def testCountWithViscount(self):
+        nobles = Nobles()
+        nobles.count(['e'])
+
+        expected = 1
+        actual = nobles.nobles['Vicounts']
+
+        self.assertEqual(expected, actual)
+
+    def testAccumulateSelf(self):
+        nobles = Nobles()
+        nobles.nobles['Vicounts'] = 1
+
+        nobles.accumulate(nobles)
+
+        expected = 2
+        actual = nobles.nobles['Vicounts']
+
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -38,6 +38,26 @@ class TestStar(unittest.TestCase):
         self.assertTrue(star1.ggCount == 3)
         self.assertEqual(star1.star_list, ['M2 V'])
 
+    def testParseIrkigkhanRUCollapse(self):
+        sector = Sector('Core', ' 0, 0')
+        star1 = Star.parse_line_into_star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+                     self.starline, sector, 'fixed',  'collapse')
+
+        expected = 756
+        actual = star1.ru
+
+        self.assertEqual(expected, actual)
+
+    def testParseIrkigkhanRUScaled(self):
+        sector = Sector('Core', ' 0, 0')
+        star1 = Star.parse_line_into_star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+                     self.starline, sector, 'fixed',  'scaled')
+
+        expected = 756
+        actual = star1.ru
+
+        self.assertEqual(expected, actual)
+
     def testParseShanaMa(self):
         sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -60,7 +60,7 @@ class TestStar(unittest.TestCase):
 
     def testParseShanaMa(self):
         sector = Sector('Core', ' 0, 0')
-        star1 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
+        star1 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
                      self.starline,  sector, 'fixed',  None)
 
         self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
@@ -175,7 +175,7 @@ class TestStar(unittest.TestCase):
              self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
         star2 = Star.parse_line_into_star("0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
              self.starline, Sector('Core', ' 0, 0'), 'fixed',  None)
-        star3 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (300-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
+        star3 = Star.parse_line_into_star("0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
                      self.starline,  Sector('Core', ' 0, 0'), 'fixed',  None)
         
         self.assertEqual(star1,  star2)

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -46,7 +46,7 @@ class TestTradeCode(unittest.TestCase):
         code = TradeCodes(u"Ph C:0404")
         self.assertTrue(code.owned == [u'C:0404'], code.owned)
         self.assertTrue(code.colonies("Spinward Marches") == [u'C:Spin-0404'], code.colonies("Spinward Marches"))
-        self.assertTrue(code.owners('Spinward Marvhes') == [])
+        self.assertTrue(code.owners('Spinward Marches') == [])
         
     def testOwned (self):
         code = TradeCodes(u"Ag O:1011")
@@ -76,7 +76,7 @@ class TestTradeCode(unittest.TestCase):
         self.assertTrue(code.sophonts == ['Wiki4', 'Huma2'])
         self.assertTrue(code.codeset == ['Ag'])
         
-    def testSophontCompbined(self):
+    def testSophontCombined(self):
         code = TradeCodes("Ri (Wiki) Huma4 Alph2 (Deneb)2")
         self.assertTrue(len(code.homeworld) > 0)
         self.assertTrue(code.sophonts == ['Huma4', 'Alph2', 'WikiW', 'Dene2'], msg=code.sophonts)


### PR DESCRIPTION
Pretty much what it says on the tin - fix up obvious typos in comments and, in a couple of cases, variable names and array indices.

I steered well clear of British v American English.