### PR TITLE
Update requirements to wikitools3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ networkx
 pypdflite
 inflect
 Pillow
-wikitools==1.3
+wikitools3==3.0.1
 jinja2
 jsonpickle


### PR DESCRIPTION
Fixes https://github.com/makhidkarun/traveller_pyroute/issues/22.

Note that while I ran `pip install -r requirements.txt` I couldn't figure out how to run the unit tests, so this should be tested before merging.

Also FYI I could help you switch to [Poetry](https://python-poetry.org) for package management if you'd like. The main advantage is that Poetry enables bundling otherwise conflicting versions of dependencies, and it also streamlines installation to the user's path as well as publishing to PyPI.