### PR TITLE
Preheat upper pathfinding bounds

### DIFF
--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -260,6 +260,14 @@ class TradeCalculation(RouteCalculation):
                 nubound = min(midleft + midright)
                 upbound = min(upbound, nubound)
 
+        if 0 < len(hist_src[0]) and 0 < len(hist_targ[0]):
+            common, src, trg = np.intersect1d(hist_src[0], hist_targ[0], assume_unique=True, return_indices=True)
+            if 0 < len(common):
+                midleft = hist_src[1][src]
+                midright = hist_targ[1][trg]
+                nubound = min(midleft + midright)
+                upbound = min(upbound, nubound)
+
         return upbound
 
     def update_statistics(self, star, target, tradeCr, tradePass):

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -388,7 +388,6 @@ class TradeCalculation(RouteCalculation):
 
         self.galaxy.landmarks[(source.index, target.index)] = distance
         self.galaxy.landmarks[(target.index, source.index)] = distance
-        self.galaxy.landmarks_bulk.add_edge(source.index, target.index, distance)
 
         # Gather basic statistics.
         tradeBTN = self.get_btn(source, target, distance)

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -251,6 +251,15 @@ class TradeCalculation(RouteCalculation):
                 nubound = min(midleft + midright)
                 upbound = min(upbound, nubound)
 
+        hist_src = self.galaxy.historic_costs._arcs[stardex]
+        if 0 < len(hist_src[0]):
+            common, src, trg = np.intersect1d(hist_src[0], trg_adj[0], assume_unique=True, return_indices=True)
+            if 0 < len(common):
+                midleft = hist_src[1][src]
+                midright = trg_adj[1][trg]
+                nubound = min(midleft + midright)
+                upbound = min(upbound, nubound)
+
         return upbound
 
     def update_statistics(self, star, target, tradeCr, tradePass):

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -202,6 +202,7 @@ class TradeCalculation(RouteCalculation):
             "This route from " + str(star) + " to " + str(target) + " has already been processed in reverse"
 
         try:
+            upbound = self._preheat_upper_bound(star, target)
             mincost = copy.deepcopy(self.star_graph._min_cost)
             rawroute, _ = astar_path_numpy(self.star_graph, star.index, target.index,
                                            self.galaxy.heuristic_distance_bulk, min_cost=mincost)
@@ -230,6 +231,12 @@ class TradeCalculation(RouteCalculation):
         # Update the trade route (edges)
         tradeCr, tradePass = self.route_update_simple(route, True)
         self.update_statistics(star, target, tradeCr, tradePass)
+
+    def _preheat_upper_bound(self, star, target):
+        stardex = star.index
+        targdex = target.index
+
+        return float('+inf')
 
     def update_statistics(self, star, target, tradeCr, tradePass):
         if star.sector != target.sector:

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -234,12 +234,12 @@ class TradeCalculation(RouteCalculation):
         tradeCr, tradePass = self.route_update_simple(route, True)
         self.update_statistics(star, target, tradeCr, tradePass)
 
-    def _preheat_upper_bound(self, star, target):
+    def _preheat_upper_bound(self, star, target, allow_reheat=True):
         stardex = star.index
         targdex = target.index
         # Don't reheat on _every_ route, but reheat frequently enough to keep historic costs sort-of firm.
         # Keeping this deterministic helps keep input reduction straight, as there's less state to track.
-        reheat = (stardex + targdex) % (math.floor(math.sqrt(len(self.star_graph)))) == 0
+        reheat = allow_reheat and ((stardex + targdex) % (math.floor(math.sqrt(len(self.star_graph)))) == 0)
 
         upbound = float('+inf')
         reheat_list = set()
@@ -302,6 +302,8 @@ class TradeCalculation(RouteCalculation):
                     if edge['weight'] > newcost:
                         self.galaxy.stars[start][end]['weight'] = newcost
                         self.galaxy.historic_costs.lighten_edge(start, end, newcost)
+            reheated_upbound = self._preheat_upper_bound(star, target, allow_reheat=False)
+            upbound = min(reheated_upbound, upbound)
 
         return upbound
 

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -242,6 +242,15 @@ class TradeCalculation(RouteCalculation):
         src_adj = self.star_graph._arcs[stardex]
         trg_adj = self.star_graph._arcs[targdex]
 
+        hist_targ = self.galaxy.historic_costs._arcs[targdex]
+        if 0 < len(hist_targ[0]):
+            common, src, trg = np.intersect1d(src_adj[0], hist_targ[0], assume_unique=True, return_indices=True)
+            if 0 < len(common):
+                midleft = src_adj[1][src]
+                midright = hist_targ[1][trg]
+                nubound = min(midleft + midright)
+                upbound = min(upbound, nubound)
+
         return upbound
 
     def update_statistics(self, star, target, tradeCr, tradePass):

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -758,6 +758,8 @@ class Galaxy(AreaItem):
 
     def heuristic_distance_bulk(self, active_nodes, target):
         raw = self.trade.shortest_path_tree.lower_bound_bulk(active_nodes, target)
+        distances = self.trade.star_graph.distances_from_target(target)
+        raw = np.maximum(raw, distances)
 
         # The minimum edge cost on each node is itself an admissible heuristic:
         # If u is the target, min-edge-cost is special-cased to 0, which equals the cost to target.

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -395,7 +395,6 @@ class Galaxy(AreaItem):
         self.max_jump_range = max_jump
         self.min_btn = min_btn
         self.landmarks = dict()
-        self.landmarks_bulk = None
         self.historic_costs = None
         self.big_component = None
         self.star_mapping = dict()
@@ -526,7 +525,6 @@ class Galaxy(AreaItem):
         assert map_len == shadow_len, "Mismatch between shadow stars and stars mapping, " + str(shadow_len) + " and " + str(map_len)
         for item in self.stars.nodes:
             assert 'star' in self.stars.nodes[item], "Star attribute not set for item " + str(item)
-        self.landmarks_bulk = RouteLandmarkGraph(self.stars)
         self.historic_costs = RouteLandmarkGraph(self.stars)
 
     def set_bounding_sectors(self):

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -758,7 +758,7 @@ class Galaxy(AreaItem):
 
     def heuristic_distance_bulk(self, active_nodes, target):
         raw = self.trade.shortest_path_tree.lower_bound_bulk(active_nodes, target)
-        distances = self.trade.star_graph.distances_from_target(target)
+        distances = self.trade.star_graph.distances_from_target(active_nodes, target)
         raw = np.maximum(raw, distances)
 
         # The minimum edge cost on each node is itself an admissible heuristic:

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -396,6 +396,7 @@ class Galaxy(AreaItem):
         self.min_btn = min_btn
         self.landmarks = dict()
         self.landmarks_bulk = None
+        self.historic_costs = None
         self.big_component = None
         self.star_mapping = dict()
         self.trade = None
@@ -526,6 +527,7 @@ class Galaxy(AreaItem):
         for item in self.stars.nodes:
             assert 'star' in self.stars.nodes[item], "Star attribute not set for item " + str(item)
         self.landmarks_bulk = RouteLandmarkGraph(self.stars)
+        self.historic_costs = RouteLandmarkGraph(self.stars)
 
     def set_bounding_sectors(self):
         for sector, neighbor in itertools.combinations(self.sectors.values(), 2):

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -758,8 +758,6 @@ class Galaxy(AreaItem):
 
     def heuristic_distance_bulk(self, active_nodes, target):
         raw = self.trade.shortest_path_tree.lower_bound_bulk(active_nodes, target)
-        lands = self.landmarks_bulk[target]
-        raw[lands[0]] = np.maximum(raw[lands[0]], lands[1])
 
         # The minimum edge cost on each node is itself an admissible heuristic:
         # If u is the target, min-edge-cost is special-cased to 0, which equals the cost to target.

--- a/PyRoute/Pathfinding/DistanceBase.py
+++ b/PyRoute/Pathfinding/DistanceBase.py
@@ -3,19 +3,34 @@ Created on Feb 25, 2024
 
 @author: CyberiaResurrection
 """
+import numpy as np
 
 
 class DistanceBase:
 
     def __init__(self, graph):
-        self._nodes = list(graph.nodes())
+        raw_nodes = graph.nodes()
+        self._nodes = list(raw_nodes)
+        num_nodes = len(self._nodes)
         self._indexes = {node: i for (i, node) in enumerate(self._nodes)}
+        positions = [
+            raw_nodes[u]['star'].hex.hex_position() for u in self._nodes
+        ]
+        self._positions = np.zeros((num_nodes, 2), dtype=int)
+        for i in range(num_nodes):
+            self._positions[i, :] = np.array(positions[i])
 
     def __len__(self):
         return len(self._nodes)
 
     def lighten_edge(self, u, v, weight):
         raise NotImplementedError("Base Class")
+
+    def distances_from_target(self, target):
+        dq = self._positions[:, 0] - self._positions[target, 0]
+        dr = self._positions[:, 1] - self._positions[target, 1]
+
+        return (abs(dq) + abs(dr) + abs(dq + dr)) // 2
 
     def _lighten_arc(self, u, v, weight):
         arcs = self._arcs[u]

--- a/PyRoute/Pathfinding/DistanceBase.py
+++ b/PyRoute/Pathfinding/DistanceBase.py
@@ -26,9 +26,9 @@ class DistanceBase:
     def lighten_edge(self, u, v, weight):
         raise NotImplementedError("Base Class")
 
-    def distances_from_target(self, target):
-        dq = self._positions[:, 0] - self._positions[target, 0]
-        dr = self._positions[:, 1] - self._positions[target, 1]
+    def distances_from_target(self, active_nodes, target):
+        dq = self._positions[active_nodes, 0] - self._positions[target, 0]
+        dr = self._positions[active_nodes, 1] - self._positions[target, 1]
 
         return (abs(dq) + abs(dr) + abs(dq + dr)) // 2
 

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -6,8 +6,11 @@ Created on Feb 22, 2024
 Compared to the ancestral networkx version of astar_path, this code:
     Does _not_ use a count() object reference to break ties, as nodes are directly-comparable integers
     Leans on numpy to handle neighbour nodes, edges to same and heuristic values in bulk
-    Tracks upper-bounds on shortest-path length as they are found
+    Tracks upper-bounds on shortest-path cost as they are found
     Prunes neighbour candidates early - if this exhausts a node by leaving it no viable neighbour candidates, so be it
+    Takes an optional externally-supplied upper bound
+        - Sanity and correctness of this upper bound are the _caller_'s responsibility
+        - If the supplied upper bound produces a pathfinding failure, so be it
     Grooms the node queue in the following cases:
         When a new upper bound is found, discards queue entries whose f-values bust the new upper bound
         When a _longer_ path is found to a previously-queued node, discards queue entries whose g-values bust
@@ -21,7 +24,7 @@ import networkx as nx
 import numpy as np
 
 
-def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None):
+def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=None):
 
     push = heappush
     pop = heappop
@@ -40,7 +43,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None):
     distances[source] = 0
     # Tracks shortest _complete_ path found so far
     floatinf = float('inf')
-    upbound = floatinf
+    upbound = floatinf if upbound is None else upbound
     # pre-calc heuristics for all nodes to the target node
     potentials = bulk_heuristic(G._nodes, target)
     # pre-calc the minimum-cost edge on each node

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -51,6 +51,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
     min_cost[target] = 0
 
     node_counter = 0
+    has_bound = upbound != floatinf
 
     while queue:
         # Pop the smallest item from queue.
@@ -87,7 +88,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             distances[curnode] = dist
 
         explored[curnode] = parent
-        has_bound = upbound != floatinf
 
         raw_nodes = G_succ[curnode]
         active_nodes = raw_nodes[0]
@@ -122,6 +122,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
 
             upbound = ncost
             distances[target] = ncost
+            has_bound = True
             if 0 < len(queue):
                 queue = [item for item in queue if item[0] < upbound]
                 # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -110,11 +110,11 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             keep = augmented_weights < upbound
             if not keep.all():
                 active_nodes = active_nodes[keep]
-                active_weights = active_weights[keep]
-                augmented_weights = augmented_weights[keep]
                 num_neighbours = len(active_nodes)
                 if 0 == num_neighbours:
                     continue
+                active_weights = active_weights[keep]
+                augmented_weights = augmented_weights[keep]
 
         if target in active_nodes:
             drop = active_nodes == target

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -126,7 +126,11 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
                 queue = [item for item in queue if item[0] < upbound]
                 # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
                 queue = [item for item in queue if not (item[1] > distances[item[2]])]
-                heapify(queue)
+                # Finally, dedupe the queue after cleaning all bound-busts out and 2 or more elements are left.
+                # Empty or single-element sets cannot require deduplication, and are already heaps themselves.
+                if 1 < len(queue):
+                    queue = list(set(queue))
+                    heapify(queue)
             # push(queue, (ncost + 0, ncost, target, curnode))
             push(queue, (ncost, ncost, target, curnode))
             # target node has been processed, drop it from neighbours

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -76,12 +76,12 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None):
 
             # Skip bad paths that were enqueued before finding a better one
             qcost = distances[curnode]
-            if qcost < dist:
+            if qcost <= dist:
                 queue = [item for item in queue if not (item[1] > distances[item[2]])]
                 heapify(queue)
                 continue
             # If we've found a better path, update
-            distances[curnode] = qcost
+            distances[curnode] = dist
 
         explored[curnode] = parent
         has_bound = upbound != floatinf

--- a/Tests/Pathfinding/testRouteLandmarkGraph.py
+++ b/Tests/Pathfinding/testRouteLandmarkGraph.py
@@ -111,7 +111,7 @@ class testRouteLandmarkGraph(baseTest):
         raw_nodes = graph.nodes()
         targstar = raw_nodes[11]['star']
 
-        targ_distances = rlg.distances_from_target(11)
+        targ_distances = rlg.distances_from_target(raw_nodes, 11)
         self.assertEqual(len(rlg), len(targ_distances), "Should be one distance-to-target per node")
 
         for i in range(len(rlg)):

--- a/Tests/Pathfinding/testRouteLandmarkGraph.py
+++ b/Tests/Pathfinding/testRouteLandmarkGraph.py
@@ -98,6 +98,27 @@ class testRouteLandmarkGraph(baseTest):
         self.assertEqual([1], actual[0], "v - index nodelist not updated")
         self.assertEqual([7.5], actual[1], "v - value list not updated")
 
+    def test_verify_position_creation(self):
+        sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
+        graph, source, stars = self._setup_graph(sourcefile)
+        num_stars = len(stars)
+
+        rlg = RouteLandmarkGraph(graph)
+        self.assertEqual(num_stars, len(rlg))
+        positions = rlg._positions
+        self.assertEqual(len(rlg), len(positions), "Should be one position per node")
+
+        raw_nodes = graph.nodes()
+        targstar = raw_nodes[11]['star']
+
+        targ_distances = rlg.distances_from_target(11)
+        self.assertEqual(len(rlg), len(targ_distances), "Should be one distance-to-target per node")
+
+        for i in range(len(rlg)):
+            candstar = raw_nodes[i]['star']
+            exp_dist = targstar.distance(candstar)
+            self.assertEqual(exp_dist, targ_distances[i], "Unexpected to-target distance for " + str((candstar, i)))
+
     def _setup_graph(self, sourcefile):
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -22,11 +22,14 @@ class TestTradeCode(unittest.TestCase):
         self.logger = logging.getLogger("PyRoute")
 
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+        logging.disable(logging.NOTSET)
         # create console handler and set level to debug
         ch = logging.StreamHandler()
         ch.setLevel("INFO")
         ch.setFormatter(formatter)
         self.logger.addHandler(ch)
+        logger = logging.getLogger('PyRoute.TradeCodes')
+        logger.setLevel(logging.WARNING)
 
     def testLo(self):
         code = TradeCodes("Lo")


### PR DESCRIPTION
Benefiting from tightened _lower_ bounds in A* pathfinding only requires an _admissible_ heuristic - one that never over-estimates cost to the target from some current node.

Benefiting from tightened _upper_ bounds, however, requires that the heuristic be _consistent_, not merely admissible.  A consistent heuristic is an admissible heuristic such that, over all nodes K, for a given node N and each successor P of N, the heuristic value h(N) is not greater than the sum of the cost of the edge from N to P, c(N, P), and the heuristic value at P, h(P).  In other words:
c(N, P) >= h(N) - h(P)

As at the status quo, the bulk heuristic was the case-wise maximum of the following subheuristics:

- approx-shortest-path
- min-edge-cost
- historic path _distances_

The first two subheuristics are themselves consistent, but the historic distances can only be consistent _after the bitter end_ of pathfinding.  If one subheuristic is not consistent, the resulting bulk heuristic is not consistent.

Enter again @GamesByDavidE , whose advice and feedback proved invaluable in diagnosing the non-consistent parts of the bulk heuristic.  I followed his suggestion to replace the historic distances subheuristic with plain node-to-target distances in parsec.

I found out the hard way that this sort of exogenous upper bound **requires** a consistent heuristic to avoid having some nontrivial fraction (~15% in my tests) of pathfinding attempts fail to find a route.  Each failed attempt found a route when it wasn't supplied with an upper bound value.

With that sorted out, onto the meat of this PR.  My motivating observation was that when the first finite upper bound lands during pathfinding, the queue size gets slashed **dramatically**, with later nodes having their viable (ie, not bound busting) neighbour sets similarly trimmed - sometimes to exhaustion (ie, no viable neighbours).

For example, over the Zhodani Consulate heartland (Zdiedeiant, Stiatlchepr, Zhdant, Tienspevnekr):

Iefla (Zdiedeiant 0610) to Fievr (Stiatlchepr 2826),
- 54 pc straight line distance
- First endogenous upbound found after 400 nodes expanded
- 280 nodes in queue as at first upbound
- 277 nodes dropped from queue because they bust the new upbound

Adliev (Zdiedeiant 1227) to Fievr (Stiatlchepr 2826)
- 48 pc straight line distance
- First endogenous upbound found after 368 nodes expanded
- 368 nodes in queue as at first upbound
- 360 nodes dropped from queue because they bust the new upbound

Question The First - What happens if such an upper bound is supplied at the **start** of pathfinding?

Question The Second - **How** do we generate that upper bound?

As edge, and thus route, costs can only _stay the same_ (if no involved edge is re-used in the meantime) or _decrease_ (if at least one edge is re-used) in later pathfinding runs, the route cost when a route is found is an **upper** bound on the cost to travel that route at any later time.
I've salvaged some of the book-keeping from the skip-routing attempts and added skip links to the galaxy object's stars graph (not the DistanceGraph actually used for pathfinding, as tests showed the added links slowed down pathfinding).

When pathfinding from S to T, the route cost is obviously unknown, as the shortest path hasn't been found.
That doesn't preclude the following three cases:

1. A historic-route cost exists from at least one of S's immediate neighbours, S_n, to T.
2. A historic-route cost exists from at least one of T's immediate neighbours, T_n, to S.
3. At least one intermediate node, I, is connected by historic routes to both S and T.

In 1's case (and 2's, _mutatis mutandis_) the lower bound is the sum of C(S, S_n) and the historic-route cost from S_n to T.  In 3's case, the upper bound is the sum of the two connecting historic routes.  If a given case has multiple candidates, return the one with minimal upper bound.  If multiple cases return finite upper bounds, return the lowest.

I've called that **pre-heating** the upper bound.

Especially for historic routes found early in pathfinding, there's no guarantee these upper bounds will be anything approaching firm, let alone tight.

**Re-heating** the upper bound takes the set of historic routes that are involved in the winning candidates across all three cases (so, from 1 to 4 historic routes, depending on which case(s) returned finite bounds), re-evaluates their historic-route costs as at the current pathfinding state, and updates the stored costs for the affected historic routes.

Percentage changes are from the master value for that item, over the Zhodani Consulate heartland (Zdiedeiant, Stiatlchepr, Zhdant, and Tienspevnekr - 2,231 worlds, 108,240 routes).

As for the bound checks:
The first check (**Neighbour-set bound checks**) checked each neighbour's g value against the lower of the upper bound and the existing distance label for that node.
The second check (**Un-exhausted set checks with finite bound**) checked each remaining neighbour's f value (ie, including the heuristic) against the upper bound, if finite.

| Item | Master | Pre-heat | % drop | Re-heat | % drop |
| ----- | -----: | -----: | -----: | -----: | -----: |
| Nodes popped from queue | 11,075,222 | 10,764,518 | 2.8 | 10,764,504 | 2.8 |
| Nodes revisited | 44,160 | 44,180 | -0.05 | 44,190 | -0.07 |
| Nodes re-expanded | 433 | 404 | 6.7 | 404 | 6.7 |
| Neighbour-set bound checks | 10,923,248 | 10,612,505 | 2.8 | 10,612,482 | 2.8 |
| Neighbour-set checks with finite bound | 1,368,726 | 10,608,317 | - | 10,608,294 | - |
| % of neighbour-set checks w/finite bound | 12.53 | 99.96 | - | 99.96 | - |
| Exhausted nodes | 2,084,714 | 3,157,675 | -51.5 | 3,166,334 | -51.8 |
| Un-exhausted nodes | 8,838,534 | 7,454,830 | 15.66 | 7,446,148 | 15.75 |
| Un-exhausted set checks with finite bound | 973,633 | 7,451,571 | -665.34 | 7,442,889 | -664.45 |
| % of un-exhausted set checks w/finite bound | 11.02 | 99.96 | - | 99.96 | - |
| New upper bounds during pathfinding | 236,230 | 113,791 | 51.83 | 113,400 | 52.00 |
| Nodes actually having neighbours to queue | 8,594,714 | 5,508,333 | 35.91 | 5,492,012 | 36.10 |
| Nodes added to queue | 67,584,700 | 12,291,594 | 81.81 | 12,190,946 | 81.96 |
| Final neighbourhood size per node | 7.87 | 2.23 | 71.66 | 2.22 | 71.79 |

Sans profiling, over the same sectors:
Master: 714 s overall, 636 s pathfinding
Re-heat: 657 s overall, 570s pathfinding
A 10.3% reduction in pathfinding time's nothing to sneeze at.