### PR TITLE
Tighten starline regex's position sub-match

### DIFF
--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -13,7 +13,7 @@ from PyRoute.TradeCodes import TradeCodes
 
 class ParseStarInput:
     regex = """
-^(\d\d\d\d) +
+^([0-3]\d[0-4]\d) +
 (.{15,}) +
 (\w\w\w\w\w\w\w-\w|\?\?\?\?\?\?\?-\?) +
 (.{15,}) +


### PR DESCRIPTION
Previously, any four digits would match the position sub-match. This was done for simplicity's sake, and has worked brilliantly up until now.

With the rest of parsing getting belted, position has fallen behind a bit.  The highest valid column in a position is 32, and highest valid row is 40.  Thus, a tens column digit of 4+ is prima facie nonsensical, likewise a tens row digit of 5+.

Since we can catch those at the starline regex stage, do so.