### PR TITLE
Add custom A* pathfinding implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
 PyRoute/__pycache__/
 PyRoute/DeltaPasses/__pycache__/
 PyRoute/DeltaDebug/__pycache__/
+PyRoute/Pathfinding/__pycache__/
 Tests/__pycache__/
 PyRoute/*.pyc
 PyRoute/DeltaDebug/*.pyc
+PyRoute/Pathfinding/*.pyc
 Tests/*.pyc
 PyRoute/*.class
 PyRoute/DeltaDebug/*.class
+PyRoute/Pathfinding/*.class
 Tests/*.class
 
 # ignore IDE-related detritus

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -504,3 +504,23 @@ class Galaxy(AreaItem):
     def is_well_formed(self):
         for star in self.stars:
             star.is_well_formed()
+
+    def heuristic_distance(self, star, target):
+        return Star.heuristicDistance(star, target)
+
+    def route_cost(self, route):
+        """
+        Given a route, return its total cost via _compensated_ summation
+        """
+        total_weight = 0
+        c = 0
+        start = route[0]
+        for end in route[1:]:
+            y = float(self.stars[start][end]['weight']) - c
+            t = total_weight + y
+            c = (t - total_weight) - y
+
+            total_weight = t
+
+            start = end
+        return total_weight

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -115,10 +115,17 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
     # set target node flag
     target.is_target = True
     targ_hash = target.__hash__()
+    node_counter = 0
 
     while queue:
         # Pop the smallest item from queue.
         _, __, curnode, dist, parent = pop(queue)
+        node_counter += 1
+
+        if 0 == node_counter % 49:
+            # Trim queue items that can not result in a shorter path
+            queue = [item for item in queue if not (item[2] in enqueued and item[3] > enqueued[item[2]][0])]
+            heapify(queue)
 
         if curnode.is_target and targ_hash == curnode.__hash__() and curnode == target:
             target.is_target = False

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -172,6 +172,8 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
             if neighbor.is_target and targ_hash == neighbor.__hash__() and neighbor == target:
                 upbound = min(upbound, ncost)
                 queue = [item for item in queue if item[0] <= upbound]
+                # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
+                queue = [item for item in queue if not (item[2] in enqueued and item[3] > enqueued[item[2]][0])]
                 heapify(queue)
                 delta = upbound - dist
 

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -141,6 +141,8 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
             qcost, h = enqueued[curnode]
             if qcost < dist:
                 continue
+            # If we've found a better path, update
+            enqueued[curnode] = dist, h
 
         explored[curnode] = parent
 
@@ -167,6 +169,9 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                 # to the queue
                 if qcost <= ncost:
                     continue
+                # if qcost > ncost, we've found a less-costly
+                # path from neighbour to the source, so update enqueued value
+                enqueued[neighbor] = ncost, h
             else:
                 h = heuristic(neighbor, target)
 

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -143,13 +143,17 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                 continue
 
         explored[curnode] = parent
+        delta = upbound - dist
 
-        for neighbor, w in G_succ[curnode].items():
-            cost = weight(curnode, neighbor, w)
-            if cost is None:
-                continue
+        # Filter out neighbours who will already bust upper bound, before a better one is found
+        pre_filter_dict = {key: value for key, value in G_succ[curnode].items() if value['weight'] is not None and value['weight'] <= delta}
+
+        for neighbor in pre_filter_dict:
+            cost = pre_filter_dict[neighbor]['weight']
             ncost = dist + cost
             # if just _adding_ the neighbour busts the upper bound, move on
+            # This is still needed despite the pre-filtering - say prefiltering was against an upper bound of 2000
+            # and upper bound has now dropped to 1800
             if ncost > upbound:
                 continue
             # if this completes a path (no matter how _bad_), update the upper bound

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -167,7 +167,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
         if 0 == len(neighbours):
             continue
 
-        # if neighbours list has at least 2 elements, sort it, putting the target node first, then by ascending
+        # if neighbours list has at least 2 elements, sort it, putting the target node first, then by ascending weight
         if 1 < len(neighbours):
             neighbours.sort(key=lambda item: item[1]['weight'])
             neighbours.sort(key=lambda item: item[0].is_target, reverse=True)
@@ -201,7 +201,6 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                     # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
                     queue = [item for item in queue if not (item[2] in enqueued and item[3] > enqueued[item[2]][0])]
                     heapify(queue)
-                    delta = upbound - dist
 
             # if ncost + heuristic would bust the _upper_ bound, there's no point queueing the neighbour
             # If neighbour is the target, h should be zero

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -149,9 +149,13 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
         # Pre-filter neighbours
         # Remove neighbour nodes that are already enqueued and won't result in shorter paths to them
         neighbours = [(k, v) for (k, v) in G_succ[curnode].items() if not (k.is_enqueued and k in enqueued and dist + v['weight'] >= enqueued[k][0])]
-        if upbound != float('inf'):
+        if upbound != float('inf') and 0 < len(neighbours):
             # Remove neighbour nodes who will bust the upper bound as it currently stands
             neighbours = [(k, v) for (k, v) in neighbours if v['weight'] <= delta]
+
+        # if neighbours list is empty, go around
+        if 0 == len(neighbours):
+            continue
 
         for neighbor, w in neighbours:
             ncost = dist + w['weight']

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -97,7 +97,8 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
 
     push = heappush
     pop = heappop
-    weight = _weight_function(G, weight)
+    # weight = _weight_function(G, weight)
+    weight = weight_function(weight)
 
     G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
 
@@ -224,6 +225,10 @@ def astar_path_length(G, source, target, heuristic=None, weight="weight"):
         msg = f"Either source {source} or target {target} is not in G"
         raise nx.NodeNotFound(msg)
 
-    weight = _weight_function(G, weight)
-    path = astar_path(G, source, target, heuristic, weight)
+    weight_fn = weight_function(G, weight)
+    path = astar_path(G, source, target, heuristic, weight_fn)
     return sum(weight(u, v, G[u][v]) for u, v in zip(path[:-1], path[1:]))
+
+
+def weight_function(weight):
+    return lambda u, v, data: data.get(weight, 1)

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -143,17 +143,11 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                 continue
 
         explored[curnode] = parent
-        delta = upbound - dist
 
-        # Filter out neighbours who will already bust upper bound, before a better one is found
-        pre_filter_dict = {key: value for key, value in G_succ[curnode].items() if value['weight'] is not None and value['weight'] <= delta}
-
-        for neighbor in pre_filter_dict:
-            cost = pre_filter_dict[neighbor]['weight']
+        for neighbor, w in G_succ[curnode].items():
+            cost = w['weight']
             ncost = dist + cost
             # if just _adding_ the neighbour busts the upper bound, move on
-            # This is still needed despite the pre-filtering - say prefiltering was against an upper bound of 2000
-            # and upper bound has now dropped to 1800
             if ncost > upbound:
                 continue
             # if this completes a path (no matter how _bad_), update the upper bound

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -146,8 +146,13 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
 
         # gap between dist and current upper bound - if a neighbour's connecting weight exceeds this, skip it
         delta = upbound - dist
-        # Pre-filter neighbours who will bust the upper bound as it currently stands
-        neighbours = [(k, v) for (k, v) in G_succ[curnode].items() if v['weight'] <= delta]
+        # Pre-filter neighbours
+        # Remove neighbour nodes that are already enqueued and won't result in shorter paths to them
+        neighbours = [(k, v) for (k, v) in G_succ[curnode].items() if not (k.is_enqueued and k in enqueued and dist + v['weight'] >= enqueued[k][0])]
+        if upbound != float('inf'):
+            # Remove neighbour nodes who will bust the upper bound as it currently stands
+            neighbours = [(k, v) for (k, v) in neighbours if v['weight'] <= delta]
+
         for neighbor, w in neighbours:
             ncost = dist + w['weight']
             if neighbor.is_enqueued and neighbor in enqueued:
@@ -168,6 +173,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                 upbound = min(upbound, ncost)
                 queue = [item for item in queue if item[0] <= upbound]
                 heapify(queue)
+                delta = upbound - dist
 
             # if ncost + heuristic would bust the _upper_ bound, there's no point queueing the neighbour
             # If neighbour is the target, h should be zero

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -1,0 +1,229 @@
+"""Shortest paths and path lengths using the A* ("A star") algorithm.
+
+Lifted from networkx repo (https://github.com/networkx/networkx/blob/main/networkx/algorithms/shortest_paths/astar.py)
+as at Add note about using latex formatting in docstring in the contributor…  (commit a63c8bd).
+
+Major modification here is tracking _upper_ bounds on shortest-path length as they are found
+"""
+from heapq import heappop, heappush
+from itertools import count
+
+import networkx as nx
+from networkx.algorithms.shortest_paths.weighted import _weight_function
+
+__all__ = ["astar_path", "astar_path_length"]
+
+
+def astar_path(G, source, target, heuristic=None, weight="weight"):
+    """Returns a list of nodes in a shortest path between source and target
+    using the A* ("A-star") algorithm.
+
+    There may be more than one shortest path.  This returns only one.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node for path
+
+    target : node
+       Ending node for path
+
+    heuristic : function
+       A function to evaluate the estimate of the distance
+       from the a node to the target.  The function takes
+       two nodes arguments and must return a number.
+       If the heuristic is inadmissible (if it might
+       overestimate the cost of reaching the goal from a node),
+       the result may not be a shortest path.
+       The algorithm does not support updating heuristic
+       values for the same node due to caching the first
+       heuristic calculation per node.
+
+    weight : string or function
+       If this is a string, then edge weights will be accessed via the
+       edge attribute with this key (that is, the weight of the edge
+       joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+       such edge attribute exists, the weight of the edge is assumed to
+       be one.
+       If this is a function, the weight of an edge is the value
+       returned by the function. The function must accept exactly three
+       positional arguments: the two endpoints of an edge and the
+       dictionary of edge attributes for that edge. The function must
+       return a number or None to indicate a hidden edge.
+
+    Raises
+    ------
+    NetworkXNoPath
+        If no path exists between source and target.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> print(nx.astar_path(G, 0, 4))
+    [0, 1, 2, 3, 4]
+    >>> G = nx.grid_graph(dim=[3, 3])  # nodes are two-tuples (x,y)
+    >>> nx.set_edge_attributes(G, {e: e[1][0] * 2 for e in G.edges()}, "cost")
+    >>> def dist(a, b):
+    ...     (x1, y1) = a
+    ...     (x2, y2) = b
+    ...     return ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
+    >>> print(nx.astar_path(G, (0, 0), (2, 2), heuristic=dist, weight="cost"))
+    [(0, 0), (0, 1), (0, 2), (1, 2), (2, 2)]
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    The weight function can be used to hide edges by returning None.
+    So ``weight = lambda u, v, d: 1 if d['color']=="red" else None``
+    will find the shortest red path.
+
+    See Also
+    --------
+    shortest_path, dijkstra_path
+
+    """
+    if source not in G or target not in G:
+        msg = f"Either source {source} or target {target} is not in G"
+        raise nx.NodeNotFound(msg)
+
+    if heuristic is None:
+        # The default heuristic is h=0 - same as Dijkstra's algorithm
+        def heuristic(u, v):
+            return 0
+
+    push = heappush
+    pop = heappop
+    weight = _weight_function(G, weight)
+
+    G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
+
+    # The queue stores priority, node, cost to reach, and parent.
+    # Uses Python heapq to keep in priority order.
+    # Add a counter to the queue to prevent the underlying heap from
+    # attempting to compare the nodes themselves. The hash breaks ties in the
+    # priority and is guaranteed unique for all nodes in the graph.
+    c = count()
+    queue = [(0, next(c), source, 0, None)]
+
+    # Maps enqueued nodes to distance of discovered paths and the
+    # computed heuristics to target. We avoid computing the heuristics
+    # more than once and inserting the node into the queue too many times.
+    enqueued = {}
+    # Maps explored nodes to parent closest to the source.
+    explored = {}
+    # Tracks shortest _complete_ path found so far
+    upbound = float('inf')
+
+    while queue:
+        # Pop the smallest item from queue.
+        _, __, curnode, dist, parent = pop(queue)
+
+        if curnode == target:
+            path = [curnode]
+            node = parent
+            while node is not None:
+                path.append(node)
+                node = explored[node]
+            path.reverse()
+            return path
+
+        if curnode in explored:
+            # Do not override the parent of starting node
+            if explored[curnode] is None:
+                continue
+
+            # Skip bad paths that were enqueued before finding a better one
+            qcost, h = enqueued[curnode]
+            if qcost < dist:
+                continue
+
+        explored[curnode] = parent
+
+        for neighbor, w in G_succ[curnode].items():
+            cost = weight(curnode, neighbor, w)
+            if cost is None:
+                continue
+            ncost = dist + cost
+            # if just _adding_ the neighbour busts the upper bound, move on
+            if ncost > upbound:
+                continue
+            # if this completes a path (no matter how _bad_), update the upper bound
+            if neighbor == target:
+                upbound = min(upbound, ncost)
+                queue = [item for item in queue if item[0] <= upbound]
+            if neighbor in enqueued:
+                qcost, h = enqueued[neighbor]
+                # if qcost <= ncost, a less costly path from the
+                # neighbor to the source was already determined.
+                # Therefore, we won't attempt to push this neighbor
+                # to the queue
+                if qcost <= ncost:
+                    continue
+            else:
+                h = heuristic(neighbor, target)
+            # if ncost + heuristic would bust the _upper_ bound, there's no point queueing the neighbour
+            # If neighbour is the target, h should be zero
+            if ncost + h <= upbound:
+                enqueued[neighbor] = ncost, h
+                push(queue, (ncost + h, next(c), neighbor, ncost, curnode))
+
+    raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
+
+
+def astar_path_length(G, source, target, heuristic=None, weight="weight"):
+    """Returns the length of the shortest path between source and target using
+    the A* ("A-star") algorithm.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node for path
+
+    target : node
+       Ending node for path
+
+    heuristic : function
+       A function to evaluate the estimate of the distance
+       from the a node to the target.  The function takes
+       two nodes arguments and must return a number.
+       If the heuristic is inadmissible (if it might
+       overestimate the cost of reaching the goal from a node),
+       the result may not be a shortest path.
+       The algorithm does not support updating heuristic
+       values for the same node due to caching the first
+       heuristic calculation per node.
+
+    weight : string or function
+       If this is a string, then edge weights will be accessed via the
+       edge attribute with this key (that is, the weight of the edge
+       joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+       such edge attribute exists, the weight of the edge is assumed to
+       be one.
+       If this is a function, the weight of an edge is the value
+       returned by the function. The function must accept exactly three
+       positional arguments: the two endpoints of an edge and the
+       dictionary of edge attributes for that edge. The function must
+       return a number or None to indicate a hidden edge.
+    Raises
+    ------
+    NetworkXNoPath
+        If no path exists between source and target.
+
+    See Also
+    --------
+    astar_path
+
+    """
+    if source not in G or target not in G:
+        msg = f"Either source {source} or target {target} is not in G"
+        raise nx.NodeNotFound(msg)
+
+    weight = _weight_function(G, weight)
+    path = astar_path(G, source, target, heuristic, weight)
+    return sum(weight(u, v, G[u][v]) for u, v in zip(path[:-1], path[1:]))

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -5,13 +5,13 @@ as at Add note about using latex formatting in docstring in the contributor…  
 
 Major modification here is tracking _upper_ bounds on shortest-path length as they are found
 """
-from heapq import heappop, heappush
+from heapq import heappop, heappush, heapify
 from itertools import count
 
 import networkx as nx
 from networkx.algorithms.shortest_paths.weighted import _weight_function
 
-__all__ = ["astar_path", "astar_path_length"]
+__all__ = ["astar_path"]
 
 
 def astar_path(G, source, target, heuristic=None, weight="weight"):
@@ -90,15 +90,8 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
         msg = f"Either source {source} or target {target} is not in G"
         raise nx.NodeNotFound(msg)
 
-    if heuristic is None:
-        # The default heuristic is h=0 - same as Dijkstra's algorithm
-        def heuristic(u, v):
-            return 0
-
     push = heappush
     pop = heappop
-    # weight = _weight_function(G, weight)
-    weight = weight_function(weight)
 
     G_succ = G._adj  # For speed-up (and works for both directed and undirected graphs)
 
@@ -154,6 +147,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
             if neighbor == target:
                 upbound = min(upbound, ncost)
                 queue = [item for item in queue if item[0] <= upbound]
+                heapify(queue)
             if neighbor in enqueued:
                 qcost, h = enqueued[neighbor]
                 # if qcost <= ncost, a less costly path from the
@@ -171,62 +165,3 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
                 push(queue, (ncost + h, next(c), neighbor, ncost, curnode))
 
     raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")
-
-
-def astar_path_length(G, source, target, heuristic=None, weight="weight"):
-    """Returns the length of the shortest path between source and target using
-    the A* ("A-star") algorithm.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-
-    source : node
-       Starting node for path
-
-    target : node
-       Ending node for path
-
-    heuristic : function
-       A function to evaluate the estimate of the distance
-       from the a node to the target.  The function takes
-       two nodes arguments and must return a number.
-       If the heuristic is inadmissible (if it might
-       overestimate the cost of reaching the goal from a node),
-       the result may not be a shortest path.
-       The algorithm does not support updating heuristic
-       values for the same node due to caching the first
-       heuristic calculation per node.
-
-    weight : string or function
-       If this is a string, then edge weights will be accessed via the
-       edge attribute with this key (that is, the weight of the edge
-       joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
-       such edge attribute exists, the weight of the edge is assumed to
-       be one.
-       If this is a function, the weight of an edge is the value
-       returned by the function. The function must accept exactly three
-       positional arguments: the two endpoints of an edge and the
-       dictionary of edge attributes for that edge. The function must
-       return a number or None to indicate a hidden edge.
-    Raises
-    ------
-    NetworkXNoPath
-        If no path exists between source and target.
-
-    See Also
-    --------
-    astar_path
-
-    """
-    if source not in G or target not in G:
-        msg = f"Either source {source} or target {target} is not in G"
-        raise nx.NodeNotFound(msg)
-
-    weight_fn = weight_function(G, weight)
-    path = astar_path(G, source, target, heuristic, weight_fn)
-    return sum(weight(u, v, G[u][v]) for u, v in zip(path[:-1], path[1:]))
-
-
-def weight_function(weight):
-    return lambda u, v, data: data.get(weight, 1)

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -167,6 +167,14 @@ def astar_path(G, source, target, heuristic=None, weight="weight"):
         if 0 == len(neighbours):
             continue
 
+        # if neighbours list has at least 2 elements, sort it, putting the target node first, then by ascending
+        if 1 < len(neighbours):
+            neighbours.sort(key=lambda item: item[1]['weight'])
+            neighbours.sort(key=lambda item: item[0].is_target, reverse=True)
+            if neighbours[0][0].is_target:  # If first item is the target node, drop all neighbours with higher weights
+                targ_weight = neighbours[0][1]['weight']
+                neighbours = [(k, v) for (k, v) in neighbours if v['weight'] <= targ_weight]
+
         for neighbor, w in neighbours:
             ncost = dist + w['weight']
             if neighbor.is_enqueued and neighbor in enqueued:

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -145,6 +145,8 @@ class Star(object):
         self.star_list = None
         self.routes = None
         self.stars = None
+        self.is_enqueued = False
+        self.is_target = False
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -410,7 +410,7 @@ class XRouteCalculation(RouteCalculation):
             data = self.galaxy.stars[start][end]
             data['trade'] = max(trade, data[start][end]['trade'])
             data['count'] += 1
-            data['weight'] -= data['weight'] // self.route_reuse
+            data['weight'] -= (data['weight'] - data['distance']) // self.route_reuse
             start = end
 
         self.galaxy.ranges[route[0]][route[-1]]['actual distance'] = distance
@@ -803,7 +803,7 @@ class TradeCalculation(RouteCalculation):
                 # Reduce the weight of this route. 
                 # As the higher trade routes create established routes 
                 # which are more likely to be followed by lower trade routes
-                data['weight'] -= data['weight'] / self.route_reuse
+                data['weight'] -= (data['weight'] - data['distance']) / self.route_reuse
                 end.tradeOver += tradeCr if end != target else 0
                 start = end
 
@@ -1025,5 +1025,5 @@ class CommCalculation(RouteCalculation):
                     max(data['weight'] - 2,
                         self.route_reuse)
             else:
-                data['weight'] -= data['weight'] / self.route_reuse
+                data['weight'] -= (data['weight'] - data['distance']) / self.route_reuse
             start = end

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -683,7 +683,7 @@ class TradeCalculation(RouteCalculation):
             data = self.galaxy.stars[start][end]
             data['trade'] += tradeCr
             data['count'] += 1
-            data['weight'] -= data['weight'] / self.route_reuse
+            data['weight'] -= (data['weight'] - data['distance']) / self.route_reuse
             start = end
 
         return (tradeCr, tradePass)

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -407,10 +407,10 @@ class XRouteCalculation(RouteCalculation):
         for end in route[1:]:
             distance += start.hex_distance(end)
             end.tradeCount += 1
-            self.galaxy.stars[start][end]['trade'] = max(trade, self.galaxy.stars[start][end]['trade'])
-            self.galaxy.stars[start][end]['count'] += 1
-            self.galaxy.stars[start][end]['weight'] -= \
-                self.galaxy.stars[start][end]['weight'] // self.route_reuse
+            data = self.galaxy.stars[start][end]
+            data['trade'] = max(trade, data[start][end]['trade'])
+            data['count'] += 1
+            data['weight'] -= data['weight'] // self.route_reuse
             start = end
 
         self.galaxy.ranges[route[0]][route[-1]]['actual distance'] = distance
@@ -680,10 +680,10 @@ class TradeCalculation(RouteCalculation):
             end.tradeOver += tradeCr if end != route[-1] else 0
             end.tradeCount += 1 if end != route[-1] else 0
             end.passOver += tradePass if end != route[-1] else 0
-            self.galaxy.stars[start][end]['trade'] += tradeCr
-            self.galaxy.stars[start][end]['count'] += 1
-            self.galaxy.stars[start][end]['weight'] -= \
-                self.galaxy.stars[start][end]['weight'] / self.route_reuse
+            data = self.galaxy.stars[start][end]
+            data['trade'] += tradeCr
+            data['count'] += 1
+            data['weight'] -= data['weight'] / self.route_reuse
             start = end
 
         return (tradeCr, tradePass)
@@ -798,12 +798,12 @@ class TradeCalculation(RouteCalculation):
             for end in route:
                 if end == start:
                     continue
-                self.galaxy.stars[start][end]['trade'] += tradeCr
+                data = self.galaxy.stars[start][end]
+                data['trade'] += tradeCr
                 # Reduce the weight of this route. 
                 # As the higher trade routes create established routes 
                 # which are more likely to be followed by lower trade routes
-                self.galaxy.stars[start][end]['weight'] -= \
-                    self.galaxy.stars[start][end]['weight'] / self.route_reuse
+                data['weight'] -= data['weight'] / self.route_reuse
                 end.tradeOver += tradeCr if end != target else 0
                 start = end
 
@@ -1017,13 +1017,13 @@ class CommCalculation(RouteCalculation):
         start = route[0]
         for end in route[1:]:
             end.tradeCount += 1 if end != route[-1] else 0
-            self.galaxy.stars[start][end]['trade'] = trade
-            self.galaxy.stars[start][end]['count'] += 1
+            data = self.galaxy.stars[start][end]
+            data['trade'] = trade
+            data['count'] += 1
             if start == route[0] or end == route[-1]:
-                self.galaxy.stars[start][end]['weight'] = \
-                    max(self.galaxy.stars[start][end]['weight'] - 2,
+                data['weight'] = \
+                    max(data['weight'] - 2,
                         self.route_reuse)
             else:
-                self.galaxy.stars[start][end]['weight'] -= \
-                    self.galaxy.stars[start][end]['weight'] / self.route_reuse
+                data['weight'] -= data['weight'] / self.route_reuse
             start = end

--- a/PyRoute/TradeCalculation.py
+++ b/PyRoute/TradeCalculation.py
@@ -8,6 +8,7 @@ import logging
 import itertools
 import networkx as nx
 from PyRoute.AllyGen import AllyGen
+from PyRoute.Pathfinding.astar import astar_path
 from PyRoute.Star import Star
 
 
@@ -606,7 +607,7 @@ class TradeCalculation(RouteCalculation):
             "This route from " + str(star) + " to " + str(target) + " has already been processed in reverse"
 
         try:
-            route = nx.astar_path(self.galaxy.stars, star, target, Star.heuristicDistance)
+            route = astar_path(self.galaxy.stars, star, target, self.galaxy.heuristic_distance)
         except nx.NetworkXNoPath:
             return
 


### PR DESCRIPTION
As pathfinding is the biggest part of most runs, it actually paid off adding a custom A* implementation, derived from the networkx one, that made assumptions better fitting pyroute (rather than general use).

The custom pathfinder also aggressively prunes blind alleys, dead ends, and upper-bound-busters before spending too much time on them.

Over a 12 sector testbed (Reft Sector, Trojan Reach, Deneb, Gushemege, Verge, Riftspan Reaches, Touchstone, Hlakhoi, 
Corridor, Vland, Dagudashaag, Zarushagar), totalling 4,117 stars:

As at https://github.com/makhidkarun/traveller_pyroute/commit/076f1a130d3b2754de300731422cdeeb9e18aede :
Overall took 22 min 16 sec, (1336 s) with pathfinding occupying 18 min 17 sec (1097 s), or 82% of total.

As at "Sort neighbours after filtering", same testbed ( I hadn't gathered up all my changes to custom A*):
Overall took 16 min 15 s, (975 s) with pathfinding occupying 12 min 55 sec (775 s), or 79% of total.
