### PR TITLE
Fix up tests to match Python 3

### DIFF
--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -79,7 +79,7 @@ class TradeCodes(object):
         self.dcode = sorted(self.dcode)
 
     def __str__(self):
-        return " ".join(self.codes)
+        return " ".join(sorted(self.codes))
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -29,7 +29,7 @@ class TestStar(unittest.TestCase):
         self.assertTrue(star1.q == 0 and star1.r == 2, "%s, %s" % (star1.q, star1.r))
         self.assertTrue(star1.name == 'Irkigkhan')
         self.assertTrue(star1.uwp == 'C9C4733-9')
-        self.assertTrue(star1.alg == 'Im')
+        self.assertTrue(star1.alg_code == 'Im')
         self.assertTrue(star1.population == 10, "Population %s" % star1.population)
         self.assertTrue(star1.wtn == 9, "wtn %s" % star1.wtn)
         self.assertFalse(star1.tradeCode.industrial)
@@ -40,7 +40,7 @@ class TestStar(unittest.TestCase):
         self.assertEqual(star1.star_list, ['M2 V'])
 
     def testParseIrkigkhanRUCollapse(self):
-        sector = Sector('Core', ' 0, 0')
+        sector = Sector(' Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
             sector, 'fixed', 'fixed')
@@ -51,7 +51,7 @@ class TestStar(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testParseIrkigkhanRUScaled(self):
-        sector = Sector('Core', ' 0, 0')
+        sector = Sector(' Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
             sector, 'fixed', 'fixed')
@@ -62,7 +62,7 @@ class TestStar(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testParseShanaMa(self):
-        sector = Sector('Core', ' 0, 0')
+        sector = Sector(' Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
             sector, 'fixed', 'fixed')
@@ -72,7 +72,7 @@ class TestStar(unittest.TestCase):
         self.assertTrue(star1.q == 0 and star1.r == 3, "%s, %s" % (star1.q, star1.r))
         self.assertTrue(star1.name == 'Shana Ma')
         self.assertTrue(star1.uwp == 'E551112-7')
-        self.assertTrue(star1.alg == 'Im')
+        self.assertTrue(star1.alg_code == 'Im')
         self.assertTrue(star1.population == 0, "Population %s" % star1.population)
         self.assertTrue(star1.wtn == 2, "wtn %s" % star1.wtn)
         self.assertFalse(star1.tradeCode.industrial)
@@ -84,7 +84,7 @@ class TestStar(unittest.TestCase):
         self.assertEqual(star1.star_list, ['K2 IV', 'M7 V'])
 
     def testParseSyss(self):
-        sector = Sector('Core', ' 0, 0')
+        sector = Sector(' Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "2323 Syss                 C400746-8 Na Va Pi                   { -1 } (A67-2) [6647] BD   S  - 510 5  ImDv M9 III D M5 V",
             sector, 'fixed', 'fixed')
@@ -164,7 +164,7 @@ class TestStar(unittest.TestCase):
     def testHashValueSameAfterCaching(self):
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V  ",
-            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
 
         # Grabbing hash value twice, once to seed Star._hash, second to dig it out of that cache
         oldHash = star1.__hash__()
@@ -174,13 +174,13 @@ class TestStar(unittest.TestCase):
     def testEquals(self):
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
         star2 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
         star3 = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
 
         self.assertEqual(star1, star2)
         self.assertNotEqual(star1, star3)

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -99,20 +99,20 @@ class TestStar(unittest.TestCase):
     def testAPortModifier(self):
         # cwtn =[3,4,4,5,6,7,7,8,9,10,10,11,12,13,14,15]
         cwtn = [3, 4, 4, 5, 6, 7, 7, 8, 9, 10, 10, 11, 12, 13, 13, 14]
-        for uwtn in xrange(15):
+        for uwtn in range(15):
             wtn = int(round(max(0, (uwtn * 3 + 13) / 4)))
             self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testBPortModifier(self):
         # cwtn =[2,3,4,5,5,6,7,8,8,9,10,11,11,12,12,13]
         cwtn = [2, 3, 4, 5, 5, 6, 7, 8, 8, 9, 10, 11, 11, 12, 13, 14]
-        for uwtn in xrange(15):
+        for uwtn in range(15):
             wtn = int(round(max(0, (uwtn * 3 + 11) / 4)))
             self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testCPortModifier(self):
         cwtn = [2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 10, 10, 11, 11, 12]
-        for uwtn in xrange(15):
+        for uwtn in range(15):
             if (uwtn > 9):
                 wtn = int(round(max(0, (uwtn + 9) / 2)))
             else:
@@ -121,7 +121,7 @@ class TestStar(unittest.TestCase):
 
     def testDPortModifier(self):
         cwtn = [1, 2, 3, 4, 4, 5, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11]
-        for uwtn in xrange(15):
+        for uwtn in range(15):
             if (uwtn > 7):
                 wtn = int(round(max(0, (uwtn + 7) / 2)))
             else:
@@ -130,7 +130,7 @@ class TestStar(unittest.TestCase):
 
     def testEPortModifier(self):
         cwtn = [1, 2, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10]
-        for uwtn in xrange(15):
+        for uwtn in range(15):
             if (uwtn > 5):
                 wtn = int(round(max(0, (uwtn + 5) / 2)))
             else:
@@ -140,7 +140,7 @@ class TestStar(unittest.TestCase):
     def testXPortModifier(self):
         # cwtn =[0,1,2,3,0,0,0,1,1,2,2,3,3,4,4,5]
         cwtn = [0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5]
-        for uwtn in xrange(15):
+        for uwtn in range(15):
             wtn = int(round(max(0, (uwtn - 5) / 2)))
             self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -101,14 +101,14 @@ class TestStar(unittest.TestCase):
         cwtn = [3, 4, 4, 5, 6, 7, 7, 8, 9, 10, 10, 11, 12, 13, 13, 14]
         for uwtn in range(15):
             wtn = int(round(max(0, (uwtn * 3 + 13) // 4)))
-            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            self.assertEqual(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testBPortModifier(self):
         # cwtn =[2,3,4,5,5,6,7,8,8,9,10,11,11,12,12,13]
         cwtn = [2, 3, 4, 5, 5, 6, 7, 8, 8, 9, 10, 11, 11, 12, 13, 14]
         for uwtn in range(15):
             wtn = int(round(max(0, (uwtn * 3 + 11) // 4)))
-            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            self.assertEqual(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testCPortModifier(self):
         cwtn = [2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 10, 10, 11, 11, 12]
@@ -117,7 +117,7 @@ class TestStar(unittest.TestCase):
                 wtn = int(round(max(0, (uwtn + 9) // 2)))
             else:
                 wtn = int(round(max(0, (uwtn * 3 + 9) // 4)))
-            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            self.assertEqual(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testDPortModifier(self):
         cwtn = [1, 2, 3, 4, 4, 5, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11]
@@ -126,7 +126,7 @@ class TestStar(unittest.TestCase):
                 wtn = int(round(max(0, (uwtn + 7) // 2)))
             else:
                 wtn = int(round(max(0, (uwtn * 3 + 7) // 4)))
-            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            self.assertEqual(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testEPortModifier(self):
         cwtn = [1, 2, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10]
@@ -135,14 +135,14 @@ class TestStar(unittest.TestCase):
                 wtn = int(round(max(0, (uwtn + 5) // 2)))
             else:
                 wtn = int(round(max(0, (uwtn * 3 + 5) // 4)))
-            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            self.assertEqual(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testXPortModifier(self):
         # cwtn =[0,1,2,3,0,0,0,1,1,2,2,3,3,4,4,5]
         cwtn = [0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5]
         for uwtn in range(15):
             wtn = int(round(max(0, (uwtn - 5) // 2)))
-            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            self.assertEqual(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testCalcTrade(self):
         self.assertEqual(TradeCalculation.calc_trade(0), 1)

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -24,19 +24,19 @@ class TestStar(unittest.TestCase):
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
             sector, 'fixed', 'fixed')
 
-        self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
-        self.assertTrue(star1.position == '0103')
+        self.assertEqual('Core', star1.sector.name, star1.sector.name)
+        self.assertEqual('0103', star1.position)
         self.assertTrue(star1.q == 0 and star1.r == 2, "%s, %s" % (star1.q, star1.r))
-        self.assertTrue(star1.name == 'Irkigkhan')
-        self.assertTrue(star1.uwp == 'C9C4733-9')
-        self.assertTrue(star1.alg_code == 'Im')
-        self.assertTrue(star1.population == 10, "Population %s" % star1.population)
-        self.assertTrue(star1.wtn == 9, "wtn %s" % star1.wtn)
+        self.assertEqual('Irkigkhan', star1.name)
+        self.assertEqual('C9C4733-9', star1.uwp)
+        self.assertEqual('Im', star1.alg_code)
+        self.assertEqual(10, star1.population, "Population %s" % star1.population)
+        self.assertEqual(9, star1.wtn, "wtn %s" % star1.wtn)
         self.assertFalse(star1.tradeCode.industrial)
         self.assertFalse(star1.tradeCode.agricultural)
         self.assertFalse(star1.tradeCode.poor)
         self.assertFalse(star1.tradeCode.rich)
-        self.assertTrue(star1.ggCount == 3)
+        self.assertEqual(3, star1.ggCount)
         self.assertEqual(star1.star_list, ['M2 V'])
 
     def testParseIrkigkhanRUCollapse(self):
@@ -67,21 +67,21 @@ class TestStar(unittest.TestCase):
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
             sector, 'fixed', 'fixed')
 
-        self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
-        self.assertTrue(star1.position == '0104')
+        self.assertEqual('Core', star1.sector.name, star1.sector.name)
+        self.assertEqual('0104', star1.position)
         self.assertTrue(star1.q == 0 and star1.r == 3, "%s, %s" % (star1.q, star1.r))
-        self.assertTrue(star1.name == 'Shana Ma')
-        self.assertTrue(star1.uwp == 'E551112-7')
-        self.assertTrue(star1.alg_code == 'Im')
-        self.assertTrue(star1.population == 0, "Population %s" % star1.population)
-        self.assertTrue(star1.wtn == 2, "wtn %s" % star1.wtn)
+        self.assertEqual('Shana Ma', star1.name)
+        self.assertEqual('E551112-7', star1.uwp)
+        self.assertEqual('Im', star1.alg_code)
+        self.assertEqual(0, star1.population, "Population %s" % star1.population)
+        self.assertEqual(2, star1.wtn, "wtn %s" % star1.wtn)
         self.assertFalse(star1.tradeCode.industrial)
         self.assertFalse(star1.tradeCode.agricultural)
         self.assertTrue(star1.tradeCode.poor)
         self.assertFalse(star1.tradeCode.rich)
-        self.assertTrue(star1.ggCount == 3)
-        self.assertEqual(len(star1.star_list), 2)
-        self.assertEqual(star1.star_list, ['K2 IV', 'M7 V'])
+        self.assertEqual(3, star1.ggCount)
+        self.assertEqual(2, len(star1.star_list))
+        self.assertEqual(['K2 IV', 'M7 V'], star1.star_list)
 
     def testParseSyss(self):
         sector = Sector(' Core', ' 0, 0')
@@ -89,7 +89,7 @@ class TestStar(unittest.TestCase):
             "2323 Syss                 C400746-8 Na Va Pi                   { -1 } (A67-2) [6647] BD   S  - 510 5  ImDv M9 III D M5 V",
             sector, 'fixed', 'fixed')
 
-        self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
+        self.assertEqual('Core', star1.sector.name, star1.sector.name)
         self.assertEqual(star1.position, '2323')
         self.assertEqual(star1.name, 'Syss')
         self.assertEqual(star1.uwp, 'C400746-8')

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -16,15 +16,13 @@ from TradeCalculation import TradeCalculation
 class TestStar(unittest.TestCase):
 
     def setUp(self):
-
-        star_regex = ''.join([line.rstrip('\n') for line in Galaxy.regex])
-        self.starline = re.compile(star_regex)
+        pass
 
     def testParseIrkigkhan(self):
-        sector = Sector('Core', ' 0, 0')
+        sector = Sector(' Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            self.starline, sector, 'fixed', None)
+            sector, 'fixed', 'fixed')
 
         self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
         self.assertTrue(star1.position == '0103')
@@ -45,7 +43,7 @@ class TestStar(unittest.TestCase):
         sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            self.starline, sector, 'fixed', 'collapse')
+            sector, 'fixed', 'fixed')
 
         expected = 756
         actual = star1.ru
@@ -56,7 +54,7 @@ class TestStar(unittest.TestCase):
         sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            self.starline, sector, 'fixed', 'scaled')
+            sector, 'fixed', 'fixed')
 
         expected = 756
         actual = star1.ru
@@ -67,7 +65,7 @@ class TestStar(unittest.TestCase):
         sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-            self.starline, sector, 'fixed', None)
+            sector, 'fixed', 'fixed')
 
         self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
         self.assertTrue(star1.position == '0104')
@@ -89,7 +87,7 @@ class TestStar(unittest.TestCase):
         sector = Sector('Core', ' 0, 0')
         star1 = Star.parse_line_into_star(
             "2323 Syss                 C400746-8 Na Va Pi                   { -1 } (A67-2) [6647] BD   S  - 510 5  ImDv M9 III D M5 V",
-            self.starline, sector, 'fixed', None)
+            sector, 'fixed', 'fixed')
 
         self.assertTrue(star1.sector.name == 'Core', star1.sector.name)
         self.assertEqual(star1.position, '2323')
@@ -166,7 +164,7 @@ class TestStar(unittest.TestCase):
     def testHashValueSameAfterCaching(self):
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V  ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
 
         # Grabbing hash value twice, once to seed Star._hash, second to dig it out of that cache
         oldHash = star1.__hash__()
@@ -176,13 +174,13 @@ class TestStar(unittest.TestCase):
     def testEquals(self):
         star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
         star2 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
         star3 = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector('Core', ' 0, 0'), 'fixed', 'fixed')
 
         self.assertEqual(star1, star2)
         self.assertNotEqual(star1, star3)
@@ -192,7 +190,7 @@ class TestStar(unittest.TestCase):
     def testStarSize(self):
         star1 = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
 
 
 if __name__ == "__main__":

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -100,49 +100,49 @@ class TestStar(unittest.TestCase):
         # cwtn =[3,4,4,5,6,7,7,8,9,10,10,11,12,13,14,15]
         cwtn = [3, 4, 4, 5, 6, 7, 7, 8, 9, 10, 10, 11, 12, 13, 13, 14]
         for uwtn in range(15):
-            wtn = int(round(max(0, (uwtn * 3 + 13) / 4)))
-            self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            wtn = int(round(max(0, (uwtn * 3 + 13) // 4)))
+            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testBPortModifier(self):
         # cwtn =[2,3,4,5,5,6,7,8,8,9,10,11,11,12,12,13]
         cwtn = [2, 3, 4, 5, 5, 6, 7, 8, 8, 9, 10, 11, 11, 12, 13, 14]
         for uwtn in range(15):
-            wtn = int(round(max(0, (uwtn * 3 + 11) / 4)))
-            self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            wtn = int(round(max(0, (uwtn * 3 + 11) // 4)))
+            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testCPortModifier(self):
         cwtn = [2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 10, 10, 11, 11, 12]
         for uwtn in range(15):
             if (uwtn > 9):
-                wtn = int(round(max(0, (uwtn + 9) / 2)))
+                wtn = int(round(max(0, (uwtn + 9) // 2)))
             else:
-                wtn = int(round(max(0, (uwtn * 3 + 9) / 4)))
-            self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+                wtn = int(round(max(0, (uwtn * 3 + 9) // 4)))
+            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testDPortModifier(self):
         cwtn = [1, 2, 3, 4, 4, 5, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11]
         for uwtn in range(15):
             if (uwtn > 7):
-                wtn = int(round(max(0, (uwtn + 7) / 2)))
+                wtn = int(round(max(0, (uwtn + 7) // 2)))
             else:
-                wtn = int(round(max(0, (uwtn * 3 + 7) / 4)))
-            self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+                wtn = int(round(max(0, (uwtn * 3 + 7) // 4)))
+            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testEPortModifier(self):
         cwtn = [1, 2, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10]
         for uwtn in range(15):
             if (uwtn > 5):
-                wtn = int(round(max(0, (uwtn + 5) / 2)))
+                wtn = int(round(max(0, (uwtn + 5) // 2)))
             else:
-                wtn = int(round(max(0, (uwtn * 3 + 5) / 4)))
-            self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+                wtn = int(round(max(0, (uwtn * 3 + 5) // 4)))
+            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testXPortModifier(self):
         # cwtn =[0,1,2,3,0,0,0,1,1,2,2,3,3,4,4,5]
         cwtn = [0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5]
         for uwtn in range(15):
-            wtn = int(round(max(0, (uwtn - 5) / 2)))
-            self.assertTrue(wtn == cwtn[uwtn], "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
+            wtn = int(round(max(0, (uwtn - 5) // 2)))
+            self.assertEquals(cwtn[uwtn], wtn, "at %s: %s vs %s" % (uwtn, wtn, cwtn[uwtn]))
 
     def testCalcTrade(self):
         self.assertEqual(TradeCalculation.calc_trade(0), 1)

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -31,7 +31,7 @@ class TestTradeCode(unittest.TestCase):
     def testLo(self):
         code = TradeCodes("Lo")
         self.assertTrue(code.pcode is None)
-        self.assertTrue(str(code) == u'Lo')
+        self.assertEqual(u'Lo', str(code))
         self.assertTrue(code.low)
         self.assertFalse(code.high)
 
@@ -44,15 +44,15 @@ class TestTradeCode(unittest.TestCase):
 
     def testColony(self):
         code = TradeCodes(u"Ph C:0404")
-        self.assertTrue(code.owned == [u'C:0404'], code.owned)
-        self.assertTrue(code.colonies("Spinward Marches") == [u'C:Spin-0404'], code.colonies("Spinward Marches"))
-        self.assertTrue(code.owners('Spinward Marches') == [])
+        self.assertEqual([u'C:0404'], code.owned, code.owned)
+        self.assertEqual([u'C:Spin-0404'], code.colonies("Spinward Marches"), code.colonies("Spinward Marches"))
+        self.assertEqual([], code.owners('Spinward Marches'))
 
     def testOwned(self):
         code = TradeCodes(u"Ag O:1011")
-        self.assertTrue(code.owned == [u'O:1011'], code.owned)
-        self.assertTrue(code.owners('Deneb') == [u'O:Dene-1011'])
-        self.assertTrue(code.colonies('Deneb') == [])
+        self.assertEqual([u'O:1011'], code.owned, code.owned)
+        self.assertEqual([u'O:Dene-1011'], code.owners('Deneb'))
+        self.assertEqual([], code.colonies('Deneb'))
 
     def testSophonts(self):
         code = TradeCodes(u"(Wiki)")
@@ -61,27 +61,27 @@ class TestTradeCode(unittest.TestCase):
 
     def testSophontsPartial(self):
         code = TradeCodes(u"(Wiki)4")
-        self.assertTrue(code.homeworld == [u'Wiki4'], code.homeworld)
-        self.assertTrue(code.sophonts == [u'Wiki4'])
+        self.assertEqual([u'Wiki4'], code.homeworld, code.homeworld)
+        self.assertEqual([u'Wiki4'], code.sophonts)
 
     def testWorldSophont(self):
         code = TradeCodes("Ag Huma4")
         self.assertFalse(code.homeworld)
-        self.assertTrue(code.sophonts == ['Huma4'])
-        self.assertTrue(code.codeset == ['Ag'])
+        self.assertEqual(['Huma4'], code.sophonts)
+        self.assertEqual(['Ag'], code.codeset)
 
     def testWorldSophontsMultiple(self):
         code = TradeCodes("Ag Wiki4 Huma2")
         self.assertFalse(code.homeworld)
-        self.assertTrue(code.sophonts == ['Wiki4', 'Huma2'])
-        self.assertTrue(code.codeset == ['Ag'])
+        self.assertEqual(['Wiki4', 'Huma2'], code.sophonts)
+        self.assertEqual(['Ag'], code.codeset)
 
     def testSophontCombined(self):
         code = TradeCodes("Ri (Wiki) Huma4 Alph2 (Deneb)2")
         self.assertTrue(len(code.homeworld) > 0)
         self.assertEqual(['Huma4', 'Alph2', 'WikiW', 'Dene2'], code.sophonts, msg=code.sophonts)
         self.assertEqual(['WikiW', 'Dene2'], code.homeworld, msg=code.homeworld)
-        self.assertTrue(code.codeset == ['Ri'], code.codeset)
+        self.assertEqual(['Ri'], code.codeset, code.codeset)
 
     def testCodeCheck(self):
         code = TradeCodes("Fl")

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -12,15 +12,12 @@ from Galaxy import Sector, Galaxy
 class TestTradeCode(unittest.TestCase):
 
     def setUp(self):
-        star_regex = ''.join([line.rstrip('\n') for line in Galaxy.regex])
-
-        self.starline = re.compile(star_regex)
         self.star1 = Star.parse_line_into_star(
             "0103 Irkigkhan            C9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
         self.star2 = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
-            self.starline, Sector('Core', ' 0, 0'), 'fixed', None)
+            Sector(' Core', ' 0, 0'), 'fixed', 'fixed')
 
         self.logger = logging.getLogger("PyRoute")
 

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -37,8 +37,8 @@ class TestTradeCode(unittest.TestCase):
 
     def testOrdering(self):
         code = TradeCodes("Wa Ag Ni")
-        self.assertTrue(code.pcode == 'Wa')
-        self.assertTrue(str(code) == u'Ag Ni Wa')
+        self.assertEqual('Wa', code.pcode)
+        self.assertEqual(u'Ag Ni Wa', str(code))
         self.assertTrue(code.agricultural)
         self.assertTrue(code.nonindustrial)
 
@@ -56,12 +56,12 @@ class TestTradeCode(unittest.TestCase):
 
     def testSophonts(self):
         code = TradeCodes(u"(Wiki)")
-        self.assertTrue(code.homeworld == [u'Wiki'], code.homeworld)
-        self.assertTrue(code.sophonts == [u'WikiW'], code.sophonts)
+        self.assertEqual([u'WikiW'], code.homeworld, code.homeworld)
+        self.assertEqual([u'WikiW'], code.sophonts, code.sophonts)
 
     def testSophontsPartial(self):
         code = TradeCodes(u"(Wiki)4")
-        self.assertTrue(code.homeworld == [u'Wiki'], code.homeworld)
+        self.assertTrue(code.homeworld == [u'Wiki4'], code.homeworld)
         self.assertTrue(code.sophonts == [u'Wiki4'])
 
     def testWorldSophont(self):
@@ -79,8 +79,8 @@ class TestTradeCode(unittest.TestCase):
     def testSophontCombined(self):
         code = TradeCodes("Ri (Wiki) Huma4 Alph2 (Deneb)2")
         self.assertTrue(len(code.homeworld) > 0)
-        self.assertTrue(code.sophonts == ['Huma4', 'Alph2', 'WikiW', 'Dene2'], msg=code.sophonts)
-        self.assertTrue(code.homeworld == ['Wiki', 'Deneb'], msg=code.homeworld)
+        self.assertEqual(['Huma4', 'Alph2', 'WikiW', 'Dene2'], code.sophonts, msg=code.sophonts)
+        self.assertEqual(['WikiW', 'Dene2'], code.homeworld, msg=code.homeworld)
         self.assertTrue(code.codeset == ['Ri'], code.codeset)
 
     def testCodeCheck(self):

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -95,8 +95,28 @@ class TestTradeCode(unittest.TestCase):
 
     def testCodeCheckFails(self):
         code = TradeCodes("Wa")
-        self.assertFalse(code.check_world_codes(self.star1))
-        self.assertFalse(code.check_world_codes(self.star2))
+        with self.assertLogs(self.logger, level='ERROR') as log:
+            self.assertFalse(code.check_world_codes(self.star1))
+            # assert that what we expected was logged
+            self.assertEqual(2, len(log.output))
+            self.assertEqual(
+                [
+                    'ERROR:PyRoute.TradeCodes:Irkigkhan (Core 0103)-C9C4733-9 Calculated "Fl" not in trade codes [\'Wa\']',
+                    'ERROR:PyRoute.TradeCodes:Irkigkhan (Core 0103)-C9C4733-9 Found invalid "Wa" in trade codes: [\'Wa\']'
+                ],
+                log.output)
+        with self.assertLogs(self.logger, level='ERROR') as log:
+            self.assertFalse(code.check_world_codes(self.star2))
+            # assert that what we expected was logged
+            self.assertEqual(3, len(log.output))
+            self.assertEqual(
+                [
+                    'ERROR:PyRoute.TradeCodes:Shana Ma (Core 0104)-E551112-7 Calculated "Po" not in trade codes [\'Wa\']',
+                    'ERROR:PyRoute.TradeCodes:Shana Ma (Core 0104)-E551112-7 Found invalid "Wa" in trade codes: [\'Wa\']',
+                    'ERROR:PyRoute.TradeCodes:Shana Ma (Core 0104) - Calculated "Lo" not in trade codes [\'Wa\']',
+                ],
+                log.output
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The test suite seems to have rotted since the jump to Python 3, so this PR fixes the bit rot and gets test suite running clean. This is a necessary (but not sufficient) precondition to enable per-pull-request CI setup.

In addition, to reduce visual clutter during test runs, I directly asserted the expected logger results in testCodeCheckFails.