### PR TITLE
Start enforcing during-pathfinding invariants

### DIFF
--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -786,6 +786,8 @@ class TradeCalculation(RouteCalculation):
         if star.port in 'DEX':
             weight += 25
         weight -= star.importance + target.importance
+        # Per https://www.baeldung.com/cs/dijkstra-vs-a-pathfinding , to ensure termination in finite time:
+        # "the edges have strictly positive costs"
         assert 0 < weight, "Weight of edge between " + str(star) + " and " + str(
             target) + " must be positive"
         return weight

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -593,10 +593,14 @@ class TradeCalculation(RouteCalculation):
         If we can't find a route (no Jump 4 (or N) path), skip this pair
         otherwise update the trade information.
         """
+        assert 'actual distance' not in self.galaxy.ranges[target][star],\
+            "This route from " + str(star) + " to " + str(target) + " has already been processed in reverse"
+
         try:
             route = nx.astar_path(self.galaxy.stars, star, target, Star.heuristicDistance)
         except nx.NetworkXNoPath:
             return
+
 
         # TODO: Generate the routes in both directions- A->B and B->A. 
         # if they produce different routes (they might), select the the lower cost one

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -429,6 +429,8 @@ class XRouteCalculation(RouteCalculation):
         weight -= 6 if star.tradeCode.subsecor_capital or target.tradeCode.subsector_capital else 0
         weight -= 6 if star.tradeCode.other_capital or target.tradeCode.other_capital else 0
         weight -= 6 if star.tradeCode.sector_capital or target.tradeCode.sector_capital else 0
+        assert 0 < weight, "Weight of edge between " + str(star) + " and " + str(
+            target) + " must be positive"
 
         return weight
 
@@ -784,6 +786,8 @@ class TradeCalculation(RouteCalculation):
         if star.port in 'DEX':
             weight += 25
         weight -= star.importance + target.importance
+        assert 0 < weight, "Weight of edge between " + str(star) + " and " + str(
+            target) + " must be positive"
         return weight
 
     def calculate_components(self):
@@ -943,6 +947,8 @@ class CommCalculation(RouteCalculation):
         weight -= 6 if self.capitals(star) or self.capitals(target) else 0
         weight -= 6 if self.bases(star) or self.bases(target) else 0
         weight -= 3 if self.is_rich(star) or self.is_rich(target) else 0
+        assert 0 < weight, "Weight of edge between " + str(star) + " and " + str(
+            target) + " must be positive"
         return weight
 
     def more_important(self, star, neighbor, imp):

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -642,11 +642,7 @@ class TradeCalculation(RouteCalculation):
         - add a count for the worlds and edges
         - reduce the weight of routes used to allow more trade to flow
         """
-        distance = 0
-        start = route[0]
-        for end in route[1:]:
-            distance += start.hex_distance(end)
-            start = end
+        distance = self.route_distance(route)
 
         # Internal statistics
         self.galaxy.ranges[route[0]][route[-1]]['actual distance'] = distance
@@ -675,6 +671,18 @@ class TradeCalculation(RouteCalculation):
             start = end
 
         return (tradeCr, tradePass)
+
+    @staticmethod
+    def route_distance(route):
+        """
+        Given a route, return its line length in parsec
+        """
+        distance = 0
+        start = route[0]
+        for end in route[1:]:
+            distance += start.hex_distance(end)
+            start = end
+        return distance
 
     def route_update_skip(self, route, tradeCr):
         """

--- a/Tests/testTradeCalculation.py
+++ b/Tests/testTradeCalculation.py
@@ -1,0 +1,66 @@
+import unittest
+import re
+import sys
+
+sys.path.append('../PyRoute')
+from Star import Star
+from Galaxy import Sector, Galaxy
+from TradeCalculation import TradeCalculation
+
+
+class testTradeCalculation(unittest.TestCase):
+    def test_negative_route_weight_trips_assertion(self):
+        expected = 'Weight of edge between Irkigkhan (Core 0103) and Irkigkhan (Core 0103) must be positive'
+        actual = None
+        try:
+            sector = Sector(' Core', ' 0, 0')
+            star1 = Star.parse_line_into_star(
+                "0103 Irkigkhan            B9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+                sector, 'fixed', 'fixed')
+
+            galaxy = Galaxy(min_btn=13)
+            tradecalc = TradeCalculation(galaxy)
+
+            tradecalc.route_weight(star1, star1)
+        except AssertionError as e:
+            actual = str(e)
+            pass
+
+        self.assertEqual(expected, actual)
+
+    def test_zero_route_weight_trips_assertion(self):
+        expected = 'Weight of edge between Irkigkhan (Core 0103) and Irkigkhan (Core 0103) must be positive'
+        actual = None
+        try:
+            sector = Sector(' Core', ' 0, 0')
+            star1 = Star.parse_line_into_star(
+                "0103 Irkigkhan            B9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+                sector, 'fixed', 'fixed')
+            star1.importance = 0
+
+            galaxy = Galaxy(min_btn=13)
+            tradecalc = TradeCalculation(galaxy)
+
+            tradecalc.route_weight(star1, star1)
+        except AssertionError as e:
+            actual = str(e)
+            pass
+
+        self.assertEqual(expected, actual)
+
+    def test_positive_route_weight_doesnt_trip_assertion(self):
+            sector = Sector(' Core', ' 0, 0')
+            star1 = Star.parse_line_into_star(
+                "0103 Irkigkhan            B9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+                sector, 'fixed', 'fixed')
+            star1.importance = -1
+
+            galaxy = Galaxy(min_btn=13)
+            tradecalc = TradeCalculation(galaxy)
+
+            self.assertEqual(2, tradecalc.route_weight(star1, star1))
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Start implementing the during-generation invariants I listed here: https://github.com/makhidkarun/traveller_pyroute/issues/16#issuecomment-991689038

@tjoneslo , et al, a program's invariants are like a building's foundations - you need them to build a solid building (or program). Invariants describe conditions that must _always_ hold for your program to have a chance of running correctly.

The existing code was only generating at most one of the forward or reverse routes from star A to star B, so I enforced that behaviour.
The positive-edge-cost invariant actually applies to A* pathfinding itself, not PyRoute directly, but (as you can see in the commit), enforcing it saves a lot of hassle.