### PR TITLE
Handle missing/wonky star sizes

### DIFF
--- a/PyRoute/SystemData/StarList.py
+++ b/PyRoute/SystemData/StarList.py
@@ -17,10 +17,12 @@ class StarList(object):
     stellar_line = '([OBAFGKM][0-9] ?(?:Ia|Ib|III|II|IV|VII|VI|V|D)|D|NS|PSR|BH|BD)'
     star_line = '^([OBAFGKM])([0-9]) ?(Ia|Ib|III|II|IV|VI|V)'
     mid_star_line = '([OBAFGKM])([0-9]) ?(Ia|Ib|III|II|IV|VI|V)'
+    two_stars_line = '([OBAFGKM][0-9]) ([OBAFGKM][0-9]) ?(Ia|Ib|III|II|IV|VI|V)'
 
     stellar_match = re.compile(stellar_line)
     star_match = re.compile(star_line)
     mid_star_match = re.compile(mid_star_line)
+    two_stars_match = re.compile(two_stars_line)
 
     # Limits
     max_stars = 8  # T5.10 book 3 p 21, "A system may to have up to eight stars:"
@@ -40,6 +42,17 @@ class StarList(object):
     }
 
     def __init__(self, stars_line, trim_stars=False):
+        # Count C as a typoed V, given their adjacency on QWERTY keyboards
+        stars_line = stars_line.replace(' IC', ' IV')
+        # Try to rumble missing star sizes
+        twostars = StarList.two_stars_match.findall(stars_line)
+        if twostars:
+            for item in twostars:
+                # If there's a missing star size, play the odds and assume V
+                original = item[0] + ' ' + item[1] + ' ' + item[2]
+                remix = item[0] + ' V ' + item[1] + ' ' + item[2]
+                stars_line = stars_line.replace(original, remix)
+
         self.stars_line = stars_line
         stars = StarList.stellar_match.findall(stars_line)
         if not stars:

--- a/PyRoute/SystemData/StarList.py
+++ b/PyRoute/SystemData/StarList.py
@@ -18,11 +18,13 @@ class StarList(object):
     star_line = '^([OBAFGKM])([0-9]) ?(Ia|Ib|III|II|IV|VI|V)'
     mid_star_line = '([OBAFGKM])([0-9]) ?(Ia|Ib|III|II|IV|VI|V)'
     two_stars_line = '([OBAFGKM][0-9]) ([OBAFGKM][0-9]) ?(Ia|Ib|III|II|IV|VI|V)'
+    end_star_line = '([OBAFGKM][0-9])[ ]{0,}$'
 
     stellar_match = re.compile(stellar_line)
     star_match = re.compile(star_line)
     mid_star_match = re.compile(mid_star_line)
     two_stars_match = re.compile(two_stars_line)
+    end_star_match = re.compile(end_star_line)
 
     # Limits
     max_stars = 8  # T5.10 book 3 p 21, "A system may to have up to eight stars:"
@@ -44,14 +46,20 @@ class StarList(object):
     def __init__(self, stars_line, trim_stars=False):
         # Count C as a typoed V, given their adjacency on QWERTY keyboards
         stars_line = stars_line.replace(' IC', ' IV')
-        # Try to rumble missing star sizes
-        twostars = StarList.two_stars_match.findall(stars_line)
-        if twostars:
-            for item in twostars:
-                # If there's a missing star size, play the odds and assume V
-                original = item[0] + ' ' + item[1] + ' ' + item[2]
-                remix = item[0] + ' V ' + item[1] + ' ' + item[2]
-                stars_line = stars_line.replace(original, remix)
+        old_line = None
+        # Try to rumble missing star sizes, and iteratively fill them in
+        while stars_line != old_line:
+            old_line = stars_line
+            twostars = StarList.two_stars_match.findall(stars_line)
+            if twostars:
+                for item in twostars:
+                    # If there's a missing star size, play the odds and assume V
+                    original = item[0] + ' ' + item[1] + ' ' + item[2]
+                    remix = item[0] + ' V ' + item[1] + ' ' + item[2]
+                    stars_line = stars_line.replace(original, remix)
+            endstar = StarList.end_star_match.findall(stars_line)
+            if endstar:
+                stars_line = stars_line.strip() + ' V'
 
         self.stars_line = stars_line
         stars = StarList.stellar_match.findall(stars_line)

--- a/PyRoute/SystemData/StarList.py
+++ b/PyRoute/SystemData/StarList.py
@@ -46,6 +46,7 @@ class StarList(object):
     def __init__(self, stars_line, trim_stars=False):
         # Count C as a typoed V, given their adjacency on QWERTY keyboards
         stars_line = stars_line.replace(' IC', ' IV')
+        stars_line = stars_line.replace(' C', ' V')
         old_line = None
         # Try to rumble missing star sizes, and iteratively fill them in
         while stars_line != old_line:

--- a/Tests/Hypothesis/testStarList.py
+++ b/Tests/Hypothesis/testStarList.py
@@ -294,6 +294,7 @@ class testStarList(unittest.TestCase):
             ('Wrenton 1901', 'G7 M4 V', 'G7 V M4 V'),
             ('Blaskon 2824', 'M5 IC', 'M5 IV'),
             ('Ricenden 0210', 'M2 M5 M8 V', 'M2 V M5 V M8 V'),
+            ('Tail End Charlie 1803', 'G2 II G3 V M9 ', 'G2 II G3 V M9 V')
         ]
 
         for msg, starline, expected in cases:

--- a/Tests/Hypothesis/testStarList.py
+++ b/Tests/Hypothesis/testStarList.py
@@ -292,7 +292,8 @@ class testStarList(unittest.TestCase):
     def test_handle_missing_and_wonky_star_sizes(self):
         cases = [
             ('Wrenton 1901', 'G7 M4 V', 'G7 V M4 V'),
-            ('Blaskon 2824', 'M5 IC', 'M5 IV')
+            ('Blaskon 2824', 'M5 IC', 'M5 IV'),
+            ('Ricenden 0210', 'M2 M5 M8 V', 'M2 V M5 V M8 V'),
         ]
 
         for msg, starline, expected in cases:

--- a/Tests/Hypothesis/testStarList.py
+++ b/Tests/Hypothesis/testStarList.py
@@ -294,7 +294,9 @@ class testStarList(unittest.TestCase):
             ('Wrenton 1901', 'G7 M4 V', 'G7 V M4 V'),
             ('Blaskon 2824', 'M5 IC', 'M5 IV'),
             ('Ricenden 0210', 'M2 M5 M8 V', 'M2 V M5 V M8 V'),
-            ('Tail End Charlie 1803', 'G2 II G3 V M9 ', 'G2 II G3 V M9 V')
+            ('Tail End Charlie 1803', 'G2 II G3 V M9 ', 'G2 II G3 V M9 V'),
+            ('Woop Woop 1824', 'M5 CI', 'M5 VI'),
+            ('Woop Woop 3240', 'M5 C', 'M5 V')
         ]
 
         for msg, starline, expected in cases:

--- a/Tests/Hypothesis/testStarList.py
+++ b/Tests/Hypothesis/testStarList.py
@@ -288,3 +288,17 @@ class testStarList(unittest.TestCase):
         else:
             self.assertIsNotNone(min_flux, "if max-flux is not None, so must be min-flux.  " + hyp_line)
             self.assertTrue(max_flux >= min_flux, "Min-flux cannot exceed max-flux.  " + hyp_line)
+
+    def test_handle_missing_and_wonky_star_sizes(self):
+        cases = [
+            ('Wrenton 1901', 'G7 M4 V', 'G7 V M4 V'),
+            ('Blaskon 2824', 'M5 IC', 'M5 IV')
+        ]
+
+        for msg, starline, expected in cases:
+            if expected is None:
+                continue
+            with self.subTest(msg):
+                starlist = StarList(starline)
+                str_rep = str(starlist)
+                self.assertEqual(expected, str_rep, "Unexpected parsing repair")


### PR DESCRIPTION
As at the status quo, missing/wonky star sizes ended up heaved out the window.

Two _specific_ cases (motivating this PR) I tripped over from the M1105 Travmap data (turned out they were the _only_ ones in the M1105 data as at Nov 2023) are:
```
Wrenton 1901: G7 M4 V
Blaskon 2828: M5 IC
```

After checking with @inexorabletash , he agreed (presuming the QWERTY keyboard layout) that IC is most likely a typoed form of IV.  For missing sizes, he agreed with my suggestion to play the odds and assume a star size of V.

The two motivating examples fall out after those changes as:
```
Wrenton 1901: G7 V M4 V
Blaskon 2828: M5 IV
```

These two _particular_ cases have been fixed in Travmap, but I want to harden PyRoute against similar, undetected, cases, such as in other milieux, and future fat-fingers.

As such, I've also handled:
- missing star size at _end_ of stars line beyond actual, living star: ```G2 II G3 V M9 ``` now unpacks as ```G2 II G3 V M9 V```
- multiple missing star sizes _before_ end of line, between actual, living stars: ```M2 M5 M8 V``` gets unpacked as ```M2 V M5 V M8 V```