### PR TITLE
Add hypothesis tests to Hex

### DIFF
--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -93,6 +93,14 @@ class Hex(object):
         return q, r
 
     @staticmethod
+    def axial_to_hex(q, r):
+        row = q
+        q_offset = (q + (q & 1)) // 2
+        col = r + q_offset
+
+        return row, col
+
+    @staticmethod
     def dy_offset(row: int, sector_y: int) -> int:
         offset = 41 - row - 1
         return sector_y * 40 + offset

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -113,6 +113,14 @@ class Hex(object):
         offset = 41 - row - 1
         return sector_y * 40 + offset
 
+    @staticmethod
+    def dy_reverse(dy_offset: int):
+        sector_y = dy_offset // 40
+        offset = dy_offset % 40
+
+        row = 40 - offset
+        return row, sector_y
+
     @property
     def x(self):
         return self.q

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -27,10 +27,7 @@ class Hex(object):
         self.row = int(self.position[2:4])
         self.dx = sector.x * 32 + self.col - 1
         self.dy = sector.y * 40 + self.row - 1
-        dy_offset = 41 - int(self.position[2:4]) - 1
-        adjusted_dy = sector.y * 40 + dy_offset
-
-        self.q, self.r = Hex.hex_to_axial(self.dx, adjusted_dy)
+        self.q, self.r = Hex.hex_to_axial(self.dx, Hex.dy_offset(self.row, sector.y))
 
     def distance(self, other):
         return Hex.axial_distance((self.q, self.r), (other.q, other.r))

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -104,9 +104,10 @@ class Hex(object):
     def axial_to_sector(q, r):
         (raw_row, raw_col) = Hex.axial_to_hex(q, r)
 
-        row = Hex.dy_offset(raw_row, 0)
+        col, sector_y = Hex.dy_reverse(raw_col)
+        row = (raw_row % 32) + 1
 
-        return row, raw_col
+        return row, col
 
     @staticmethod
     def dy_offset(row: int, sector_y: int) -> int:

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -95,6 +95,11 @@ class Hex(object):
         r = col - q_offset
         return q, r
 
+    @staticmethod
+    def dy_offset(row: int, sector_y: int) -> int:
+        offset = 41 - row - 1
+        return sector_y * 40 + offset
+
     @property
     def x(self):
         return self.q

--- a/PyRoute/Position/Hex.py
+++ b/PyRoute/Position/Hex.py
@@ -101,6 +101,14 @@ class Hex(object):
         return row, col
 
     @staticmethod
+    def axial_to_sector(q, r):
+        (raw_row, raw_col) = Hex.axial_to_hex(q, r)
+
+        row = Hex.dy_offset(raw_row, 0)
+
+        return row, raw_col
+
+    @staticmethod
     def dy_offset(row: int, sector_y: int) -> int:
         offset = 41 - row - 1
         return sector_y * 40 + offset

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -36,6 +36,15 @@ class testHexHypothesis(unittest.TestCase):
         self.assertEqual(y, col, 'Col co-ord not unpacked.  ' + hyp_line)
         self.assertEqual(x, row, 'Row co-ord not unpacked.  ' + hyp_line)
 
+    @given(integers(), integers(min_value=1, max_value=40))
+    @example(0, 1)
+    def test_dy_offset_and_reverse(self, sector_y, row):
+        hyp_line = "Hypothesis input: " + str(sector_y) + ", " + str(row)
+        dy_offset = Hex.dy_offset(row, sector_y)
+        nu_row, nu_sector_y = Hex.dy_reverse(dy_offset)
+
+        self.assertEqual(row, nu_row, "Row not round-tripped.  " + hyp_line)
+        self.assertEqual(sector_y, nu_sector_y, "Sector_y not round-tripped.  " + hyp_line)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -1,0 +1,27 @@
+import unittest
+
+from hypothesis import given, assume, example, HealthCheck, settings
+from hypothesis.strategies import text, integers
+
+from PyRoute.Position.Hex import Hex
+
+
+class testHexHypothesis(unittest.TestCase):
+
+    @given(integers(), integers())
+    @example(1, 0)
+    def test_axial_to_hex_and_hex_to_axial_round_trip(self, row, col):
+        hyp_line = "Hypothesis input: " + str(row) + ", " + str(col)
+        (q, r) = Hex.hex_to_axial(row, col)
+
+        (nu_row, nu_col) = Hex.axial_to_hex(q, r)
+        self.assertEqual(row, nu_row, "Row co-ord did not round-trip.  " + hyp_line)
+        self.assertEqual(col, nu_col, "Col co-ord did not round trip.  " + hyp_line)
+
+        (nu_q, nu_r) = Hex.hex_to_axial(nu_row, nu_col)
+        self.assertEqual(q, nu_q, "Q co-ord did not round-trip.  " + hyp_line)
+        self.assertEqual(r, nu_r, "R co-ord did not round-trip.  " + hyp_line)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -9,6 +9,9 @@ from PyRoute.Position.Hex import Hex
 
 class testHexHypothesis(unittest.TestCase):
 
+    """
+    Given a hex co-ord pair, verify it converts cleanly to axial co-ordinates, and then back to the original hex co-ords
+    """
     @given(integers(), integers())
     @example(1, 0)
     def test_axial_to_hex_and_hex_to_axial_round_trip(self, row, col):
@@ -23,6 +26,10 @@ class testHexHypothesis(unittest.TestCase):
         self.assertEqual(q, nu_q, "Q co-ord did not round-trip.  " + hyp_line)
         self.assertEqual(r, nu_r, "R co-ord did not round-trip.  " + hyp_line)
 
+    """
+    Given a set of sector and within-sector co-ords, verify conversion to axial co-ords and that extracted sector
+    co-ords match the original values
+    """
     @given(integers(min_value=-10, max_value=10), integers(min_value=-10, max_value=10), integers(min_value=1, max_value=32), integers(min_value=1, max_value=40))
     @example(0, 0, 1, 1)
     @example(0, 0, 1, 40)

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -3,6 +3,7 @@ import unittest
 from hypothesis import given, assume, example, HealthCheck, settings
 from hypothesis.strategies import text, integers
 
+from PyRoute.Galaxy import Sector
 from PyRoute.Position.Hex import Hex
 
 
@@ -21,6 +22,19 @@ class testHexHypothesis(unittest.TestCase):
         (nu_q, nu_r) = Hex.hex_to_axial(nu_row, nu_col)
         self.assertEqual(q, nu_q, "Q co-ord did not round-trip.  " + hyp_line)
         self.assertEqual(r, nu_r, "R co-ord did not round-trip.  " + hyp_line)
+
+    @given(integers(min_value=-10, max_value=10), integers(min_value=-10, max_value=10), integers(min_value=1, max_value=32), integers(min_value=1, max_value=40))
+    @example(0, 0, 1, 1)
+    def test_axial_to_sector_co_ords(self, sec_x, sec_y, x, y):
+        hyp_line = "Hypothesis input: " + str(sec_x) + ", " + str(sec_y) + ', ' + str(x) + ', ' + str(y)
+        sec_co_ords = '# ' + str(sec_x) + ', ' + str(sec_y)
+        sector = Sector('# dummy', sec_co_ords)
+        hex_co_ords = str(x).rjust(2, '0') + str(y).rjust(2, '0')
+        hex = Hex(sector, hex_co_ords)
+
+        row, col = Hex.axial_to_sector(hex.q, hex.r)
+        self.assertEqual(y, col, 'Col co-ord not unpacked.  ' + hyp_line)
+        self.assertEqual(x, row, 'Row co-ord not unpacked.  ' + hyp_line)
 
 
 if __name__ == '__main__':

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -25,16 +25,24 @@ class testHexHypothesis(unittest.TestCase):
 
     @given(integers(min_value=-10, max_value=10), integers(min_value=-10, max_value=10), integers(min_value=1, max_value=32), integers(min_value=1, max_value=40))
     @example(0, 0, 1, 1)
+    @example(0, 0, 1, 40)
+    @example(0, 0, 32, 1)
+    @example(0, 0, 32, 40)
+    @example(0, 0, 16, 20)
+    @example(1, 0, 1, 1)
     def test_axial_to_sector_co_ords(self, sec_x, sec_y, x, y):
         hyp_line = "Hypothesis input: " + str(sec_x) + ", " + str(sec_y) + ', ' + str(x) + ', ' + str(y)
         sec_co_ords = '# ' + str(sec_x) + ', ' + str(sec_y)
         sector = Sector('# dummy', sec_co_ords)
         hex_co_ords = str(x).rjust(2, '0') + str(y).rjust(2, '0')
-        hex = Hex(sector, hex_co_ords)
+        cand_hex = Hex(sector, hex_co_ords)
 
-        row, col = Hex.axial_to_sector(hex.q, hex.r)
-        self.assertEqual(y, col, 'Col co-ord not unpacked.  ' + hyp_line)
-        self.assertEqual(x, row, 'Row co-ord not unpacked.  ' + hyp_line)
+        col, row = Hex.axial_to_sector(cand_hex.q, cand_hex.r)
+        self.assertEqual(x, col, 'Col co-ord not unpacked.  ' + hyp_line)
+        self.assertEqual(y, row, 'Row co-ord not unpacked.  ' + hyp_line)
+
+        nu_hex_co_ords = str(col).rjust(2, '0') + str(row).rjust(2, '0')
+        self.assertEqual(hex_co_ords, nu_hex_co_ords, "Position string did not round trip.  " + hyp_line)
 
     @given(integers(), integers(min_value=1, max_value=40))
     @example(0, 1)

--- a/Tests/Position/testHex.py
+++ b/Tests/Position/testHex.py
@@ -92,6 +92,26 @@ class testHex(unittest.TestCase):
         self.assertEqual(34, pos4.r)
         self.assertEqual(-31, pos4.q)
 
+    def testCoreSector(self):
+        pos = [
+            Hex(self.coreSector, "0101"),
+            Hex(self.coreSector, "0140"),
+            Hex(self.coreSector, "3201"),
+            Hex(self.coreSector, "3240"),
+            Hex(self.coreSector, "1620")
+        ]
+
+        self.assertEqual(pos[0].hex_position(), (0, 39))
+        self.assertEqual(pos[1].hex_position(), (0, 0))
+        self.assertEqual(pos[2].hex_position(), (31, 23))
+        self.assertEqual(pos[3].hex_position(), (31, -16))
+        self.assertEqual(pos[4].hex_position(), (15, 12))
+
+        for idx, (x, y) in enumerate([(1, 1), (1, 40), (32, 1), (32, 40), (16, 20)]):
+            offset = Hex.dy_offset(y, (self.coreSector.dy // 40))
+            q, r = Hex.hex_to_axial(x + self.coreSector.dx - 1, offset)
+            self.assertEqual(pos[idx].hex_position(), (q, r))
+
     def testSectorDistances(self):
         pos1 = Hex(self.coreSector, "0140")
         pos2 = Hex(self.coreSector, "0220")


### PR DESCRIPTION
Add axial_to_hex conversion (functional inverse of hex_to_axial);
Add axial_to_sector conversion (dumping out within-sector co-ords only);
Add hypothesis tests to verify both new conversions