### PR TITLE
Unify approx-SP forest

### DIFF
--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -9,11 +9,13 @@ import math
 
 import numpy as np
 import networkx as nx
+import numpy as np
 
 from PyRoute.Pathfinding.DistanceGraph import DistanceGraph
 from PyRoute.AllyGen import AllyGen
 from PyRoute.Calculation.RouteCalculation import RouteCalculation
 from PyRoute.Pathfinding.ApproximateShortestPathForestDistanceGraph import ApproximateShortestPathForestDistanceGraph
+from PyRoute.Pathfinding.ApproximateShortestPathForestUnified import ApproximateShortestPathForestUnified
 from PyRoute.TradeBalance import TradeBalance
 from PyRoute.Pathfinding.astar_numpy import astar_path_numpy
 
@@ -174,7 +176,8 @@ class TradeCalculation(RouteCalculation):
         source.is_landmark = True
         # Feed the landmarks in as roots of their respective shortest-path trees.
         # This sets up the approximate-shortest-path bounds to be during the first pathfinding call.
-        self.shortest_path_tree = ApproximateShortestPathForestDistanceGraph(source.index, self.galaxy.stars, self.epsilon, sources=landmarks)
+        self.shortest_path_tree = ApproximateShortestPathForestUnified(source.index, self.galaxy.stars,
+                                                                             self.epsilon, sources=landmarks)
 
         base_btn = 0
         counter = 0
@@ -379,6 +382,7 @@ class TradeCalculation(RouteCalculation):
         - reduce the weight of routes used to allow more trade to flow
         """
         distance = self.route_distance(route)
+        route_cost = self.route_cost(route)
 
         source = route[0]
         target = route[-1]

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -9,12 +9,10 @@ import math
 
 import numpy as np
 import networkx as nx
-import numpy as np
 
 from PyRoute.Pathfinding.DistanceGraph import DistanceGraph
 from PyRoute.AllyGen import AllyGen
 from PyRoute.Calculation.RouteCalculation import RouteCalculation
-from PyRoute.Pathfinding.ApproximateShortestPathForestDistanceGraph import ApproximateShortestPathForestDistanceGraph
 from PyRoute.Pathfinding.ApproximateShortestPathForestUnified import ApproximateShortestPathForestUnified
 from PyRoute.TradeBalance import TradeBalance
 from PyRoute.Pathfinding.astar_numpy import astar_path_numpy
@@ -382,7 +380,6 @@ class TradeCalculation(RouteCalculation):
         - reduce the weight of routes used to allow more trade to flow
         """
         distance = self.route_distance(route)
-        route_cost = self.route_cost(route)
 
         source = route[0]
         target = route[-1]

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -33,8 +33,6 @@ class ApproximateShortestPathForestUnified:
                                                                                    seeds=raw_seeds,
                                                                                    divisor=self._divisor)
             self._distances[:, i] = result
-        foo = 1
-        pass
 
     def lower_bound_bulk(self, active_nodes, target):
         raw = np.abs(self._distances[active_nodes, :] - self._distances[target, :])

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -1,0 +1,118 @@
+"""
+Created on Feb 29, 2024
+
+@author: CyberiaResurrection
+"""
+import numpy as np
+from PyRoute.Star import Star
+from PyRoute.Pathfinding.DistanceGraph import DistanceGraph
+from PyRoute.Pathfinding.single_source_dijkstra import implicit_shortest_path_dijkstra_distance_graph
+
+
+class ApproximateShortestPathForestUnified:
+
+    def __init__(self, source, graph, epsilon, sources=None):
+        seeds, source, num_trees = self._get_sources(graph, source, sources)
+        self._graph = DistanceGraph(graph)
+        self._source = source
+        self._epsilon = epsilon
+        # memoising this because its value gets used _heavily_ in lower bound calcs, called during heuristic generation
+        self._divisor = 1 / (1 + epsilon)
+        self._sources = sources
+        self._seeds = seeds
+        self._num_trees = num_trees
+        self._graph_len = len(self._graph)
+        self._distances = np.ones((self._graph_len, self._num_trees)) * float('+inf')
+
+        # spin up initial distances
+        for i in range(self._num_trees):
+            raw_seeds = self._seeds[i] if isinstance(self._seeds[i], list) else list(self._seeds[i].values())
+            self._distances[raw_seeds, i] = 0
+            result = implicit_shortest_path_dijkstra_distance_graph(self._graph, self._source,
+                                                                                   self._distances[:, i],
+                                                                                   seeds=raw_seeds,
+                                                                                   divisor=self._divisor)
+            self._distances[:, i] = result
+        foo = 1
+        pass
+
+    def lower_bound_bulk(self, active_nodes, target):
+        raw = np.abs(self._distances[active_nodes, :] - self._distances[target, :])
+
+        return np.max(raw, axis=1)
+
+    def update_edges(self, edges):
+        dropnodes = set()
+        for item in edges:
+            left = item[0]
+            right = item[1]
+            leftdist = self._distances[left, :]
+            rightdist = self._distances[right, :]
+            shelf = self._graph._arcs[left]
+            keep = shelf[0] == right
+            weight = shelf[1][keep][0]
+            delta = abs(leftdist - rightdist)
+            # Given distance labels, L, on nodes u and v, assuming u's label being smaller,
+            # and edge cost between u and v of d(u, v):
+            # L(u) + d(u, v) <= L(v)
+            # Or, after rearranging,
+            # d(u, v) <= L(v) - L(u)
+            # u and v do _NOT_ have to be shortest-path parent/child for this bound to hold
+
+            # Allowing an approximation tolerance of epsilon (say 0.1), that bound becomes
+            # d(u, v) * (1 + epsilon) <= L(v) - L(u)
+
+            # If that bound no longer holds, it's due to the edge (u, v) having its weight decreased during pathfinding.
+            # Tag each incident node as needing updates.
+
+            if np.max(delta) >= weight:
+                dropnodes.add(left)
+                dropnodes.add(right)
+
+        # if no nodes are to be dropped, nothing to do - bail out
+        if 0 == len(dropnodes):
+            return
+
+        # Now we have the nodes incident to edges that bust the (1+eps) approximation bound, feed them into restarted
+        # dijkstra to update the approx-SP tree/forest.  Some nodes in dropnodes may well be SP descendants of others,
+        # but it wasn't worth the time or complexity cost to filter them out here.
+        for i in range(self._num_trees):
+            self._distances[:, i] = implicit_shortest_path_dijkstra_distance_graph(self._graph, self._source,
+                                                                            distance_labels=self._distances[:, i],
+                                                                            seeds=dropnodes, divisor=self._divisor)
+
+    def _get_sources(self, graph, source, sources):
+        seeds = None
+        num_trees = 1
+        if isinstance(source, Star) and source.component is None:
+            raise ValueError(
+                "Source node " + str(source) + " has undefined component.  Has calculate_components() been run?")
+        if isinstance(source, int):
+            if 'star' not in graph.nodes[source]:
+                raise ValueError("Source node # " + str(source) + " does not have star attribute")
+            if graph.nodes[source]['star'].component is None:
+                raise ValueError(
+                    "Source node " + str(graph.nodes[source][
+                                             'star']) + " has undefined component.  Has calculate_components() been run?")
+            seeds = [[source]]
+        if sources is not None:
+            for source in sources:
+                if isinstance(source, Star) and sources[source].component is None:
+                    raise ValueError("Source node " + str(
+                        sources[source]) + " has undefined component.  Has calculate_components() been run?")
+                if isinstance(source, int):
+                    if 'star' not in graph.nodes[source]:
+                        raise ValueError("Source node # " + str(source) + " does not have star attribute")
+                    if graph.nodes[source]['star'].component is None:
+                        raise ValueError(
+                            "Source node " + str(graph.nodes[source][
+                                                     'star']) + " has undefined component.  Has calculate_components() been run?")
+            if isinstance(sources, dict):
+                seeds = [list(sources.values())]
+            else:
+                seeds = sources
+                num_trees = len(sources)
+        return seeds, source, num_trees
+
+    def lighten_edge(self, u, v, weight):
+        self._graph.lighten_edge(u, v, weight)

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -35,7 +35,13 @@ class ApproximateShortestPathForestUnified:
             self._distances[:, i] = result
 
     def lower_bound_bulk(self, active_nodes, target):
-        raw = np.abs(self._distances[active_nodes, :] - self._distances[target, :])
+        actives = self._distances[active_nodes, :]
+        target = self._distances[target, :]
+        overdrive = target == float('+inf')
+        if overdrive.any():
+            target[overdrive] = 0
+            actives[:, overdrive] = 0
+        raw = np.abs(actives - target)
 
         return np.max(raw, axis=1)
 

--- a/PyRoute/Pathfinding/LandmarkSchemes/LandmarksTriaxialExtremes.py
+++ b/PyRoute/Pathfinding/LandmarkSchemes/LandmarksTriaxialExtremes.py
@@ -17,6 +17,8 @@ class LandmarksTriaxialExtremes:
         result.append(dict())
         result.append(dict())
         for component_id in self.galaxy.trade.components:
+            comp_size = self.galaxy.trade.components[component_id]
+
             stars = [item for item in self.galaxy.star_mapping.values() if component_id == item.component]
             # maximum q in component
             source = max(stars, key=lambda item: item.hex.q)
@@ -24,6 +26,9 @@ class LandmarksTriaxialExtremes:
                 result[0][component_id] = source.index
             else:
                 result[0][component_id] = source
+
+            if 2 > comp_size:
+                continue
 
             # minimum r in component
             source = min(stars, key=lambda item: item.hex.r)

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -134,6 +134,10 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
                     heapify(queue)
             # push(queue, (ncost + 0, ncost, target, curnode))
             push(queue, (ncost, ncost, target, curnode))
+            #  If target node is only active node, and is neighbour node of only active queue element, bail out now
+            #  and dodge the now-known-to-be-pointless neighbourhood bookkeeping.
+            if 1 == len(queue) and 1 == len(active_nodes):
+                continue
             # target node has been processed, drop it from neighbours
             keep = active_nodes != target
             # As we have a tighter upper bound, apply it to the neighbours as well

--- a/Tests/Pathfinding/testApproximateShortestPathForest.py
+++ b/Tests/Pathfinding/testApproximateShortestPathForest.py
@@ -18,6 +18,7 @@ from PyRoute.Pathfinding.LandmarkSchemes.LandmarksWTNExtremes import LandmarksWT
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from PyRoute.Pathfinding.ApproximateShortestPathForestDistanceGraph import ApproximateShortestPathForestDistanceGraph
+from PyRoute.Pathfinding.ApproximateShortestPathForestUnified import ApproximateShortestPathForestUnified
 from Tests.baseTest import baseTest
 
 
@@ -69,6 +70,101 @@ class testApproximateShortestPathForest(baseTest):
         self.assertIsNotNone(actual)
 
         np.testing.assert_array_almost_equal(expected, actual, 0.000001, "Unexpected bounds array")
+
+    def test_trixial_bounds_in_bulk_unified(self):
+        galaxy = self.set_up_zarushagar_sector()
+
+        foo = LandmarksTriaxialExtremes(galaxy)
+        landmarks = foo.get_landmarks(index=True)
+        graph = galaxy.stars
+        stars = list(graph.nodes)
+        source = stars[0]
+
+        approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
+        self.assertEqual(3, approx._num_trees)
+
+        active_nodes = [2, 80]
+        target = 80
+        expected = np.array([310.833, 0])
+        actual = approx.lower_bound_bulk(active_nodes, target)
+        self.assertIsNotNone(actual)
+
+        np.testing.assert_array_almost_equal(expected, actual, 0.000001, "Unexpected bounds array")
+
+    def test_unified_can_handle_singleton_landmarks(self):
+        galaxy = self.set_up_zarushagar_sector()
+
+        foo = LandmarksTriaxialExtremes(galaxy)
+        landmarks = foo.get_landmarks(index=True)[0]
+        graph = galaxy.stars
+        stars = list(graph.nodes)
+        source = stars[0]
+
+        approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
+        self.assertEqual(1, approx._num_trees)
+
+    def test_verify_near_root_edge_propagates(self):
+        sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
+        jsonfile = self.unpack_filename('PathfindingFiles/single_source_distances_ibara_subsector_from_0101.json')
+
+        sector = SectorDictionary.load_traveller_map_file(sourcefile)
+        delta = DeltaDictionary()
+        delta[sector.name] = sector
+
+        args = self._make_args()
+
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, 1, False)
+        galaxy.output_path = args.output
+
+        galaxy.generate_routes()
+        galaxy.trade.calculate_components()
+
+        graph = galaxy.stars
+        stars = list(graph.nodes)
+        source = stars[0]
+        leafnode = stars[30]
+
+        approx = ApproximateShortestPathForestUnified(source, graph, 0)
+
+        # auxiliary network dijkstra calculation to dish out parent nodes
+        paths = nx.single_source_dijkstra_path(graph, source)
+        right = paths[leafnode][1]
+
+        # seed expected distances
+        with open(jsonfile, 'r') as file:
+            expected_string = json.load(file)
+
+        expected_distances = dict()
+        component = [item for item in stars if graph.nodes[item]['star'].component == graph.nodes[source]['star'].component]
+        for item in component:
+            exp_dist = 0
+            rawstar = graph.nodes[item]['star']
+            if str(rawstar) in expected_string:
+                exp_dist = expected_string[str(rawstar)]
+            expected_distances[item] = exp_dist
+
+        distance_check = list(expected_distances.values()) == approx._distances[:,0]
+        self.assertTrue(distance_check.all(), "Unexpected distances after SPT creation")
+
+        # adjust weight
+        oldweight = galaxy.stars[source][right]['weight']
+        galaxy.stars[source][right]['weight'] -= 1
+        galaxy.trade.star_graph.lighten_edge(source, right, oldweight - 1)
+        approx._graph.lighten_edge(source, right, oldweight - 1)
+
+        # tell SPT weight has changed
+        edge = (source, right)
+
+        for item in expected_distances:
+            if expected_distances[item] > 0 and 'Selsinia (Zarushagar 0201)' != str(graph.nodes[item]['star']):
+                expected_distances[item] -= 1
+
+        approx.update_edges([edge])
+
+        distance_check = list(expected_distances.values()) == approx._distances[:, 0]
+        self.assertTrue(distance_check.all(), "Unexpected distances after SPT restart")
 
     def set_up_zarushagar_sector(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar.sec')

--- a/Tests/Pathfinding/testApproximateShortestPathForest.py
+++ b/Tests/Pathfinding/testApproximateShortestPathForest.py
@@ -103,6 +103,36 @@ class testApproximateShortestPathForest(baseTest):
         approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
         self.assertEqual(1, approx._num_trees)
 
+    def test_unified_can_handle_bulk_lobound_from_singleton_component(self):
+        galaxy = self.set_up_zarushagar_sector()
+
+        foo = LandmarksTriaxialExtremes(galaxy)
+        landmarks = foo.get_landmarks(index=True)
+        graph = galaxy.stars
+        stars = list(graph.nodes)
+        source = stars[0]
+        targ = [item for item in graph if graph.nodes()[item]['star'].component == 1][0]
+
+        approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
+
+        bulk_lo = approx.lower_bound_bulk(stars, targ)
+        self.assertEqual(1129.1666666666667, max(bulk_lo), "Unexpected lobound")
+
+    def test_unified_can_handle_bulk_lobound_to_singleton_component(self):
+        galaxy = self.set_up_zarushagar_sector()
+
+        foo = LandmarksTriaxialExtremes(galaxy)
+        landmarks = foo.get_landmarks(index=True)
+        graph = galaxy.stars
+        stars = list(graph.nodes)
+        source = stars[0]
+        targ = [item for item in graph if graph.nodes()[item]['star'].component == 1][0]
+
+        approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
+
+        bulk_lo = approx.lower_bound_bulk(stars, source)
+        self.assertEqual(float('+inf'), bulk_lo[targ])
+
     def test_verify_near_root_edge_propagates(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
         jsonfile = self.unpack_filename('PathfindingFiles/single_source_distances_ibara_subsector_from_0101.json')


### PR DESCRIPTION
Before this PR, bulk lower-bound calculations in the approx-SP forest involved spinning through each approx-SP tree the forest contained, making the bulk lower-bound call on the tree, and then collecting and reducing the results.

Even though bulk heuristic is now only called once per pathfinding run, its runtime will become an increasing problem (and chunk of overall pathfinding runtime) as:
- tighter upper and lower bounds are generated and used, leading to fewer nodes queued and expanded;
- as more landmarks are added to each connected component (which also tightens lower bounds, causing a double whammy).

Obvious solution is obvious - transform the sequence of N method calls into one such call, leaning on numpy to manipulate the unified distances array in bulk.

Pulling all the distance manipulation into one spot surfaced a couple more tweaks.
Tweak the first - _fastpath_: Memoise _which_ rows of the distance matrix had finite values for a given target node.
If any such rows start infinite for a given target node, they _stay_ infinite (by how the edge-update gubbins work), and the corresponding rows don't have to be retrieved from **self._distances**.
Conversely, if no such rows are infinite, explicitly retrieve _all_ rows, obviating the need to slice **self._distances** by row.
Tweak the second - _speedypath_ : If on fastpath and all nodes are active, we would be implicitly retrieving the entire **self._distances** array by slicing it.  Explicitly retrieve the whole thing instead.

~~Timing changes were within profiling noise, so I can't claim any speedup from the status quo.~~
As at the status quo, Zhodani heartland at route reuse=10 had 809s overall time, 666s pathfinding.
With the fastpath tweaks landed, same setup had 696s overall time, 613s pathfinding.
A 7.9% speedup isn't massive, but it isn't tiny, either, and is nothing to sneeze at.
