### PR TITLE
Canonicalise trade codes

### DIFF
--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -604,3 +604,9 @@ class TradeCodes(object):
             return False, msg
 
         return True, msg
+
+    def check_canonical(self):
+        return True, []
+
+    def canonicalise(self):
+        pass

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -285,22 +285,24 @@ class TradeCodes(object):
         atmo = '0123456789ABCDEF' if atmo is None else atmo
         hydro = '0123456789A' if hydro is None else hydro
         check = True
-        if star.size in size and star.atmo in atmo and star.hydro in hydro \
-                and code not in self.codeset:
+        star_match = star.size in size and star.atmo in atmo and star.hydro in hydro
+        code_match = code in self.codeset
+        if star_match and not code_match:
             self.logger.error('{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset))
             check = False
-        if code in self.codeset and \
-                not (star.size in size and star.atmo in atmo and star.hydro in hydro):
+        if code_match and not star_match:
             self.logger.error('{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset))
             check = False
         return check
 
     def _check_pop_code(self, star, code, pop):
         check = True
-        if star.pop in pop and code not in self.codeset:
+        star_match = star.pop in pop
+        code_match = code in self.codeset
+        if star_match and not code_match:
             self.logger.error('{} - Calculated "{}" not in trade codes {}'.format(star, code, self.codeset))
             check = False
-        if code in self.codeset and star.pop not in pop:
+        if code_match and not star_match:
             self.logger.error(
                 '{} - Found invalid "{}" code on world with {} population: {}'.format(star, code, star.pop,
                                                                                        self.codeset))
@@ -312,12 +314,12 @@ class TradeCodes(object):
         hydro = '0123456789A' if hydro is None else hydro
         pop = '0123456789ABCD' if pop is None else pop
         check = True
-        if star.atmo in atmo and star.hydro in hydro and star.pop in pop \
-                and code not in self.codeset:
+        star_match = star.atmo in atmo and star.hydro in hydro and star.pop in pop
+        code_match = code in self.codeset
+        if star_match and not code_match:
             self.logger.error('{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset))
             check = False
-        if code in self.codeset and \
-                not (star.atmo in atmo and star.hydro in hydro and star.pop in pop):
+        if code_match and not star_match:
             self.logger.error('{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset))
             check = False
         return check

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -289,9 +289,11 @@ class TradeCodes(object):
         if star_match == code_match:
             return True
         if star_match and not code_match:
-            self.logger.error('{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset))
+            msg = '{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset)
+            self.logger.error(msg)
         if code_match and not star_match:
-            self.logger.error('{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset))
+            msg = '{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset)
+            self.logger.error(msg)
         return False
 
     def _check_pop_code(self, star, code, pop):
@@ -300,11 +302,12 @@ class TradeCodes(object):
         if star_match == code_match:
             return True
         if star_match and not code_match:
-            self.logger.error('{} - Calculated "{}" not in trade codes {}'.format(star, code, self.codeset))
+            msg = '{} - Calculated "{}" not in trade codes {}'.format(star, code, self.codeset)
+            self.logger.error(msg)
         if code_match and not star_match:
-            self.logger.error(
-                '{} - Found invalid "{}" code on world with {} population: {}'.format(star, code, star.pop,
-                                                                                       self.codeset))
+            msg = '{} - Found invalid "{}" code on world with {} population: {}'.format(star, code, star.pop,
+                                                                                       self.codeset)
+            self.logger.error(msg)
         return False
 
     def _check_econ_code(self, star, code, atmo, hydro, pop):
@@ -316,9 +319,11 @@ class TradeCodes(object):
         if star_match == code_match:
             return True
         if star_match and not code_match:
-            self.logger.error('{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset))
+            msg = '{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset)
+            self.logger.error(msg)
         if code_match and not star_match:
-            self.logger.error('{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset))
+            msg = '{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset)
+            self.logger.error(msg)
         return False
 
     def check_world_codes(self, star):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -284,45 +284,42 @@ class TradeCodes(object):
         size = '0123456789ABC' if size is None else size
         atmo = '0123456789ABCDEF' if atmo is None else atmo
         hydro = '0123456789A' if hydro is None else hydro
-        check = True
         star_match = star.size in size and star.atmo in atmo and star.hydro in hydro
         code_match = code in self.codeset
+        if star_match == code_match:
+            return True
         if star_match and not code_match:
             self.logger.error('{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset))
-            check = False
         if code_match and not star_match:
             self.logger.error('{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset))
-            check = False
-        return check
+        return False
 
     def _check_pop_code(self, star, code, pop):
-        check = True
         star_match = star.pop in pop
         code_match = code in self.codeset
+        if star_match == code_match:
+            return True
         if star_match and not code_match:
             self.logger.error('{} - Calculated "{}" not in trade codes {}'.format(star, code, self.codeset))
-            check = False
         if code_match and not star_match:
             self.logger.error(
                 '{} - Found invalid "{}" code on world with {} population: {}'.format(star, code, star.pop,
                                                                                        self.codeset))
-            check = False
-        return check
+        return False
 
     def _check_econ_code(self, star, code, atmo, hydro, pop):
         atmo = '0123456789ABCDEF' if atmo is None else atmo
         hydro = '0123456789A' if hydro is None else hydro
         pop = '0123456789ABCD' if pop is None else pop
-        check = True
         star_match = star.atmo in atmo and star.hydro in hydro and star.pop in pop
         code_match = code in self.codeset
+        if star_match == code_match:
+            return True
         if star_match and not code_match:
             self.logger.error('{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset))
-            check = False
         if code_match and not star_match:
             self.logger.error('{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset))
-            check = False
-        return check
+        return False
 
     def check_world_codes(self, star):
         check = True

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -621,7 +621,7 @@ class TradeCodes(object):
 
     def check_canonical(self, star):
         msg = []
-        result = self.check_world_codes(star, msg)
+        self.check_world_codes(star, msg)
 
         return 0 == len(msg), msg
 

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -280,7 +280,7 @@ class TradeCodes(object):
     def calculate_pcode(self):
         return self.pcode
 
-    def _check_planet_code(self, star, code, size, atmo, hydro):
+    def _check_planet_code(self, star, code, size, atmo, hydro, listmsg=None):
         size = '0123456789ABC' if size is None else size
         atmo = '0123456789ABCDEF' if atmo is None else atmo
         hydro = '0123456789A' if hydro is None else hydro
@@ -293,10 +293,13 @@ class TradeCodes(object):
             msg = '{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset)
         if code_match and not star_match:
             msg = '{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset)
-        self.logger.error(msg)
+        if isinstance(listmsg, list):
+            listmsg.append(msg)
+        else:
+            self.logger.error(msg)
         return False
 
-    def _check_pop_code(self, star, code, pop):
+    def _check_pop_code(self, star, code, pop, listmsg=None):
         star_match = star.pop in pop
         code_match = code in self.codeset
         if star_match == code_match:
@@ -308,10 +311,13 @@ class TradeCodes(object):
         if code_match and not star_match:
             msg = '{} - Found invalid "{}" code on world with {} population: {}'.format(star, code, star.pop,
                                                                                        self.codeset)
-        self.logger.error(msg)
+        if isinstance(listmsg, list):
+            listmsg.append(msg)
+        else:
+            self.logger.error(msg)
         return False
 
-    def _check_econ_code(self, star, code, atmo, hydro, pop):
+    def _check_econ_code(self, star, code, atmo, hydro, pop, listmsg=None):
         atmo = '0123456789ABCDEF' if atmo is None else atmo
         hydro = '0123456789A' if hydro is None else hydro
         pop = '0123456789ABCD' if pop is None else pop
@@ -325,34 +331,42 @@ class TradeCodes(object):
         if code_match and not star_match:
             msg = '{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset)
         self.logger.error(msg)
+        if isinstance(listmsg, list):
+            listmsg.append(msg)
+        else:
+            self.logger.error(msg)
         return False
 
-    def check_world_codes(self, star):
+    def check_world_codes(self, star, msg=None):
+        is_list = isinstance(msg, list)
+        msg = msg if is_list else None
         check = True
-        check = self._check_planet_code(star, 'As', '0', '0', '0') and check
-        check = self._check_planet_code(star, 'De', None, '23456789', '0') and check
-        check = self._check_planet_code(star, 'Fl', None, 'ABC', '123456789A') and check
-        check = self._check_planet_code(star, 'Ga', '678', '568', '567') and check
-        check = self._check_planet_code(star, 'He', '3456789ABC', '2479ABC', '012') and check
-        check = self._check_planet_code(star, 'Ic', None, '01', '123456789A') and check
-        check = self._check_planet_code(star, 'Po', None, '2345', '0123') and check
+        check = self._check_planet_code(star, 'As', '0', '0', '0', msg) and check
+        check = self._check_planet_code(star, 'De', None, '23456789', '0', msg) and check
+        check = self._check_planet_code(star, 'Fl', None, 'ABC', '123456789A', msg) and check
+        check = self._check_planet_code(star, 'Ga', '678', '568', '567', msg) and check
+        check = self._check_planet_code(star, 'He', '3456789ABC', '2479ABC', '012', msg) and check
+        check = self._check_planet_code(star, 'Ic', None, '01', '123456789A', msg) and check
+        check = self._check_planet_code(star, 'Po', None, '2345', '0123', msg) and check
         check = self._check_planet_code(star, 'Oc', 'ABCD', '3456789DEF', 'A') and check
         check = self._check_planet_code(star, 'Va', None, '0', None) and check
-        check = self._check_planet_code(star, 'Wa', '3456789', '3456789DEF', 'A') and check
+        check = self._check_planet_code(star, 'Wa', '3456789', '3456789DEF', 'A', msg) and check
 
         # self._check_pop_code('Ba', '0')
-        check = self._check_pop_code(star, 'Lo', '123') and check
-        check = self._check_pop_code(star, 'Ni', '456') and check
-        check = self._check_pop_code(star, 'Ph', '8') and check
-        check = self._check_pop_code(star, 'Hi', '9ABCD') and check
+        check = self._check_pop_code(star, 'Lo', '123', msg) and check
+        check = self._check_pop_code(star, 'Ni', '456', msg) and check
+        check = self._check_pop_code(star, 'Ph', '8', msg) and check
+        check = self._check_pop_code(star, 'Hi', '9ABCD', msg) and check
 
-        check = self._check_econ_code(star, 'Pa', '456789', '45678', '48') and check
-        check = self._check_econ_code(star, 'Ag', '456789', '45678', '567') and check
-        check = self._check_econ_code(star, 'Na', '0123', '0123', '6789ABCD') and check
-        check = self._check_econ_code(star, 'Pi', '012479', None, '78') and check
-        check = self._check_econ_code(star, 'In', '012479ABC', None, '9ABCD') and check
-        check = self._check_econ_code(star, 'Pr', '68', None, '59') and check
-        check = self._check_econ_code(star, 'Ri', '68', None, '678') and check
+        check = self._check_econ_code(star, 'Pa', '456789', '45678', '48', msg) and check
+        check = self._check_econ_code(star, 'Ag', '456789', '45678', '567', msg) and check
+        check = self._check_econ_code(star, 'Na', '0123', '0123', '6789ABCD', msg) and check
+        check = self._check_econ_code(star, 'Pi', '012479', None, '78', msg) and check
+        check = self._check_econ_code(star, 'In', '012479ABC', None, '9ABCD', msg) and check
+        check = self._check_econ_code(star, 'Pr', '68', None, '59', msg) and check
+        check = self._check_econ_code(star, 'Ri', '68', None, '678', msg) and check
+        if is_list:
+            return msg
         return check
 
     def owned_by(self, star):
@@ -605,8 +619,11 @@ class TradeCodes(object):
 
         return True, msg
 
-    def check_canonical(self):
-        return True, []
+    def check_canonical(self, star):
+        msg = []
+        result = self.check_world_codes(star, msg)
+
+        return 0 == len(msg), msg
 
     def canonicalise(self):
         pass

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -288,12 +288,12 @@ class TradeCodes(object):
         code_match = code in self.codeset
         if star_match == code_match:
             return True
+        msg = None
         if star_match and not code_match:
             msg = '{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset)
-            self.logger.error(msg)
         if code_match and not star_match:
             msg = '{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset)
-            self.logger.error(msg)
+        self.logger.error(msg)
         return False
 
     def _check_pop_code(self, star, code, pop):
@@ -301,13 +301,14 @@ class TradeCodes(object):
         code_match = code in self.codeset
         if star_match == code_match:
             return True
+        msg = None
         if star_match and not code_match:
             msg = '{} - Calculated "{}" not in trade codes {}'.format(star, code, self.codeset)
-            self.logger.error(msg)
+
         if code_match and not star_match:
             msg = '{} - Found invalid "{}" code on world with {} population: {}'.format(star, code, star.pop,
                                                                                        self.codeset)
-            self.logger.error(msg)
+        self.logger.error(msg)
         return False
 
     def _check_econ_code(self, star, code, atmo, hydro, pop):
@@ -318,12 +319,12 @@ class TradeCodes(object):
         code_match = code in self.codeset
         if star_match == code_match:
             return True
+        msg = None
         if star_match and not code_match:
             msg = '{}-{} Calculated "{}" not in trade codes {}'.format(star, str(star.uwp), code, self.codeset)
-            self.logger.error(msg)
         if code_match and not star_match:
             msg = '{}-{} Found invalid "{}" in trade codes: {}'.format(star, str(star.uwp), code, self.codeset)
-            self.logger.error(msg)
+        self.logger.error(msg)
         return False
 
     def check_world_codes(self, star):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -625,5 +625,5 @@ class TradeCodes(object):
 
         return 0 == len(msg), msg
 
-    def canonicalise(self):
+    def canonicalise(self, star):
         pass

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -4,11 +4,11 @@ from datetime import timedelta
 from hypothesis import given, assume, example, HealthCheck, settings
 from hypothesis.strategies import text, from_regex, composite, sampled_from, lists, floats
 
-from Galaxy import Sector
+from PyRoute.Galaxy import Sector
 from PyRoute.Inputs.ParseStarInput import ParseStarInput
 from PyRoute.TradeCodes import TradeCodes
-from Star import Star
-from SystemData.UWP import UWP
+from PyRoute.Star import Star
+from PyRoute.SystemData.UWP import UWP
 
 
 tradecodes = []

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -2,13 +2,38 @@ import unittest
 from datetime import timedelta
 
 from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, from_regex
+from hypothesis.strategies import text, from_regex, composite, sampled_from, lists, floats
 
 from Galaxy import Sector
 from PyRoute.Inputs.ParseStarInput import ParseStarInput
 from PyRoute.TradeCodes import TradeCodes
 from Star import Star
 from SystemData.UWP import UWP
+
+
+tradecodes = []
+
+
+@composite
+def trade_code(draw):
+    if 0 == len(tradecodes):
+        tradecodes.extend(TradeCodes.pcodes)
+        tradecodes.extend(TradeCodes.dcodes)
+        tradecodes.extend(TradeCodes.ext_codes)
+        tradecodes.extend(TradeCodes.allowed_residual_codes)
+
+    strat = sampled_from(tradecodes)
+
+    return draw(lists(strat, min_size=2, max_size=12))
+
+
+@composite
+def trade_line(draw):
+    choice = draw(floats(min_value=0.0, max_value=1.0))
+
+    if 0.5 > choice:
+        return draw(text(min_size=15, max_size=36, alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*'))
+    return draw(trade_code())
 
 
 class testTradeCodes(unittest.TestCase):
@@ -62,12 +87,32 @@ class testTradeCodes(unittest.TestCase):
         self.assertEqual(trade_string, nu_trade_string, msg)
 
     @given(from_regex(regex=UWP.match, alphabet='0123456789abcdefghjklmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWYXZ -{}()[]?\'+*'),
-           text(min_size=15, max_size=36, alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*'))
+          trade_line())
     @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))  # suppress slow-data health check, too-much filtering
     @example('A000000-0', '000000000000000')
+    @example('A000100-0', '000000000000000')
+    @example('A000400-0', '000000000000000')
+    @example('A001000-0', '000000000000000')
+    @example('A000600-0', '000000000000000')
+    @example('A000700-0', '000000000000000')
+    @example('A020000-0', '000000000000000')
+    @example('A0A1000-0', '000000000000000')
+    @example('A320000-0', '000000000000000')
+    @example('A044400-0', '000000000000000')
+    @example('A044500-0', '000000000000000')
+    @example('A060500-0', '000000000000000')
+    @example('A000800-0', '000000000000000')
+    @example('A000900-0', '000000000000000')
+    @example('A060600-0', '000000000000000')
+    @example('A33A000-0', '000000000000000')
+    @example('A655000-0', '000000000000000')
+    @example('A000000-0', 'Ba')
+    @example('ABDA000-0', '000000000000000')
     def test_verify_canonicalisation_is_idempotent(self, s, trade_line):
         s = s[0:9]
-        hyp_input = 'Hypothesis input: ' + s + ', ' + trade_line
+        if isinstance(trade_line, list):
+            trade_line = ' '.join(trade_line)
+        hyp_input = 'Hypothesis input: \'' + s + '\', \'' + trade_line + '\''
         starline = '0101 000000000000000 {} {}  - - 0 000   0000D'.format(s, trade_line.ljust(38))
         sector = Sector('# Core', '# 0, 0')
         pop_code = 'scaled'

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -58,6 +58,21 @@ class testTradeCodes(unittest.TestCase):
         msg = "Re-parsed TradeCodes string does not equal original parsed string"
         self.assertEqual(trade_string, nu_trade_string, msg)
 
+    @given(text(min_size=15, alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*'))
+    def test_verify_canonicalisation_is_idempotent(self, s):
+        hyp_input = 'Hypothesis input: ' + s
+
+        trade = TradeCodes(s)
+        result, _ = trade.is_well_formed()
+        assume(result)
+
+        result, msg = trade.check_canonical()
+        assume(0 < len(msg))
+
+        trade.canonicalise()
+        result, msg = trade.check_canonical()
+        self.assertEqual(0, len(msg), "Canonicalisation failed.  " + hyp_input)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add the machinery to canonicalise trade codes according to T5 rules against the starline's current UWP.

This will ultimately hook into full-starline canonicalisation, useful both for delta debugging and cleaning up wonky sector data.