### PR TITLE
Add trade multi-processing variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Tests/.pytest_cache/
 # ignore downloaded/generated files
 sectors/
 maps/
+diffs/
+test_data/

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -150,7 +150,13 @@ class TradeCalculation(RouteCalculation):
         # connected components in the underlying galaxy.stars graph - such pathfinding attempts are doomed
         # to failure.
         self.calculate_components()
-        btn = [(s, n, d) for (s, n, d) in self.galaxy.ranges.edges(data=True) if s.component == n.component]
+
+        btn_skipped = [(s, n) for (s, n) in self.galaxy.ranges.edges() if s.component != n.component]
+        self.logger.debug(f"Found {len(btn_skipped)} non-component routes, removing from ranges graph")
+        for s, n in btn_skipped:
+            self.galaxy.ranges.remove_edge(s, n)
+
+        btn = [(s, n, d) for (s, n, d) in self.galaxy.ranges.edges(data=True)]
         btn.sort(key=lambda tn: tn[2]['btn'], reverse=True)
 
         # Pick landmarks - biggest WTN system in each graph component.  It worked out simpler to do this for _all_
@@ -214,8 +220,10 @@ class TradeCalculation(RouteCalculation):
             raise AssertionError(msg)
 
         # Update the trade route (edges)
-        tradeCr, tradePass = self.route_update_simple(route)
+        tradeCr, tradePass = self.route_update_simple(route, True)
+        self.update_statistics(star, target, tradeCr, tradePass)
 
+    def update_statistics(self, star, target, tradeCr, tradePass):
         if star.sector != target.sector:
             star.sector.stats.tradeExt += tradeCr // 2
             target.sector.stats.tradeExt += tradeCr // 2
@@ -279,7 +287,7 @@ class TradeCalculation(RouteCalculation):
             return (name_from, name_to)
         return (name_to, name_from)
 
-    def route_update_simple(self, route):
+    def route_update_simple(self, route, reweight=True):
         """
         Update the trade calculations based upon the route selected.
         - add the trade values for the worlds, and edges
@@ -320,13 +328,15 @@ class TradeCalculation(RouteCalculation):
             data = self.galaxy.stars[start.index][end.index]
             data['trade'] += tradeCr
             data['count'] += 1
-            data['weight'] -= (data['weight'] - data['distance']) / self.route_reuse
+            if reweight:
+                data['weight'] -= (data['weight'] - data['distance']) / self.route_reuse
             edges.append((start.index, end.index))
             start = end
 
         # Feed the list of touched edges into the approximate-shortest-path machinery, so it can update whatever
         # distance labels it needs to stay within its approximation bound.
-        self.shortest_path_tree.update_edges(edges)
+        if reweight:
+            self.shortest_path_tree.update_edges(edges)
 
         return (tradeCr, tradePass)
 

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -88,14 +88,16 @@ class TradeCalculation(RouteCalculation):
     def base_range_routes(self, star, neighbor):
         dist = star.distance(neighbor)
         max_dist = self.btn_range[min(max(0, max(star.wtn, neighbor.wtn) - self.min_wtn), 5)]
-        btn = self.get_btn(star, neighbor, dist)
-        # add all the stars in the BTN range, but  skip this pair
+        # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
-        if dist <= max_dist and btn >= self.min_btn:
-            passBTN = self.get_passenger_btn(btn, star, neighbor)
-            self.galaxy.ranges.add_edge(star, neighbor, distance=dist,
-                                        btn=btn,
-                                        passenger_btn=passBTN)
+        if dist <= max_dist:
+            # Only bother getting btn if the route is inside max length
+            btn = self.get_btn(star, neighbor, dist)
+            if btn >= self.min_btn:
+                passBTN = self.get_passenger_btn(btn, star, neighbor)
+                self.galaxy.ranges.add_edge(star, neighbor, distance=dist,
+                                            btn=btn,
+                                            passenger_btn=passBTN)
         return dist
 
     def generate_routes(self):

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -149,6 +149,8 @@ class TradeMPCalculation(TradeCalculation):
         self.start_mp_services()
         # Do the remaining routes, which are long and will take a while
         self.process_long_routes(self.btn[large_btn_index:])
+        self.multilateral_balance_trade()
+        self.multilateral_balance_pass()
 
     # This is the multiprocess method, which contains all the logic for using multi-process in the parent (core) process
     # When this is completed, all the child process should be completed.

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -1,0 +1,516 @@
+"""
+@author: tjoneslo
+"""
+import os
+
+import networkx as nx
+from networkx import is_path
+from PyRoute.AllyGen import AllyGen
+from PyRoute.Calculation.RouteCalculation import RouteCalculation
+from PyRoute.Pathfinding.ApproximateShortestPathTree import ApproximateShortestPathTree
+from PyRoute.Pathfinding.astar import astar_path_indexes
+from multiprocessing import Queue, Pool
+from queue import Empty
+
+# Convert the TradeMPCalculation to a global variable to allow the child processes to access it, and all the data.
+tradeCalculation = None
+
+
+def intrasector_process(working_queue, processed_queue):
+    """
+    This is the core working function used by the child processes spawned by the start_mp_services() functions.
+    :param working_queue: List of sectors to process
+    :param processed_queue: List of routes found by the child process, consumed by the paraent.
+    :return: None
+    """
+    global tradeCalculation
+    while True:
+        # Read the sector names from the queue created by parent process.
+        # When the queue is empty we're done and can complete the process
+        try:
+            sector = working_queue.get(block=True, timeout=1)
+        except Empty:
+            break
+        count = 0
+        tradeCalculation.logger.info(f"starting work in {sector}")
+        for (star, neighbor, data) in tradeCalculation.btn:
+
+            # Here we're just doing the routes that are within the one sector we're currently processing
+            # If other routes are to be done, this will have to change to select the routes from the BTN list.
+            # TODO: Organized the tradeCalculation.btn to divided into sector / galaxy lists.
+            if not (star.sector.name == sector and neighbor.sector.name == sector):
+                continue
+
+            # if this route has been processed, skip it, but still count it
+            if data.get('jumps', False):
+                count += 1
+                continue
+
+            try:
+                rawroute, diag = astar_path_indexes(tradeCalculation.galaxy.stars, star.index, neighbor.index,
+                                                    tradeCalculation.galaxy.heuristic_distance_indexes)
+            except nx.NetworkXNoPath:
+                continue
+
+
+            # Update the routes in the child's internal list, like we would for the primary one,
+            # But only for the child data. This makes sure the routes are properly reduced in weights for the next
+            # route search.
+            route = [tradeCalculation.galaxy.star_mapping[item] for item in rawroute]
+            tradeCalculation.route_update_simple(route, True)
+
+            # Put the rawroute (list of indexes) on the return queue to the parent process.
+            processed_queue.put(rawroute)
+            count += 1
+
+        tradeCalculation.logger.info(f"Process for {sector} completed, {count} routes processed.")
+    # And were done. Note this for the user.
+    tradeCalculation.logger.info(f"child process {os.getpid()} completed.")
+
+
+def long_route_process(working_queue, processed_queue):
+    global tradeCalculation
+    processed = 0
+    total = working_queue.qsize()
+
+    # Working queue here is sending a pair of star indexes to process.
+    while True:
+        try:
+            (star,neighbor) = working_queue.get(block=True, timeout=1)
+        except Empty:
+            break
+
+        try:
+            route, diag = astar_path_indexes(tradeCalculation.galaxy.stars, star, neighbor,
+                                             tradeCalculation.galaxy.heuristic_distance_indexes)
+        except nx.NetworkXNoPath:
+            continue
+
+        # Route is a list of star indexes, which is what the parent process is assuming.
+        processed_queue.put(route)
+        processed += 1
+        if total > 100 and processed % (total // 20) == 0:
+            tradeCalculation.logger.info(f'Child {os.getpid()} processed {processed} routes, at {processed // (total // 100)}%')
+
+    # And were done. Note this for the user.
+    tradeCalculation.logger.info(f"child process {os.getpid()} completed, processed {processed} routes")
+
+
+class TradeMPCalculation(RouteCalculation):
+    """
+    Perform the trade calculations by generating the routes
+    between all the trade pairs using a multi-process route finder
+    """
+    # Weight for route over a distance. The relative cost for
+    # moving freight between two worlds a given distance apart
+    # in a single jump.
+    # These are made up from whole cloth.          
+    # distance_weight = [0, 30, 50, 70, 90, 120, 140 ]
+
+    # GT Weights based upon one pass estimate
+    # distance_weight = [0, 30, 50, 70, 110, 170, 300]
+
+    # Pure HG weights
+    # distance_weight = [0, 30, 50, 75, 130, 230, 490]
+
+    # MGT weights
+    # distance_weight = [0, 30, 60, 105, 190, 410, 2470]
+
+    # T5 Weights, now with Hop Drive
+    distance_weight = [0, 30, 50, 75, 130, 230, 490, 9999, 9999, 9999, 300]
+
+    # max_connections = [6, 18, 36, 60, 90, 126, 168, 216, 270, 330]
+    max_connections = [6, 12, 18, 30, 45, 63, 84, 108, 135, 165]
+
+    # Set an initial range for influence for worlds based upon their
+    # wtn. For a given world look up the range given by (wtn-8) (min 0), 
+    # and the system checks every other world in that range for trade 
+    # opportunity. See the btn_jump_mod and min btn to see how  
+    # worlds are excluded from this list. 
+    btn_range = [2, 9, 29, 59, 99, 299]
+
+    # Maximum WTN to process routes for
+    max_wtn = 15
+
+    def __init__(self, galaxy, min_btn=13, route_btn=8, route_reuse=10, debug_flag=False, mp_threads=os.cpu_count()-1):
+        super(TradeMPCalculation, self).__init__(galaxy)
+
+        # Minimum BTN to calculate routes for. BTN between two worlds less than
+        # this value are ignored. Set lower to have more routes calculated, but
+        # may not have an impact on the overall trade flows.
+        self.min_btn = min_btn
+
+        # Minimum WTN to process routes for
+        self.min_wtn = route_btn
+
+        # Override the default setting for route-reuse from the base class
+        # based upon program arguments. 
+        self.route_reuse = route_reuse
+
+        # Are debugging gubbins turned on?
+        self.debug_flag = debug_flag
+        self.btn = []
+        self.mp_threads = mp_threads
+
+    def base_route_filter(self, star, neighbor):
+        return False
+
+    def unilateral_filter(self, star):
+        if star.zone in ['R', 'F']:
+            return True
+        if star.tradeCode.barren:
+            return True
+        return False
+
+    def base_range_routes(self, star, neighbor):
+        dist = star.distance(neighbor)
+        max_dist = self.btn_range[min(max(0, max(star.wtn, neighbor.wtn) - self.min_wtn), 5)]
+        btn = self.get_btn(star, neighbor, dist)
+        # add all the stars in the BTN range, but  skip this pair
+        # if there isn't enough trade to warrant a trade check
+        if dist <= max_dist and btn >= self.min_btn:
+            passBTN = self.get_passenger_btn(btn, star, neighbor)
+            self.galaxy.ranges.add_edge(star, neighbor, distance=dist,
+                                        btn=btn,
+                                        passenger_btn=passBTN)
+        return dist
+
+    def generate_routes(self):
+        """
+        Generate the basic routes between all the stars. This creates two sets
+        of routes.
+        - Stars: The basic J4 (max-jump) routes for all pairs of stars.
+        - Ranges: The set of trade routes needing to be calculated.
+        """
+        self.generate_base_routes()
+
+        self.logger.info('calculating routes...')
+        for star in self.galaxy.stars:
+            if len(self.galaxy.stars[star]) < 11:
+                continue
+            neighbor_routes = [(s, n, d) for (s, n, d) in self.galaxy.stars.edges([star], True)]
+            # Need to do two sorts here:
+            # BTN low to high to find them first
+            # Range high to low to find them first 
+            neighbor_routes.sort(key=lambda tn: tn[2]['btn'])
+            neighbor_routes.sort(key=lambda tn: tn[2]['distance'], reverse=True)
+
+            length = len(neighbor_routes)
+
+            # remove edges from the list which are 
+            # A) The most distant first
+            # B) The lowest BTN for equal distant routes
+            # If the neighbor has only a few (<15) connections don't remove that one
+            # until there are 20 connections left. 
+            # This may be reduced by other stars deciding you are too far away.             
+            for (s, n, d) in neighbor_routes:
+                if len(self.galaxy.stars[n]) < 15:
+                    continue
+                if length <= self.max_connections[self.galaxy.max_jump_range - 1]:
+                    break
+                if d.get('xboat', False) or d.get('comm', False):
+                    continue
+                self.galaxy.stars.remove_edge(s, n)
+                length -= 1
+        self.logger.info(f'Final route count {self.galaxy.stars.number_of_edges()}')
+
+    def calculate_routes(self):
+        """
+        The base calculate routes. Read through all the stars in WTN order.
+        Do this order to allow the higher trade routes establish the basic routes
+        for the lower routes to follow.
+        """
+        self.logger.info('sorting routes...')
+
+        # Filter out pathfinding attempts that can never return a route, as they're between two different
+        # connected components in the underlying galaxy.stars graph - such pathfinding attempts are doomed
+        # to failure.
+        self.calculate_components()
+        self.btn = [(s, n, d) for (s, n, d) in self.galaxy.ranges.edges(data=True) if s.component == n.component]
+        self.btn.sort(key=lambda tn: tn[2]['btn'], reverse=True)
+
+        # Pick landmarks - biggest WTN system in each graph component.  It worked out simpler to do this for _all_
+        # components, even those with only one star.
+        landmarks = self.get_landmarks(index=True)
+        source = max(self.galaxy.star_mapping.values(), key=lambda item: item.wtn)
+        source.is_landmark = True
+        # Feed the landmarks in as roots of their respective shortest-path trees.
+        # This sets up the approximate-shortest-path bounds to be during the first pathfinding call.
+        self.shortest_path_tree = ApproximateShortestPathTree(source.index, self.galaxy.stars, 0.2, sources=landmarks)
+
+        large_btn_index = next(i for i,v in enumerate(self.btn) if v[2]['btn'] == 18)
+
+        # Do the large routes (btn 19 - 26) first. These are short and take only a short amount of time.
+        self.process_routes(self.btn[0:large_btn_index-1])
+        # Do the in-sector routes next. Again short, and famed across multiple processor to make this faster.
+        self.start_mp_services()
+        # Do the remaining routes, which are long and will take a while
+        self.process_long_routes(self.btn[large_btn_index:])
+
+    # This is the multiprocess method, which contains all the logic for using multi-process in the parent (core) process
+    # When this is completed, all the child process should be completed.
+    def start_mp_services (self):
+        global tradeCalculation
+        tradeCalculation = self
+
+        # Create the Queues for sending data between processes.
+        sector_queue = Queue()
+        routes_queue = Queue()
+        count = 0
+        # write sector names to the queue
+        for sector in self.galaxy.sectors.keys():
+            sector_queue.put(sector)
+
+        # This starts the child processes.
+        # Use a "with ... as ..." to ensure the workers and everything is cleaned up
+        # when the workers are completed.
+        self.logger.info(f"Starting {self.mp_threads} child processes for sector route calculations")
+        with Pool(processes=self.mp_threads, initializer=intrasector_process, initargs=(sector_queue, routes_queue)):
+            # Loop over the routes found by the child processes.
+            while True:
+                try:
+                    # Get a route from the child processes. This assumes the child processes (collectively)
+                    # won't take more than 3 seconds to produce a route. And they will produce routes faster
+                    # than the parent process can consume them. Which is why we have the queue.
+                    # Once we run out of routes to process, break from the loop
+                    route_list = routes_queue.get(block=True, timeout=3)
+                except Empty:
+                    if not sector_queue.empty():
+                        continue
+                    break
+                # convert route_list (list of star indexes) to route (list of stars)
+                route = [self.galaxy.star_mapping[item] for item in route_list]
+
+                assert is_path(self.galaxy.stars, route_list), f"Route returned by mp process is not a correct path: {route}"
+
+                # Using the route found by the child process update the stars / routes graphs in the parent process
+                start = route[0]
+                target = route[-1]
+                tradeCr, tradePass = self.route_update_simple(route, True)
+                self.update_statistics(start, target, tradeCr, tradePass)
+                count += 1
+        self.logger.info(f"Intra-sector route processing completed. Process {count} routes")
+
+    def process_long_routes(self, btn):
+        # Create the Queues for sending data between processes.
+        find_queue = Queue()
+        routes_queue = Queue()
+        processed = 0
+
+        for (start, target, data) in btn:
+            # skip the routes already that have been processed
+            if data.get('jumps', False):
+                continue
+            find_queue.put((start.index, target.index))
+
+        total = find_queue.qsize()
+        self.logger.info(f"Starting child processes for long route calculations. processing {total} routes")
+
+        with Pool(processes=self.mp_threads, initializer=long_route_process, initargs=(find_queue, routes_queue)):
+            # Loop over the routes found by the child processes.
+            while True:
+                try:
+                    route_list = routes_queue.get(block=True, timeout=5)
+                except Empty:
+                    if not find_queue.empty():
+                        continue
+                    break
+                route = [self.galaxy.star_mapping[item] for item in route_list]
+                assert is_path(self.galaxy.stars, route_list), f"Route returned by mp process is not a correct path: {route}"
+
+                if total > 100 and processed % (total // 20) == 0:
+                    self.logger.info(f'processed {processed} routes, at {processed // (total // 100)}%')
+
+                # Using the route found by the child process update the stars / routes graphs in the parent process
+                start = route[0]
+                target = route[-1]
+                tradeCr, tradePass = self.route_update_simple(route, False)
+                self.update_statistics(start, target, tradeCr, tradePass)
+                processed += 1
+        self.logger.info(f"Long route processing completed. process {processed} routes")
+
+    def process_routes(self, btn):
+        '''
+        Do the other "half" of the routes, the ones not performed by the child process.
+        :return: None
+        '''
+        base_btn = 0
+        counter = 0
+        processed = 0
+        total = len(btn)
+        for (star, neighbor, data) in btn:
+            if base_btn != data['btn']:
+                if counter > 0:
+                    self.logger.info(f'processed {counter} routes at BTN {base_btn}')
+                base_btn = data['btn']
+                counter = 0
+            if total > 100 and processed % (total // 20) == 0:
+                self.logger.info(f'processed {processed} routes, at {processed // (total // 100)}%')
+
+            # If the route has been processed in the child worker, skip it here. But count it toward the number of
+            # processed routes.
+            if data.get('jumps', False):
+                counter += 1
+                processed += 1
+                continue
+
+            # Do the trade route discovery and route calculation
+            self.get_trade_between(star, neighbor)
+            counter += 1
+            processed += 1
+        self.logger.info(f'processed {counter} routes at BTN {base_btn}')
+
+    def get_trade_between(self, star, target):
+        """
+        Calculate the route between star and target
+        If we can't find a route (no Jump 4 (or N) path), skip this pair
+        otherwise update the trade information.
+        """
+        assert 'actual distance' not in self.galaxy.ranges[target][star],\
+            f"This route from {star} to {target} has already been processed in reverse"
+
+        try:
+            rawroute, diag = astar_path_indexes(self.galaxy.stars, star.index, target.index, self.galaxy.heuristic_distance_indexes)
+        except nx.NetworkXNoPath:
+            return
+
+        route = [self.galaxy.star_mapping[item] for item in rawroute]
+
+        assert self.galaxy.route_no_revisit(route), \
+            f"Route between {star}  and {target} revisits at least one star"
+
+        if self.debug_flag:
+            fwd_weight = self.route_cost(route)
+            route.reverse()
+            rev_weight = self.route_cost(route)
+            route.reverse()
+            delta = fwd_weight - rev_weight
+            assert 1e-16 > delta * delta,\
+                f"Route weight between {repr(star)} and {repr(target)} should not be direction sensitive.  Forward weight {fwd_weight}, rev weight {rev_weight}. delta {abs(delta)}"
+
+        # Update the trade route (edges)
+        tradeCr, tradePass = self.route_update_simple(route, True)
+        self.update_statistics(star, target, tradeCr, tradePass)
+
+    def update_statistics(self, star, target, tradeCr, tradePass):
+        if star.sector != target.sector:
+            star.sector.stats.tradeExt += tradeCr // 2
+            target.sector.stats.tradeExt += tradeCr // 2
+            star.sector.subsectors[star.subsector()].stats.tradeExt += tradeCr // 2
+            target.sector.subsectors[target.subsector()].stats.tradeExt += tradeCr // 2
+            star.sector.stats.passengers += tradePass // 2
+            target.sector.stats.passengers += tradePass // 2
+        else:
+            star.sector.stats.trade += tradeCr
+            star.sector.stats.passengers += tradePass
+            if star.subsector() == target.subsector():
+                star.sector.subsectors[star.subsector()].stats.trade += tradeCr
+            else:
+                star.sector.subsectors[star.subsector()].stats.tradeExt += tradeCr // 2
+                target.sector.subsectors[target.subsector()].stats.tradeExt += tradeCr // 2
+
+        if AllyGen.are_allies(star.alg_code, target.alg_code):
+            self.galaxy.alg[AllyGen.same_align(star.alg_code)].stats.trade += tradeCr
+            self.galaxy.alg[AllyGen.same_align(star.alg_code)].stats.passengers += tradePass
+        else:
+            self.galaxy.alg[AllyGen.same_align(star.alg_code)].stats.tradeExt += tradeCr // 2
+            self.galaxy.alg[AllyGen.same_align(target.alg_code)].stats.tradeExt += tradeCr // 2
+            self.galaxy.alg[AllyGen.same_align(star.alg_code)].stats.passengers += tradePass // 2
+            self.galaxy.alg[AllyGen.same_align(target.alg_code)].stats.passengers += tradePass // 2
+
+        self.galaxy.stats.trade += tradeCr
+        self.galaxy.stats.passengers += tradePass
+
+    def route_update_simple(self, route, reweight=True):
+        """
+        Update the trade calculations based upon the route selected.
+        - add the trade values for the worlds, and edges
+        - add a count for the worlds and edges
+        - reduce the weight of routes used to allow more trade to flow
+        """
+        distance = self.route_distance(route)
+
+        source = route[0]
+        target = route[-1]
+
+        # Internal statistics
+        rangedata = self.galaxy.ranges[source][target]
+        rangedata['actual distance'] = distance
+        rangedata['jumps'] = len(route) - 1
+
+        # Gather basic statistics. 
+        tradeBTN = self.get_btn(source, target, distance)
+        tradeCr = self.calc_trade(tradeBTN)
+        source.tradeIn += tradeCr // 2
+        target.tradeIn += tradeCr // 2
+        tradePassBTN = self.get_passenger_btn(tradeBTN, source, target)
+        tradePass = self.calc_passengers(tradePassBTN)
+
+        source.passIn += tradePass
+        target.passIn += tradePass
+
+        edges = []
+        start = source
+        for end in route[1:]:
+            if end != target:
+                end.tradeOver += tradeCr
+                end.tradeCount += 1
+                end.passOver += tradePass
+
+            data = self.galaxy.stars[start.index][end.index]
+            data['trade'] += tradeCr
+            data['count'] += 1
+            if reweight:
+                data['weight'] -= (data['weight'] - data['distance']) / self.route_reuse
+            edges.append((start.index, end.index))
+            start = end
+
+        # Feed the list of touched edges into the approximate-shortest-path machinery, so it can update whatever
+        # distance labels it needs to stay within its approximation bound.
+        self.shortest_path_tree.update_edges(edges)
+
+        return (tradeCr, tradePass)
+
+    @staticmethod
+    def route_distance(route):
+        """
+        Given a route, return its line length in parsec
+        """
+        distance = 0
+        start = route[0]
+        for end in route[1:]:
+            distance += start.distance(end)
+            start = end
+        return distance
+
+    def route_cost(self, route):
+        """
+        Given a route, return its total cost via _compensated_ summation
+        """
+        total_weight = 0
+        c = 0
+        start = route[0]
+        for end in route[1:]:
+            y = float(self.galaxy.stars[start][end]['weight']) - c
+            t = total_weight + y
+            c = (t - total_weight) - y
+
+            total_weight = t
+
+            start = end
+        return total_weight
+
+    def route_weight(self, star, target):
+        dist = star.distance(target)
+        weight = self.distance_weight[dist]
+        if target.alg_code != star.alg_code:
+            weight += 25
+        if star.port in 'CDEX':
+            weight += 25
+        if star.port in 'DEX':
+            weight += 25
+        weight -= star.importance + target.importance
+        # Per https://www.baeldung.com/cs/dijkstra-vs-a-pathfinding , to ensure termination in finite time:
+        # "the edges have strictly positive costs"
+        assert 0 < weight, f"Weight of edge between {star} and {target} must be positive"
+        return weight

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -8,9 +8,9 @@ from networkx import is_path
 from multiprocessing import Queue, Pool
 from queue import Empty
 
-from ApproximateShortestPathTreeZeroCaching import ApproximateShortestPathTreeZeroCaching
 from PyRoute.Calculation.TradeCalculation import TradeCalculation
 from PyRoute.Pathfinding.ApproximateShortestPathTree import ApproximateShortestPathTree
+from PyRoute.Pathfinding.ApproximateShortestPathTreeZeroCaching import ApproximateShortestPathTreeZeroCaching
 from PyRoute.Pathfinding.astar import astar_path_indexes
 
 # Convert the TradeMPCalculation to a global variable to allow the child processes to access it, and all the data.
@@ -245,10 +245,10 @@ class TradeMPCalculation(TradeCalculation):
         self.logger.info(f"Long route processing completed. process {processed} routes")
 
     def process_routes(self, btn):
-        '''
+        """
         Do the first "half" of the routes, the ones not performed by the child process.
         :return: None
-        '''
+        """
         base_btn = 0
         counter = 0
         processed = 0

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -10,7 +10,6 @@ from queue import Empty
 
 from PyRoute.Calculation.TradeCalculation import TradeCalculation
 from PyRoute.Pathfinding.ApproximateShortestPathTree import ApproximateShortestPathTree
-from PyRoute.Pathfinding.ApproximateShortestPathTreeZeroCaching import ApproximateShortestPathTreeZeroCaching
 from PyRoute.Pathfinding.astar import astar_path_indexes
 
 # Convert the TradeMPCalculation to a global variable to allow the child processes to access it, and all the data.
@@ -198,15 +197,7 @@ class TradeMPCalculation(TradeCalculation):
 
     def process_long_routes(self, btn):
 
-        if 60 > len(self.galaxy.sectors):
-            self.shortest_path_tree = ApproximateShortestPathTreeZeroCaching(
-                self.shortest_path_tree._source,
-                self.galaxy.stars,
-                0,
-                sources=self.shortest_path_tree._sources
-            )
-        else:
-            self.shortest_path_tree = ApproximateShortestPathTree(self.shortest_path_tree._source, self.galaxy.stars,
+        self.shortest_path_tree = ApproximateShortestPathTree(self.shortest_path_tree._source, self.galaxy.stars,
                                                                   0, sources=self.shortest_path_tree._sources)
 
         # Create the Queues for sending data between processes.

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -198,12 +198,17 @@ class TradeMPCalculation(TradeCalculation):
 
     def process_long_routes(self, btn):
 
-        self.shortest_path_tree = ApproximateShortestPathTreeZeroCaching(
-            self.shortest_path_tree._source,
-            self.galaxy.stars,
-            0,
-            sources=self.shortest_path_tree._sources
-        )
+        if 60 > len(self.galaxy.sectors):
+            self.shortest_path_tree = ApproximateShortestPathTreeZeroCaching(
+                self.shortest_path_tree._source,
+                self.galaxy.stars,
+                0,
+                sources=self.shortest_path_tree._sources
+            )
+        else:
+            self.shortest_path_tree = ApproximateShortestPathTree(self.shortest_path_tree._source, self.galaxy.stars,
+                                                                  0, sources=self.shortest_path_tree._sources)
+
         # Create the Queues for sending data between processes.
         find_queue = Queue()
         routes_queue = Queue()

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -8,6 +8,7 @@ from networkx import is_path
 from multiprocessing import Queue, Pool
 from queue import Empty
 
+from ApproximateShortestPathTreeZeroCaching import ApproximateShortestPathTreeZeroCaching
 from PyRoute.Calculation.TradeCalculation import TradeCalculation
 from PyRoute.Pathfinding.ApproximateShortestPathTree import ApproximateShortestPathTree
 from PyRoute.Pathfinding.astar import astar_path_indexes
@@ -195,8 +196,12 @@ class TradeMPCalculation(TradeCalculation):
 
     def process_long_routes(self, btn):
 
-        self.shortest_path_tree = ApproximateShortestPathTree(self.shortest_path_tree._source, self.galaxy.stars,
-                                                              0, sources=self.shortest_path_tree._sources)
+        self.shortest_path_tree = ApproximateShortestPathTreeZeroCaching(
+            self.shortest_path_tree._source,
+            self.galaxy.stars,
+            0,
+            sources=self.shortest_path_tree._sources
+        )
         # Create the Queues for sending data between processes.
         find_queue = Queue()
         routes_queue = Queue()

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -78,7 +78,7 @@ def long_route_process(working_queue, processed_queue):
     # Working queue here is sending a pair of star indexes to process.
     while True:
         try:
-            (star,neighbor) = working_queue.get(block=True, timeout=1)
+            (star, neighbor) = working_queue.get(block=True, timeout=1)
         except Empty:
             break
 
@@ -141,7 +141,7 @@ class TradeMPCalculation(TradeCalculation):
         # This sets up the approximate-shortest-path bounds to be during the first pathfinding call.
         self.shortest_path_tree = ApproximateShortestPathTree(source.index, self.galaxy.stars, 0.2, sources=landmarks)
 
-        large_btn_index = next(i for i,v in enumerate(self.btn) if v[2]['btn'] == 18)
+        large_btn_index = next(i for i, v in enumerate(self.btn) if v[2]['btn'] == 18)
 
         # Do the large routes (btn 19 - 26) first. These are short and take only a short amount of time.
         self.process_routes(self.btn[0:large_btn_index-1])

--- a/PyRoute/DeltaDebug/DeltaGalaxy.py
+++ b/PyRoute/DeltaDebug/DeltaGalaxy.py
@@ -12,8 +12,9 @@ from PyRoute.AllyGen import AllyGen
 
 class DeltaGalaxy(Galaxy):
 
-    def read_sectors(self, sectors, pop_code, ru_calc):
-        self._set_trade_object(self.route_reuse, self.trade_choice)
+    def read_sectors(self, sectors, pop_code, ru_calc,
+                     route_reuse, trade_choice, route_btn, mp_threads, debug_flag):
+        self._set_trade_object(route_reuse, trade_choice, route_btn, mp_threads, debug_flag)
         star_counter = 0
         sector: SectorDictionary
 

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -272,11 +272,12 @@ class DeltaReduce:
         q = None
 
         try:
-            galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-            galaxy.read_sectors(sectors, args.pop_code, args.ru_calc)
+            galaxy = DeltaGalaxy(args.btn, args.max_jump)
+            galaxy.read_sectors(sectors, args.pop_code, args.ru_calc,
+                                args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
             galaxy.output_path = args.output
 
-            galaxy.generate_routes(args.routes, args.route_reuse)
+            galaxy.generate_routes()
 
             galaxy.set_borders(args.borders, args.ally_match)
 

--- a/PyRoute/Pathfinding/ApproximateShortestPathTreeZeroCaching.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathTreeZeroCaching.py
@@ -1,0 +1,21 @@
+"""
+Created on Sep 21, 2023
+
+@author: CyberiaResurrection
+"""
+import functools
+
+from PyRoute.Pathfinding.ApproximateShortestPathTree import ApproximateShortestPathTree
+
+
+class ApproximateShortestPathTreeZeroCaching(ApproximateShortestPathTree):
+
+    def __init__(self, source, graph, epsilon, sources=None):
+        super(ApproximateShortestPathTreeZeroCaching, self).__init__(source, graph, 0, sources)
+
+    @functools.cache
+    def lower_bound(self, source, target):
+        return super(ApproximateShortestPathTreeZeroCaching, self).lower_bound(source, target)
+
+    def update_edges(self, edges):
+        raise UnboundLocalError("Pointless when caching")

--- a/PyRoute/Pathfinding/astar.py
+++ b/PyRoute/Pathfinding/astar.py
@@ -382,25 +382,29 @@ def astar_path_indexes(G, source, target, heuristic=None, weight="weight"):
                 num_neighbours = len(neighbours)
 
         diagnostics['neighbours_checked'] += num_neighbours
+        diagnostics['heuristic_calls'] += num_neighbours
+        diagnostics['nodes_queued'] += num_neighbours
         for neighbor, ncost in neighbours:
             if neighbor in enqueued:
+                diagnostics['heuristic_calls'] -= 1
                 qcost, h = enqueued[neighbor]
                 # if qcost <= ncost, a less costly path from the
                 # neighbor to the source was already determined.
                 # Therefore, we won't attempt to push this neighbor
                 # to the queue
                 if qcost <= ncost:
+                    diagnostics['nodes_queued'] -= 1
                     continue
                 # if qcost > ncost, we've found a less-costly
                 # path from neighbour to the source, so we'll update it when we re-queue the neighbour
             else:
-                diagnostics['heuristic_calls'] += 1
                 h = heuristic(neighbor, target)
 
             # if ncost + h would bust the current _upper_ bound, there's no point continuing with the neighbour,
             # let alone queueing it
             # If neighbour is the target, h should be zero
             if ncost + h > upbound:
+                diagnostics['nodes_queued'] -= 1
                 continue
 
             # if this completes a path (no matter how _bad_), update the upper bound.
@@ -415,7 +419,6 @@ def astar_path_indexes(G, source, target, heuristic=None, weight="weight"):
                     queue = [item for item in queue if not (item[1] in enqueued and item[2] > enqueued[item[1]][0])]
                     heapify(queue)
 
-            diagnostics['nodes_queued'] += 1
             enqueued[neighbor] = ncost, h
             push(queue, (ncost + h, neighbor, ncost, curnode))
 

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -63,6 +63,7 @@ class Hex(object):
     def _hex_core(dx, dy, dz):
         return max(abs(dx), abs(dy), abs(dz))
 
+    @functools.cache
     def hex_position(self):
         return (self.q, self.r)
 

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -43,6 +43,11 @@ class Hex(object):
     def axial_distance(Hex1, Hex2):
         dq = Hex1[0] - Hex2[0]
         dr = Hex1[1] - Hex2[1]
+        return Hex._axial_core(dq, dr)
+
+    @staticmethod
+    @functools.cache
+    def _axial_core(dq, dr):
         return (abs(dq) + abs(dr) + abs(dq + dr)) // 2
 
     # Used to calculate distances for the TradeCalculation via the Network Graph, which requires a function

--- a/PyRoute/StatCalculation.py
+++ b/PyRoute/StatCalculation.py
@@ -28,14 +28,14 @@ class Populations(object):
         return self.population < other.population
 
 class ObjectStatistics(object):
-    base_mapping = {'C':'Corsair base', 'D':'Naval depot', 'E': 'Embassy', 'K': 'Naval base', 'M': 'Military base',
+    base_mapping = {'C': 'Corsair base', 'D': 'Naval depot', 'E': 'Embassy', 'K': 'Naval base', 'M': 'Military base',
                     'N': 'Naval base', 'O': 'Naval outpost',
-                    'R': 'Clan base', 'S': 'Scout base', 'T':'Tlaukhu base', 'V': 'Scout base', 'W': 'Way station',
+                    'R': 'Clan base', 'S': 'Scout base', 'T': 'Tlaukhu base', 'V': 'Scout base', 'W': 'Way station',
                     '*': 'Unknown', 'I': 'Unknown',
                     'G': 'Vargr Naval base',  'J': 'Naval base',
                     'L': 'Hiver naval base', 'P': 'Droyne Naval base', 'Q': 'Droyne military garrison',
                     'X': 'Zhodani relay station', 'Y': 'Zhodani depot',
-                    'A': 'Split', 'B': 'Split', 'F': 'Split','H': 'Split', 'U': 'Split', 'Z': 'Split' }
+                    'A': 'Split', 'B': 'Split', 'F': 'Split', 'H': 'Split', 'U': 'Split', 'Z': 'Split'}
 
     def __init__(self):
         self.population = 0

--- a/PyRoute/TradeBalance.py
+++ b/PyRoute/TradeBalance.py
@@ -98,7 +98,7 @@ class TradeBalance(dict):
 
         assert 2 > self.maximum, "Uncompensated " + str(self.target) + " imbalance present"
 
-        assert self.sum <= ceil(num_sector / 2), "Uncompensated multilateral " + str(self.target) + " imbalance present"
+        assert self.sum <= ceil(num_sector / 2), f"Uncompensated multilateral {self.target} imbalance present in {self.field}"
 
     @property
     def maximum(self):

--- a/PyRoute/WikiUploadPDF.py
+++ b/PyRoute/WikiUploadPDF.py
@@ -30,7 +30,7 @@ def uploadSummaryText(site, summaryFile, era, area_name):
         lines = f.readlines()
 
     name = 'initial table'
-    stats_text = {name:[]}
+    stats_text = {name: []}
 
     for line in lines:
         if "statistics ==" in line:

--- a/PyRoute/route.py
+++ b/PyRoute/route.py
@@ -28,13 +28,14 @@ def process():
                        help='Allegiance matching for borders, default [collapse]')
 
     route = parser.add_argument_group('Routes', 'Route generation options')
-    route.add_argument('--routes', dest='routes', choices=['trade', 'comm', 'xroute', 'owned', 'none'], default='trade',
+    route.add_argument('--routes', dest='routes',
+                       choices=['trade', 'comm', 'xroute', 'owned', 'none', 'trade-mp'], default='trade',
                        help='Route type to be generated, default [trade]')
     route.add_argument('--min-btn', dest='btn', default=13, type=int,
                        help='Minimum BTN used for route calculation, default [13]')
     route.add_argument('--min-route-btn', dest='route_btn', default=8, type=int,
                        help='Minimum btn for drawing on the map, default [8]')
-    route.add_argument('--max-jump', dest='max_jump', default=4, type=int,
+    route.add_argument('--max-jump', dest='max_jump', default=4, type=int, choices=range(1,11),
                        help='Maximum jump distance for trade routes, default [4]')
     route.add_argument('--pop-code', choices=['fixed', 'scaled', 'benford'], default='scaled',
                        help='Interpretation of the population modifier code, default [scaled]')
@@ -44,18 +45,20 @@ def process():
                        help='RU calculation, default [scaled]')
     route.add_argument('--speculative-version', choices=['CT', 'T5', 'None'], default='CT',
                        help='version of the speculative trade calculations, default [CT]')
+    route.add_argument('--mp-threads', default=os.cpu_count()-1, type=int,
+                       help=f"Number of processes to use for trade-mp processing, default {os.cpu_count()-1}")
 
     output = parser.add_argument_group('Output', 'Output options')
 
     output.add_argument('--output', default='maps', help='output directory for maps, statistics')
-    output.add_argument('--owned-worlds', dest='owned', default=False, action='store_true',
+    output.add_argument('--owned-worlds', dest='owned', default=False, action=argparse.BooleanOptionalAction,
                         help='Generate the owned worlds report, used for review purposes')
-    output.add_argument('--no-trade', dest='trade', default=True, action='store_false',
-                        help='Do not generate any trade data, only the default statistical data')
-    output.add_argument('--no-maps', dest='maps', default=True, action='store_false',
-                        help='Do not generate sector level trade maps')
-    output.add_argument('--no-subsector-maps', dest='subsectors', default=True, action='store_false',
-                        help='Do not generate subsector level maps')
+    output.add_argument('--trade', default=True, action=argparse.BooleanOptionalAction,
+                        help='Generate trade data with route information')
+    output.add_argument('--maps', dest='maps', default=True, action=argparse.BooleanOptionalAction,
+                        help='Generate sector level trade maps')
+    output.add_argument('--subsector-maps', dest='subsectors', default=True, action=argparse.BooleanOptionalAction,
+                        help='Generate subsector level maps')
     output.add_argument('--min-ally-count', dest='ally_count', default=10, type=int,
                         help='Minimum number of worlds in an allegiance for output, default [10]')
     output.add_argument('--json-data', dest='json_data', default=False, action='store_true',
@@ -67,10 +70,10 @@ def process():
     source.add_argument('sector', nargs='*', help='T5SS sector file(s) to process')
 
     debugging = parser.add_argument_group('Debug', "Debugging flags")
-    debugging.add_argument('--debug', dest="debug_flag", default=False, action='store_true',
+    debugging.add_argument('--debug', dest="debug_flag", default=False,  action=argparse.BooleanOptionalAction,
                            help="Turn on trade-route debugging")
 
-    parser.add_argument('--version', action='version', version='%(prog)s 0.3')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.4')
     parser.add_argument('--log-level', default='INFO')
 
     args = parser.parse_args()
@@ -79,7 +82,8 @@ def process():
 
     logger.info("starting processing")
 
-    galaxy = Galaxy(args.btn, args.max_jump, args.route_btn, args.debug_flag, trade_choice=args.routes, reuse=args.route_reuse)
+    galaxy = Galaxy(args.btn, args.max_jump)
+
     galaxy.output_path = args.output
 
     raw_sectors_list = args.sector
@@ -93,11 +97,12 @@ def process():
         else:
             logger.warning(sector + " is duplicated")
 
-    galaxy.read_sectors(sectors_list, args.pop_code, args.ru_calc)
+    galaxy.read_sectors(sectors_list, args.pop_code, args.ru_calc,
+                        args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
 
     logger.info("%s sectors read" % len(galaxy.sectors))
 
-    galaxy.generate_routes(args.routes, args.route_reuse)
+    galaxy.generate_routes()
 
     galaxy.set_borders(args.borders, args.ally_match)
 

--- a/PyRoute/route.py
+++ b/PyRoute/route.py
@@ -35,7 +35,7 @@ def process():
                        help='Minimum BTN used for route calculation, default [13]')
     route.add_argument('--min-route-btn', dest='route_btn', default=8, type=int,
                        help='Minimum btn for drawing on the map, default [8]')
-    route.add_argument('--max-jump', dest='max_jump', default=4, type=int, choices=range(1,11),
+    route.add_argument('--max-jump', dest='max_jump', default=4, type=int, choices=range(1, 11),
                        help='Maximum jump distance for trade routes, default [4]')
     route.add_argument('--pop-code', choices=['fixed', 'scaled', 'benford'], default='scaled',
                        help='Interpretation of the population modifier code, default [scaled]')

--- a/Tests/Outputs/testHexMap.py
+++ b/Tests/Outputs/testHexMap.py
@@ -13,8 +13,8 @@ from Tests.baseTest import baseTest
 
 
 class testHexMap(baseTest):
-    timestamp_regex = b'(\d{14,})'
-    md5_regex = b'([0-9a-f]{32,})'
+    timestamp_regex = rb'(\d{14,})'
+    md5_regex = rb'([0-9a-f]{32,})'
     timeline = re.compile(timestamp_regex)
     md5line = re.compile(md5_regex)
 
@@ -31,8 +31,9 @@ class testHexMap(baseTest):
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta[sector.name] = sector
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
         secname = 'Zao Kfeng Ig Grilokh'
@@ -73,8 +74,10 @@ class testHexMap(baseTest):
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta[sector.name] = sector
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
+
         galaxy.output_path = args.output
 
         secname = 'Zao Kfeng Ig Grilokh'
@@ -113,16 +116,18 @@ class testHexMap(baseTest):
         args.interestingtype = None
         args.maps = True
         args.subsectors = True
+        args.routes = 'trade'
 
         delta = DeltaDictionary()
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta[sector.name] = sector
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes('trade', 10)
+        galaxy.generate_routes()
 
         with open(starsfile, 'rb') as file:
             galaxy.stars = nx.read_edgelist(file, nodetype=int)
@@ -177,12 +182,12 @@ class testHexMap(baseTest):
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta[sector.name] = sector
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.trade = None
-        galaxy.generate_routes('comm', 10)
+        galaxy.generate_routes()
 
         with open(starsfile, 'rb') as file:
             galaxy.stars = nx.read_edgelist(file, nodetype=int)

--- a/Tests/Pathfinding/testApproximateShortestPathTree.py
+++ b/Tests/Pathfinding/testApproximateShortestPathTree.py
@@ -28,11 +28,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -58,11 +59,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -87,11 +89,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -115,11 +118,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -154,11 +158,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -191,11 +196,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -243,11 +249,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -300,11 +307,12 @@ class testApproximateShortestPathTree(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         graph = galaxy.stars
@@ -343,6 +351,8 @@ class testApproximateShortestPathTree(baseTest):
         args.ally_count = 10
         args.json_data = False
         args.output = tempfile.gettempdir()
+        args.debugflag = False
+        args.mp_threads = 1
         return args
 
 if __name__ == '__main__':

--- a/Tests/Pathfinding/testApproximateShortestPathTreeRegressions.py
+++ b/Tests/Pathfinding/testApproximateShortestPathTreeRegressions.py
@@ -19,11 +19,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         btn = [(s, n, d) for (s, n, d) in galaxy.ranges.edges(data=True) if s.component == n.component]
@@ -48,11 +49,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         btn = [(s, n, d) for (s, n, d) in galaxy.ranges.edges(data=True) if s.component == n.component]
@@ -77,11 +79,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         btn = [(s, n, d) for (s, n, d) in galaxy.ranges.edges(data=True) if s.component == n.component]
@@ -106,11 +109,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         btn = [(s, n, d) for (s, n, d) in galaxy.ranges.edges(data=True) if s.component == n.component]
@@ -137,11 +141,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'comm'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.is_well_formed()
         galaxy.trade.calculate_routes()
 
@@ -158,11 +163,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'comm'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.is_well_formed()
         galaxy.trade.calculate_routes()
 
@@ -179,11 +185,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'xroute'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.is_well_formed()
         galaxy.trade.calculate_routes()
 
@@ -200,11 +207,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'xroute'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.is_well_formed()
         galaxy.trade.calculate_routes()
 
@@ -221,11 +229,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'xroute'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.is_well_formed()
         galaxy.trade.calculate_routes()
 
@@ -242,11 +251,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'owned'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         btn = [(s, n, d) for (s, n, d) in galaxy.ranges.edges(data=True) if s.component == n.component]
@@ -273,11 +283,12 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.max_jump = 4
         args.routes = 'none'
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         btn = [(s, n, d) for (s, n, d) in galaxy.ranges.edges(data=True) if s.component == n.component]
@@ -313,6 +324,8 @@ class testApproximateShortestPathTreeRegressions(baseTest):
         args.ally_count = 10
         args.json_data = False
         args.output = tempfile.gettempdir()
+        args.debug_flag = False
+        args.mp_threads = 1
         return args
 
 

--- a/Tests/Pathfinding/testAstarIndexes.py
+++ b/Tests/Pathfinding/testAstarIndexes.py
@@ -3,11 +3,11 @@ Created on Sep 21, 2023
 
 @author: CyberiaResurrection
 """
-from ApproximateShortestPathTree import ApproximateShortestPathTree
-from DeltaDictionary import SectorDictionary, DeltaDictionary
-from DeltaGalaxy import DeltaGalaxy
+from PyRoute.Pathfinding.ApproximateShortestPathTree import ApproximateShortestPathTree
+from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
+from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from Tests.baseTest import baseTest
-from astar import astar_path_indexes
+from PyRoute.Pathfinding.astar import astar_path_indexes
 
 
 class testAStarIndexes(baseTest):

--- a/Tests/Pathfinding/testAstarIndexes.py
+++ b/Tests/Pathfinding/testAstarIndexes.py
@@ -1,0 +1,48 @@
+"""
+Created on Sep 21, 2023
+
+@author: CyberiaResurrection
+"""
+from ApproximateShortestPathTree import ApproximateShortestPathTree
+from DeltaDictionary import SectorDictionary, DeltaDictionary
+from DeltaGalaxy import DeltaGalaxy
+from Tests.baseTest import baseTest
+from astar import astar_path_indexes
+
+
+class testAStarIndexes(baseTest):
+
+    def testAStarOverSubsector(self):
+        sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
+
+        sector = SectorDictionary.load_traveller_map_file(sourcefile)
+        delta = DeltaDictionary()
+        delta[sector.name] = sector
+
+        args = self._make_args()
+
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
+        galaxy.output_path = args.output
+
+        galaxy.generate_routes()
+        galaxy.trade.calculate_components()
+
+        source = galaxy.star_mapping[0]
+        target = galaxy.star_mapping[36]
+
+        galaxy.trade.shortest_path_tree = ApproximateShortestPathTree(source.index, galaxy.stars, 0)
+
+        heuristic = galaxy.heuristic_distance_indexes
+
+        exp_route = [0, 8, 9, 15, 24, 36]
+        exp_diag = dict()
+        exp_diag['heuristic_calls'] = 27
+        exp_diag['neighbours_checked'] = 31
+        exp_diag['nodes_expanded'] = 25
+        exp_diag['nodes_queued'] = 31
+
+        act_route, act_diag = astar_path_indexes(galaxy.stars, source.index, target.index, heuristic)
+        self.assertEqual(exp_route, act_route)
+        self.assertEqual(exp_diag, act_diag)

--- a/Tests/Pathfinding/testTradeCalculationLandmarks.py
+++ b/Tests/Pathfinding/testTradeCalculationLandmarks.py
@@ -18,11 +18,12 @@ class testTradeCalculationLandmarks(baseTest):
 
         args = self._make_args()
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         self.assertEqual(1, len(galaxy.trade.components), "Unexpected number of components at J-4")
@@ -42,11 +43,12 @@ class testTradeCalculationLandmarks(baseTest):
         args = self._make_args()
         args.max_jump = 1
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         self.assertEqual(6, len(galaxy.trade.components), "Unexpected number of components at J-1")
@@ -81,6 +83,8 @@ class testTradeCalculationLandmarks(baseTest):
         args.ally_count = 10
         args.json_data = False
         args.output = tempfile.gettempdir()
+        args.debug_flag = False
+        args.mp_threads = 1
         return args
 
 if __name__ == '__main__':

--- a/Tests/baseTest.py
+++ b/Tests/baseTest.py
@@ -37,6 +37,8 @@ class baseTest(unittest.TestCase):
         args.ally_count = 10
         args.json_data = False
         args.output = tempfile.gettempdir()
+        args.mp_threads = 1
+        args.debug_flag = False
         return args
 
     def _make_args_no_line(self):

--- a/Tests/testAllyGenBorders.py
+++ b/Tests/testAllyGenBorders.py
@@ -6,7 +6,6 @@ import unittest
 from collections import defaultdict
 
 import pytest
-
 from PyRoute.AllyGen import AllyGen
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
@@ -26,11 +25,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -54,11 +54,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -82,11 +83,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -110,11 +112,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -138,11 +141,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -166,11 +170,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -194,11 +199,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -223,11 +229,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -253,11 +260,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -283,11 +291,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -313,11 +322,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -344,11 +354,12 @@ class testAllyGenBorders(baseTest):
         args = self._make_args()
         args.max_jump = 4
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         expected_allies, expected_borders = self.load_expected_values(allymap, borderfile)
@@ -417,6 +428,8 @@ class testAllyGenBorders(baseTest):
         args.ally_count = 10
         args.json_data = False
         args.output = tempfile.gettempdir()
+        args.debug_flag = False
+        args.mp_threads = 1
         return args
 
 

--- a/Tests/testDeltaGalaxy.py
+++ b/Tests/testDeltaGalaxy.py
@@ -13,10 +13,11 @@ class testDeltaGalaxy(baseTest):
         delta = DeltaDictionary()
         delta[sector.name] = sector
 
-        galaxy = DeltaGalaxy(15, 4, 8)
+        galaxy = DeltaGalaxy(15, 4)
 
         with self.assertRaises(Exception) as context:
-            galaxy.read_sectors(delta, 'scaled', 'scaled')
+            galaxy.read_sectors(delta, 'scaled', 'scaled',
+                                10, 'trade', 8, 1, False)
 
         self.assertTrue('duplicated in sector Dagudashaag' in str(context.exception))
 

--- a/Tests/testDeltaReduce.py
+++ b/Tests/testDeltaReduce.py
@@ -228,6 +228,7 @@ class testDeltaReduce(baseTest):
         args.maps = False
         args.subsectors = False
         args.debugflag = False
+        args.mp_threads = 1
         args.run_sector = True
         args.run_subsector = True
         args.run_line = False
@@ -247,11 +248,13 @@ class testDeltaReduce(baseTest):
         self.assertEqual('# -2,0', gushsector.position, "Unexpected position value for Gushemege")
         delta[gushsector.name] = gushsector
 
-        galaxy = DeltaGalaxy(args.btn, args.max_jump, args.route_btn)
-        galaxy.read_sectors(delta, args.pop_code, args.ru_calc)
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debugflag)
+
         galaxy.output_path = args.output
 
-        galaxy.generate_routes(args.routes, args.route_reuse)
+        galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
         stars = list(galaxy.stars.nodes)
@@ -364,6 +367,8 @@ class testDeltaReduce(baseTest):
         args.ally_count = 10
         args.json_data = False
         args.output = tempfile.gettempdir()
+        args.mp_threads = 1
+        args.debug_flag = False
         return args
 
     def _make_args_no_line(self):

--- a/Tests/testTradeCalculation.py
+++ b/Tests/testTradeCalculation.py
@@ -103,7 +103,7 @@ class testTradeCalculation(unittest.TestCase):
         tradecalc.sector_passenger_balance[(core.name, gush.name)] = 1
         tradecalc.sector_passenger_balance[(dagu.name, gush.name)] = 1
 
-        expected = "Uncompensated multilateral passenger imbalance present"
+        expected = "Uncompensated multilateral passenger imbalance present in sectors"
         actual = None
 
         try:
@@ -132,7 +132,7 @@ class testTradeCalculation(unittest.TestCase):
         tradecalc.sector_trade_balance[(core.name, gush.name)] = 1
         tradecalc.sector_trade_balance[(dagu.name, gush.name)] = 1
 
-        expected = "Uncompensated multilateral trade imbalance present"
+        expected = "Uncompensated multilateral trade imbalance present in sectors"
         actual = None
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E", "F", "TID252"]
+select = ["E", "F", "TID252", "E231"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E", "F"]
+select = ["E", "F", "TID252"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
This PR adds in a multiprocessing-powered variant of trade calculation that can cut at least 50% off overall running times on bigger setups (implist, full-orchestra).

As with any performance tuning step, it makes a tradeoff - taking more RAM and cpu time (running in parallel) to reduce overall wallclock time.