### PR TITLE
Assign default subsector names if needed

### DIFF
--- a/PyRoute/SubsectorMap2.py
+++ b/PyRoute/SubsectorMap2.py
@@ -64,6 +64,9 @@ class GraphicSubsectorMap(GraphicMap):
         for sector in self.galaxy.sectors.values():
             for subsector in sector.subsectors.values():
                 self.subsector = subsector
+                if subsector.name is None or '' == subsector.name:
+                    # Assign a default name to stop file writes blowing up
+                    subsector.name = sector.name + "-" + subsector.position
                 img = self.document(sector)
                 self.write_base_map(img, subsector)
                 if self.trade_version != 'None':


### PR DESCRIPTION
I got tired of full-up Charted Space runs falling at one of the last hurdles, namely subsector map generation (especially in Angfutsag).  This was especially annoying if I was trying to _profile_ said run to sniff out hotspots.

With a null or blank subsector name, `SubsectorMap2.close()` was trying to close a file named `.png` - this caused PIL to have a major conniption, as it saw that as a regular dotfile without a determinable extension.  Thus, it blew up with `ValueError: unknown file extension: `.

Turns out the fix (at least, the one I found) was quite simple - if the supplied subsector name is null or blank, _assign_ a well-defined default subsector name.  I've simply gone with `{sector name}-{subsector position}` for the moment.