### PR TITLE
Fix wiki template and font file paths

### DIFF
--- a/PyRoute/FontLayer.py
+++ b/PyRoute/FontLayer.py
@@ -1,0 +1,45 @@
+"""
+Created on Dec 04, 2021
+
+@author: CyberiaResurrection
+
+A dirt-simple adapter layer to abstract the differences in where Linux distros (currently, Ubuntu and Fedora)
+store their font files away from the rest of the project
+"""
+
+from os import path
+
+
+class FontLayer(object):
+    fontdict = {}
+
+    def __init__(self):
+        self.fontdict['DejaVuSerifCondensed.ttf'] = [
+            '/usr/share/fonts/truetype/dejavu/DejaVuSerifCondensed.ttf',
+            '/usr/share/fonts/dejavu-serif-fonts/DejaVuSerifCondensed.ttf'
+        ]
+        self.fontdict['LiberationMono-Bold.ttf'] = [
+            '/usr/share/fonts/truetype/liberation/LiberationMono-Bold.ttf',
+            '/usr/share/fonts/liberation-mono/LiberationMono-Bold.ttf'
+        ]
+        self.fontdict['FreeMono.ttf'] = [
+            '/usr/share/fonts/truetype/freefont/FreeMono.ttf',
+            '/usr/share/fonts/gnu-free/FreeMono.ttf'
+        ]
+        self.fontdict['Symbola-hint.ttf'] = [
+            '/usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf',
+            '/usr/share/fonts/gdouros-symbola/Symbola.ttf'
+        ]
+
+    def getpath(self, filename):
+        # Deliberately lean on dictionaries blowing up on accessing absent keys to make it obvious
+        # that we don't know how to handle what's being asked for
+        filelist = self.fontdict[filename]
+
+        for item in filelist:
+            # for moment, don't care whether is a hard or softlinked file
+            if path.exists(item):
+                if not path.isdir(item):
+                    return item
+
+        return None

--- a/PyRoute/FontLayer.py
+++ b/PyRoute/FontLayer.py
@@ -8,7 +8,7 @@ store their font files away from the rest of the project
 """
 
 from os import path
-
+import functools
 
 class FontLayer(object):
     fontdict = {}
@@ -31,6 +31,7 @@ class FontLayer(object):
             '/usr/share/fonts/gdouros-symbola/Symbola.ttf'
         ]
 
+    @functools.cache
     def getpath(self, filename):
         # Deliberately lean on dictionaries blowing up on accessing absent keys to make it obvious
         # that we don't know how to handle what's being asked for

--- a/PyRoute/SubsectorMap2.py
+++ b/PyRoute/SubsectorMap2.py
@@ -9,6 +9,7 @@ import math
 from Map import GraphicMap
 from Galaxy import Galaxy
 from AllyGen import AllyGen
+from PyRoute.FontLayer import FontLayer
 from PIL import Image, ImageDraw, ImageColor, ImageFont
 
 
@@ -25,6 +26,7 @@ class GraphicSubsectorMap(GraphicMap):
     trailPos = (784, 1108 / 2)
     x_count = 9
     y_count = 11
+    font_layer = None
 
     def __init__(self, galaxy, routes, trade_version):
         super(GraphicSubsectorMap, self).__init__(galaxy, routes)
@@ -33,14 +35,15 @@ class GraphicSubsectorMap(GraphicMap):
         self.ym = 48  # half a hex height
         self.xm = 28  # half the length of one side
         self.textFill = self.fillWhite
-        self.namesFont = ImageFont.truetype('/usr/share/fonts/truetype/dejavu/DejaVuSerifCondensed.ttf', 32)
-        self.titleFont = ImageFont.truetype('/usr/share/fonts/truetype/dejavu/DejaVuSerifCondensed.ttf', 48)
-        self.hexFont = ImageFont.truetype('/usr/share/fonts/truetype/liberation/LiberationMono-Bold.ttf', 15)
-        self.worldFont = ImageFont.truetype('/usr/share/fonts/truetype/liberation/LiberationMono-Bold.ttf', 22)
-        self.hexFont2 = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMono.ttf', 22)
-        self.hexFont3 = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMono.ttf', 36)
-        self.hexFont4 = ImageFont.truetype("/usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf", 22)
-        self.hexFont5 = ImageFont.truetype("/usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf", 36)
+        self.font_layer = FontLayer()
+        self.namesFont = ImageFont.truetype(self.font_layer.getpath('DejaVuSerifCondensed.ttf'), 32)
+        self.titleFont = ImageFont.truetype(self.font_layer.getpath('DejaVuSerifCondensed.ttf'), 48)
+        self.hexFont = ImageFont.truetype(self.font_layer.getpath('LiberationMono-Bold.ttf'), 15)
+        self.worldFont = ImageFont.truetype(self.font_layer.getpath('LiberationMono-Bold.ttf'), 22)
+        self.hexFont2 = ImageFont.truetype(self.font_layer.getpath('FreeMono.ttf'), 22)
+        self.hexFont3 = ImageFont.truetype(self.font_layer.getpath('FreeMono.ttf'), 36)
+        self.hexFont4 = ImageFont.truetype(self.font_layer.getpath('Symbola-hint.ttf'), 22)
+        self.hexFont5 = ImageFont.truetype(self.font_layer.getpath('Symbola-hint.ttf'), 36)
         self.logger = logging.getLogger('PyRoute.GraphicSubsectorMap')
         self.trade_version = trade_version
 

--- a/PyRoute/wikistats.py
+++ b/PyRoute/wikistats.py
@@ -39,8 +39,11 @@ class WikiStats(object):
         self.json_data = json_data
         self.logger = logging.getLogger('PyRoute.WikiStats')
 
+        cwd = os.path.dirname(__file__)
+        templatedir = cwd + "/templates"
+
         self.env = Environment(
-            loader=FileSystemLoader('PyRoute/templates'),
+            loader=FileSystemLoader(templatedir),
             #loader=PackageLoader('PyRoute', 'templates'),
             autoescape=select_autoescape(['html', 'xml'])
             )


### PR DESCRIPTION
Running PyRoute on a Fedora box, when it was originally written on a Ubuntu box, has rumbled some Ubuntu-specific assumptions as to font locations.  Running PyRoute in an IDE, to debug and profile it, rumbled an implicit assumption that the current working directory is the project root dir - that assumption didn't necessarily hold.

To fix the working dir assumption, I've tweaked the wiki template class to supply the _absolute_ base dir for the wiki templates.

To encapsulate the font-location assumptions, I've added a dirt-simple adapter class (named, with much originality, FontLayer) that translates the four font files used in SubsectorMap2.py into the underlying absolute paths on Ubuntu or Fedora.  I've structured FontLayer to make it very easy to add additional mappings for existing files (such as on other Linux distros), as well as mappings for new files.