### PR TITLE
Fix delta debugging

### DIFF
--- a/PyRoute/DeltaDebug/DeltaDebug.py
+++ b/PyRoute/DeltaDebug/DeltaDebug.py
@@ -108,7 +108,7 @@ def process():
     if not (args.two_min or args.run_sector or args.run_subsector or args.run_line):
         raise ValueError("Must select at least one reduction pass to run")
 
-    galaxy = Galaxy(args.btn, args.max_jump, args.route_btn, args.debug_flag, trade_choice=args.routes, reuse=args.route_reuse)
+    galaxy = Galaxy(args.btn, args.max_jump)
     galaxy.output_path = args.output
 
     sectors_list = args.sector

--- a/Tests/baseTest.py
+++ b/Tests/baseTest.py
@@ -17,6 +17,16 @@ class baseTest(unittest.TestCase):
 
         return sourcefile
 
+    def unpack_workdir(self, dirname):
+        # try unpacked directory directly
+        workdir = os.path.abspath(dirname)
+
+        cwd = os.getcwd()
+        if not os.path.isdir(workdir):
+            workdir = os.path.abspath(cwd + dirname)
+
+        return workdir
+
     def _make_args(self):
         args = argparse.ArgumentParser(description='PyRoute input minimiser.')
         args.btn = 8

--- a/Tests/testDeltaDebug.py
+++ b/Tests/testDeltaDebug.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+import unittest
+from Tests.baseTest import baseTest
+
+
+class testDeltaDebug(baseTest):
+    def test_delta_debug_command_empty_args(self):
+        fullpath = self.unpack_filename('../PyRoute/DeltaDebug/DeltaDebug.py')
+
+        args = [
+            sys.executable,
+            fullpath
+        ]
+
+        foo = subprocess.run(args=args, capture_output=True, text=True)
+
+        self.assertEqual(0, foo.returncode, "DeltaDebug did not complete successfully")
+        expected = '0 sectors read\nReducing by sector\nReducing by subsector\nReducing by line\n'
+        actual = foo.stderr
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/testDeltaDebug.py
+++ b/Tests/testDeltaDebug.py
@@ -16,9 +16,6 @@ class testDeltaDebug(baseTest):
         foo = runner.run(command=fullpath)
 
         self.assertEqual(0, foo.returncode, "DeltaDebug did not complete successfully: " + foo.stderr)
-        expected = '0 sectors read\nReducing by sector\nReducing by subsector\nReducing by line\n'
-        actual = foo.stderr
-        self.assertEqual(expected, actual)
 
 
 if __name__ == '__main__':

--- a/Tests/testDeltaDebug.py
+++ b/Tests/testDeltaDebug.py
@@ -1,21 +1,21 @@
-import subprocess
-import sys
+import os
 import unittest
+
 from Tests.baseTest import baseTest
+from pytest_console_scripts import ScriptRunner
 
 
 class testDeltaDebug(baseTest):
+
     def test_delta_debug_command_empty_args(self):
         fullpath = self.unpack_filename('../PyRoute/DeltaDebug/DeltaDebug.py')
 
-        args = [
-            sys.executable,
-            fullpath
-        ]
+        cwd = os.getcwd()
+        runner = ScriptRunner(launch_mode="inprocess", rootdir=cwd)
 
-        foo = subprocess.run(args=args, capture_output=True, text=True)
+        foo = runner.run(command=fullpath)
 
-        self.assertEqual(0, foo.returncode, "DeltaDebug did not complete successfully")
+        self.assertEqual(0, foo.returncode, "DeltaDebug did not complete successfully: " + foo.stderr)
         expected = '0 sectors read\nReducing by sector\nReducing by subsector\nReducing by line\n'
         actual = foo.stderr
         self.assertEqual(expected, actual)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ jinja2
 jsonpickle
 numpy
 pytest
-pytest-subtests
+pytest-console-scripts
 pytest-randomly
+pytest-subtests


### PR DESCRIPTION
Update the Galaxy construction in delta debugging to match the new API.
Add pytest-console-scripts as requirement to enable scripts (such as DeltaDebug itself) to be run inside tests.
Add empty-list delta debugging test to keep an eye on the delta debugging setup and close test-coverage hole that let it break silently in the first place.