### PR TITLE
Trim unneeded computation

### DIFF
--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -224,6 +224,7 @@ class Star(object):
         star.calculate_eti()
 
         star.trade_id = None # Used by the Speculative Trade
+        star.calc_hash()
         return star
 
     def __unicode__(self):
@@ -247,9 +248,10 @@ class Star(object):
             return False
 
     def __hash__(self):
-        if self._hash is None:
-            self._hash = hash(self.__key())
         return self._hash
+
+    def calc_hash(self):
+        self._hash = hash(self.__key())
 
     def wiki_name(self):
         # name = u" ".join(w.capitalize() for w in self.name.lower().split())

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -100,6 +100,7 @@ class Star(object):
     def __init__(self):
         self.logger = logging.getLogger('PyRoute.Star')
         self._hash = None
+        self.component = None
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -475,6 +475,9 @@ class TradeCalculation(RouteCalculation):
     # List of connected components of galaxy.stars
     components = list()
 
+    # Minimum size for component to be retained in components list
+    min_component_size = 1
+
     def __init__(self, galaxy, min_btn=13, route_btn=8, route_reuse=10):
         super(TradeCalculation, self).__init__(galaxy)
 
@@ -789,7 +792,7 @@ class TradeCalculation(RouteCalculation):
         total_stars = 0
 
         for bit in bitz:
-            if 1 == len(bit):
+            if self.min_component_size >= len(bit):
                 self.redzone.union(bit)
             else:
                 raw_components.append(bit)

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -573,8 +573,8 @@ class TradeCalculation(RouteCalculation):
         # connected components in the underlying galaxy.stars graph - such pathfinding attempts are doomed
         # to failure.
         self.calculate_components()
-        # The extra major component is the residual one implied by the contents of self.components.
-        self.logger.info('filtering routes over {} major components...'.format(len(self.components)+1))
+        # The extra component is the residual one implied by the contents of self.components.
+        self.logger.info('filtering routes over {} components...'.format(len(self.components)+1))
         for i in range(0, len(self.components)):
             btn = [(s, n, d) for (s, n, d) in btn if (s in self.components[i]) == (n in self.components[i])]
         self.logger.info('Filtered route count {}'.format(len(btn)))
@@ -802,11 +802,6 @@ class TradeCalculation(RouteCalculation):
 
         for component in raw_components:
             self.components.append(set(component))
-            size = len(component)
-            total_stars -= size
-            if size >= total_stars:
-                break
-
 
 class CommCalculation(RouteCalculation):
     # Weight for route over a distance. The relative cost for

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -472,9 +472,6 @@ class TradeCalculation(RouteCalculation):
     # Stars that have been excluded, for whatever reason, from route generation
     redzone = set()
 
-    # Minimum size for component to be retained in components list
-    min_component_size = 1
-
     def __init__(self, galaxy, min_btn=13, route_btn=8, route_reuse=10):
         super(TradeCalculation, self).__init__(galaxy)
 

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -569,13 +569,14 @@ class TradeCalculation(RouteCalculation):
         for the lower routes to follow.
         """
         self.logger.info('sorting routes...')
-        btn = [(s, n, d) for (s, n, d) in self.galaxy.ranges.edges(data=True)]
-        btn.sort(key=lambda tn: tn[2]['btn'], reverse=True)
-
         # Filter out pathfinding attempts that can never return a route, as they're between two different
         # connected components in the underlying galaxy.stars graph - such pathfinding attempts are doomed
         # to failure.
         self.calculate_components()
+        btn = [(s, n, d) for (s, n, d) in self.galaxy.ranges.edges(data=True)]
+        btn.sort(key=lambda tn: tn[2]['btn'], reverse=True)
+
+
         # The extra component is the residual one implied by the contents of self.components.
         self.logger.info('filtering routes over {} components...'.format(len(self.components)+1))
         for i in range(0, len(self.components)):

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -790,14 +790,12 @@ class TradeCalculation(RouteCalculation):
     def calculate_components(self):
         bitz = nx.connected_components(self.galaxy.stars)
         raw_components = []
-        total_stars = 0
 
         for bit in bitz:
             if self.min_component_size >= len(bit):
                 self.redzone.union(bit)
             else:
                 raw_components.append(bit)
-                total_stars += len(bit)
 
         # now that we have the list of all multi-star components, sort them in descending order and pick the top N
         # such that the last selected element is not smaller than the un-selected components taken together.

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -469,6 +469,9 @@ class TradeCalculation(RouteCalculation):
     # Maximum WTN to process routes for
     max_wtn = 15
 
+    # Stars that have been excluded, for whatever reason, from route generation
+    redzone = set()
+
     def __init__(self, galaxy, min_btn=13, route_btn=8, route_reuse=10):
         super(TradeCalculation, self).__init__(galaxy)
 
@@ -484,10 +487,21 @@ class TradeCalculation(RouteCalculation):
         # based upon program arguments. 
         self.route_reuse = route_reuse
 
+
     def base_route_filter(self, star, neighbor):
-        if star.zone in ['R', 'F'] or neighbor.zone in ['R', 'F']:
+        if star in self.redzone or neighbor in self.redzone:
             return True
-        if star.tradeCode.barren or neighbor.tradeCode.barren:
+        if star.zone in ['R', 'F']:
+            self.redzone.add(star)
+            return True
+        if neighbor.zone in ['R', 'F']:
+            self.redzone.add(neighbor)
+            return True
+        if star.tradeCode.barren:
+            self.redzone.add(star)
+            return True
+        if neighbor.tradeCode.barren:
+            self.redzone.add(neighbor)
             return True
         return False
 


### PR DESCRIPTION
After digging around, I found a couple of places where unneeded computation can be trimmed.  For reference, times reported are under the PyCharm 2020 built-in profiler on the same 4x4.1 Ghz Intel i7-6700k that I did PR #3 on.  The relative changes are probably more important than the absolute times.

The first, and biggest, gain was using the structure of the galaxy.stars graph.  Due to, frinstance, small connected clusters deep in Rift sectors (such as the Islands, the mid-Rift cluster in Riftspan Reaches, to name two), it seems extremely unlikely that the resulting graph is fully connected (fancy term for any node (star, in our case) being reachable from any other).

Any pathfinding attempt between two different components is doomed to failure - by the graph structure, _no such path **can** exist_.  As NetworkX is already a dependency, we already _have_ a way to efficiently find those connected components, so let's use it to filter out (by extending the btn list comprehension in TradeCalculation.calculate_routes) as many doomed attempts ahead of time as we can.

The minor gain was reversing the polarity of the Star hash data flow (couldn't help myself).  Some wombat (ie, me) had made enough other changes to make the book-keeping code in Star.__hash__ - the `if self._hash is None:` check - itself a bit of a hot spot.  The simple change there was, since Stars are treated as immutable after generation, to pre-generate the hash value and store it.

Finally, filtering on all graph components actually simplified the component-collection code.

On the machine above, I was able to reduce route-gen time:

-  at max jump of J-4;
-  for Reft and its orthogonally-adjacent sectors (Trojan Reach, Deneb, Gushemege, Verge), Riftspan Reaches and its orthogonally-adjacent sectors (Touchstone and Hlakoi - Trojan Reach and Verge were included earlier), plus Corridor and Vland (to give a giant connected component, as a proxy for bigger runs), 10 sectors total;

from **1590s** (under profiling) to **831s** (under profiling).  Taking doomed-route filtering up to 11 dropped time to **741s** (under profiling). Suggestions from @tjoneslo dropped time to **678s**.

Out of that 57.3% reduction, 44.6% came from filtering out doomed routes, 3.1% from reversing Star.__hash__ data flow, and 5.6% from pushing doomed-route filtering to completion.  A further 3.9% came from @tjoneslo 's suggestion.

To give an idea of the scale of the problem, I've dug out some profile stats on astar_path:
| Code type | # calls | Inclusive time (ms) | Av time/run (ms) |
| ------------- | ---------: | -------------------------: | ---------------------: |
|Unmodified| 160,691 | 1,389,970 | 8.6 |
|Filtering | 140,644 | 686,274 | 4.9 |
|Doomed calls | 20,047 | 703,696 | 35.1 |
|Filtering + hash rework | 140,644 | 640,326 | 4.6 |
|Newly-doomed calls | 13,557 | 102,186 | 7.5 |
|Full filtering + hash rework | 127,087 | 538,140 | 4.3 |
|tjoneslo suggestion | 114,197 | 449,248 | 4.0 |


Normalising the timing data to the unmodified base case:
| Code type | Inclusive time (%) | Av time/run (x) |
| ------------- | -----------------------: | --------------------: |
|Unmodified| 100.0 | 1.00 |
|Filtering | 49.4 | 0.57 |
|Doomed calls | 50.6 | 4.08 |
|Filtering + hash rework | 46.1 | 0.54 |

Normalising the full-filter timing data to the filtering + hash rework base case:
| Code type | Inclusive time (%) | Av time/run (x) |
| ------------- | -----------------------: | --------------------: |
|Filtering + hash rework | 100.0 | 1.00 |
|Newly-doomed calls | 15.9 | 1.63 |
|Full filtering + hash rework | 84.1 | 0.94 |

Doomed calls being 7.1x as expensive as non-doomed ones would seem to be disproportionately expensive.

And for the Star hash calls themselves:
| Code type | # calls | Exclusive time (ms) | Av time/run (ns) | Calls / astar run |
| -------------- | --------: | -------------------------: | ---------------------: | --------------------: |
|Unmodified | 1,792,011,390 | 210,471 | 117 | 11,151 |
|Filtering | 884,539,424 | 102,102 | 116 | 6,290 |
|Doomed astar calls | 907,471,966 | 108,369 | 119 | 45,267 |
|Filtering + hash rework | 884,539,424 | 75,057 | 85 | 6,290 |
|Newly-doomed calls | 182,793,760 | 10,049 | 54 | 13,483 |
|Full filtering + hash rework | 701,745,664 | 65,008 | 92.6 | 5,522 |
|tjoneslo suggestion | 649,974,424 | 61,736 | 89.8 | 5,692 |