### PR TITLE
Constrain UWP gov types

### DIFF
--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -12,6 +12,7 @@ import math
 from PyRoute.Position.Hex import Hex
 
 from PyRoute.AllyGen import AllyGen
+from PyRoute.Inputs.ParseStarInput import ParseStarInput
 from PyRoute.SystemData.Utilities import Utilities
 from collections import OrderedDict
 
@@ -472,18 +473,7 @@ class Star(object):
             "RU = {0} * {1} * {2} * {3} = {4}".format(resources, labor, infrastructure, efficiency, self.ru))
 
     def calculate_TCS(self):
-        tax_rate = {'0': 0.50, '1': 0.8, '2': 1.0, '3': 0.9, '4': 0.85,
-                    '5': 0.95, '6': 1.0, '7': 1.0, '8': 1.1, '9': 1.15,
-                    'A': 1.20, 'B': 1.1, 'C': 1.2, 'D': 0.75, 'E': 0.75,
-                    'F': 0.75,
-                    # Aslan Government codes
-                    'G': 1.0, 'H': 1.0, 'J': 1.2, 'K': 1.1, 'L': 1.0,
-                    'M': 1.1, 'N': 1.2,
-                    # Unknown Gov Codes
-                    'I': 1.0, 'P': 1.0, 'Q': 1.0, 'R': 1.0, 'S': 1.0, 'T': 1.0,
-                    '': 1.0, 'U': 1.0, 'V': 1.0, 'W': 1.0, 'X': 1.0, '?': 0.0
-                    }
-        self.ship_capacity = int(self.population * tax_rate[self.uwpCodes['Government']] * 1000)
+        self.ship_capacity = int(self.population * Utilities.tax_rate[self.uwpCodes['Government']] * 1000)
         gwp_base = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 28, 32]
         if self.tl >= 5:
             self.tcs_gwp = self.population * gwp_base[min(self.tl - 5, 13)] * 1000
@@ -503,7 +493,7 @@ class Star(object):
         if self.tradeCode.nonagricultural:
             self.tcs_gwp = self.tcs_gwp * 8 // 10
 
-        budget = int(self.tcs_gwp * 0.03 * tax_rate[self.uwpCodes['Government']])
+        budget = int(self.tcs_gwp * 0.03 * Utilities.tax_rate[self.uwpCodes['Government']])
 
         # if AllyGen.sameAligned('Im', self.alg):
         #    budget = budget * 0.3

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -12,7 +12,6 @@ import math
 from PyRoute.Position.Hex import Hex
 
 from PyRoute.AllyGen import AllyGen
-from PyRoute.Inputs.ParseStarInput import ParseStarInput
 from PyRoute.SystemData.Utilities import Utilities
 from collections import OrderedDict
 

--- a/PyRoute/SystemData/UWP.py
+++ b/PyRoute/SystemData/UWP.py
@@ -31,6 +31,8 @@ class UWP(object):
         if not matches:
             raise ValueError('Input UWP malformed')
         line = str(matches[0]).upper()
+        if line[5] not in Utilities.tax_rate:
+            raise ValueError('Input UWP malformed')
         self._port = line[0]
         self._size = line[1]
         self._atmo = line[2]

--- a/PyRoute/SystemData/Utilities.py
+++ b/PyRoute/SystemData/Utilities.py
@@ -9,6 +9,18 @@ Supporting utilities needed by various SystemData components
 
 class Utilities:
 
+    tax_rate = {'0': 0.50, '1': 0.8, '2': 1.0, '3': 0.9, '4': 0.85,
+                '5': 0.95, '6': 1.0, '7': 1.0, '8': 1.1, '9': 1.15,
+                'A': 1.20, 'B': 1.1, 'C': 1.2, 'D': 0.75, 'E': 0.75,
+                'F': 0.75,
+                # Aslan Government codes
+                'G': 1.0, 'H': 1.0, 'J': 1.2, 'K': 1.1, 'L': 1.0,
+                'M': 1.1, 'N': 1.2,
+                # Unknown Gov Codes
+                'I': 1.0, 'P': 1.0, 'Q': 1.0, 'R': 1.0, 'S': 1.0, 'T': 1.0,
+                '': 1.0, 'U': 1.0, 'V': 1.0, 'W': 1.0, 'X': 1.0, '?': 0.0
+                }
+
     @staticmethod
     def ehex_to_int(value):
         val = int(value, 36) if value in '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ' else 0

--- a/Tests/Hypothesis/testUWP.py
+++ b/Tests/Hypothesis/testUWP.py
@@ -24,8 +24,11 @@ class testUWP(unittest.TestCase):
     @example('?0000a0-0')
     @example('?00000a-0')
     @example('?000000-a')
+    @example('?0000Y0-0')
     def test_initial_parsing(self, uwp_line):
-        uwp = UWP(uwp_line)
+        uwp = self.parse_uwp(uwp_line)
+
+        assume(uwp is not None)
 
         result, msg = uwp.is_well_formed()
         hyp_input = 'Hypothesis input: ' + uwp_line
@@ -65,8 +68,11 @@ class testUWP(unittest.TestCase):
     @example('?0000G0-0', '?000050-4')
     @example('?000?F0-0', '?000?FA-4')
     @example('?000?Q0-0', '?000?FA-4')
+    @example('?0000y0-0', None)
     def test_check_canonicalisation_and_verify_canonicalisation(self, uwp_line, expected):
-        uwp = UWP(uwp_line)
+        uwp = self.parse_uwp(uwp_line)
+
+        assume(uwp is not None)
         old_rep = str(uwp)
         hyp_input = 'Hypothesis input: ' + uwp_line
 
@@ -93,6 +99,26 @@ class testUWP(unittest.TestCase):
         # finally, if an expected value was supplied, check it
         if expected is not None:
             self.assertEqual(expected, new_rep)
+
+    def parse_uwp(self, uwp_line):
+        allowed = [
+            'Input UWP malformed'
+        ]
+        uwp = None
+        try:
+            uwp = UWP(uwp_line)
+        except ValueError as e:
+            msg = str(e)
+            unexplained = True
+
+            for line in allowed:
+                if line in msg:
+                    unexplained = False
+                    break
+
+            if unexplained:
+                raise e
+        return uwp
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Government type is used in `Star.calculateTCS()` twice to determine both budget and ship capacity.

Status quo permits any character matching `[0-9A-Za-z\?]`, which can be on a collision course to a key error, when the putative government type is not referenced in the tax rate array (shifted to `Utilities` for ease of use and dodging circular imports).

The fix is rather simple - when building the UWP object, require its putative government code to be a key in the tax rate array.  Leaving the UWP regex as-is simplifies the case of adding a government type - just add it to the tax rate array and move on.