### PR TITLE
Speed up jump-graph generation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint with ruff - syntax errors & undefined names
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff --select=E9,F63,F7,F82 --preview PyRoute
+          ruff check --select=E9,F63,F7,F82 --preview PyRoute
       - name: Lint with ruff - configured options
         run: |
           # now run configured options

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -129,12 +129,9 @@ class RouteCalculation(object):
         code1 = star1.tradeCode
         code2 = star2.tradeCode
         if code1.agricultural or code2.agricultural:
-            if (code1.agricultural and code2.needs_agricultural) or \
-               (code1.needs_agricultural and code2.agricultural):
-                btn += 1
+            btn += 1 if code1.match_ag_codes(code2) else 0
         if code1.industrial or code2.industrial:
-            if (code1.nonindustrial and code2.industrial) or (code2.nonindustrial and code1.industrial):
-                btn += 1
+            btn += 1 if code1.match_in_codes(code2) else 0
 
         if not AllyGen.are_allies(star1.alg_code, star2.alg_code):
             btn -= 1

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -129,8 +129,8 @@ class RouteCalculation(object):
         code1 = star1.tradeCode
         code2 = star2.tradeCode
         if code1.agricultural or code2.agricultural:
-            if (code1.agricultural and (code2.nonagricultural or code2.extreme)) or \
-               ((code1.nonagricultural or code1.extreme) and code2.agricultural):
+            if (code1.agricultural and code2.needs_agricultural) or \
+               (code1.needs_agricultural and code2.agricultural):
                 btn += 1
         if code1.industrial or code2.industrial:
             if (code1.nonindustrial and code2.industrial) or (code2.nonindustrial and code1.industrial):

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -145,10 +145,7 @@ class RouteCalculation(object):
         if not distance:
             distance = star1.distance(star2)
 
-        jump_index = bisect.bisect_left(RouteCalculation.btn_jump_range, distance)
-        # if distance <= 3:
-        #    logging.getLogger('PyRoute.TradeCalculation').info("{} -> index {}".format(distance, jump_index))
-        btn += RouteCalculation.btn_jump_mod[jump_index]
+        btn += RouteCalculation.get_btn_offset(distance)
 
         max_btn = (min(star1.wtn, star2.wtn) * 2) + 1
         btn = min(btn, max_btn)
@@ -158,6 +155,12 @@ class RouteCalculation(object):
     def get_passenger_btn(btn, star, neighbor):
         passBTN = btn + star.passenger_btn_mod + neighbor.passenger_btn_mod
         return passBTN
+
+    @staticmethod
+    @functools.cache
+    def get_btn_offset(distance):
+        jump_index = bisect.bisect_left(RouteCalculation.btn_jump_range, distance)
+        return RouteCalculation.btn_jump_mod[jump_index]
 
     @staticmethod
     @functools.cache

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -147,9 +147,7 @@ class RouteCalculation(object):
 
         btn += RouteCalculation.get_btn_offset(distance)
 
-        max_btn = (min(star1.wtn, star2.wtn) * 2) + 1
-        btn = min(btn, max_btn)
-        return btn
+        return min(btn, RouteCalculation.get_max_btn(star1.wtn, star2.wtn))
 
     @staticmethod
     def get_passenger_btn(btn, star, neighbor):
@@ -161,6 +159,13 @@ class RouteCalculation(object):
     def get_btn_offset(distance):
         jump_index = bisect.bisect_left(RouteCalculation.btn_jump_range, distance)
         return RouteCalculation.btn_jump_mod[jump_index]
+
+    @staticmethod
+    @functools.cache
+    def get_max_btn(star_wtn, neighbour_wtn):
+        if neighbour_wtn > star_wtn:
+            return RouteCalculation.get_max_btn(neighbour_wtn, star_wtn)
+        return (min(star_wtn, neighbour_wtn) * 2) + 1
 
     @staticmethod
     @functools.cache

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -99,6 +99,8 @@ class TradeCalculation(RouteCalculation):
         max_dist = self.btn_range[min(max(0, max(star.wtn, neighbor.wtn) - self.min_wtn), 5)]
         # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
+        if dist > max(self.galaxy.max_jump_range, max_dist):
+            return None
         if dist <= max_dist:
             # Only bother getting btn if the route is inside max length
             btn = self.get_btn(star, neighbor, dist)
@@ -108,6 +110,11 @@ class TradeCalculation(RouteCalculation):
                                             btn=btn,
                                             passenger_btn=passBTN)
         return dist
+
+    def _raw_ranges(self):
+        ranges = super(RouteCalculation)._raw_ranges()
+
+        return ranges
 
     def generate_routes(self):
         """

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -121,6 +121,15 @@ class TradeCalculation(RouteCalculation):
                                             passenger_btn=passBTN)
         return dist
 
+    def _raw_ranges(self):
+        ranges = super()._raw_ranges()
+        max_route_dist = max(self.btn_range)
+
+        ranges = ((star, neighbour) for (star, neighbour) in ranges if star.distance(neighbour) <= max_route_dist)
+        self.logger.info("Routes with endpoints more than " + str(max_route_dist) + " pc apart, trimmed")
+
+        return ranges
+
     def generate_routes(self):
         """
         Generate the basic routes between all the stars. This creates two sets

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -105,7 +105,7 @@ class TradeCalculation(RouteCalculation):
 
     def base_range_routes(self, star, neighbor):
         dist = star.distance(neighbor)
-        max_dist = self.btn_range[min(max(0, max(star.wtn, neighbor.wtn) - self.min_wtn), 5)]
+        max_dist = self._max_dist(star.wtn, neighbor.wtn)
         # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
         if dist > max(self.galaxy.max_jump_range, max_dist):
@@ -121,11 +121,18 @@ class TradeCalculation(RouteCalculation):
                                             passenger_btn=passBTN)
         return dist
 
+    @functools.cache
+    def _max_dist(self, star_wtn, neighbour_wtn):
+        if neighbour_wtn < star_wtn:
+            return self._max_dist(neighbour_wtn, star_wtn)
+        return self.btn_range[min(max(0, max(star_wtn, neighbour_wtn) - self.min_wtn), 5)]
+
     def _raw_ranges(self):
         ranges = super()._raw_ranges()
         max_route_dist = max(self.btn_range)
 
-        ranges = ((star, neighbour) for (star, neighbour) in ranges if star.distance(neighbour) <= max_route_dist)
+        ranges = ((star, neighbour) for (star, neighbour) in ranges
+                  if star.distance(neighbour) <= max_route_dist)
         self.logger.info("Routes with endpoints more than " + str(max_route_dist) + " pc apart, trimmed")
 
         return ranges

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -108,7 +108,7 @@ class TradeCalculation(RouteCalculation):
         max_dist = self._max_dist(star.wtn, neighbor.wtn)
         # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
-        if dist > max(self.galaxy.max_jump_range, max_dist):
+        if dist > max_dist and dist > self.galaxy.max_jump_range:
             return None
 
         if dist <= max_dist:

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -122,17 +122,20 @@ class TradeCalculation(RouteCalculation):
         return dist
 
     @functools.cache
-    def _max_dist(self, star_wtn, neighbour_wtn):
+    def _max_dist(self, star_wtn, neighbour_wtn, maxjump=False):
         if neighbour_wtn < star_wtn:
-            return self._max_dist(neighbour_wtn, star_wtn)
-        return self.btn_range[min(max(0, max(star_wtn, neighbour_wtn) - self.min_wtn), 5)]
+            return self._max_dist(neighbour_wtn, star_wtn, maxjump)
+        max_dist = self.btn_range[min(max(0, max(star_wtn, neighbour_wtn) - self.min_wtn), 5)]
+        if maxjump:
+            return max(max_dist, self.galaxy.max_jump_range)
+        return max_dist
 
     def _raw_ranges(self):
         ranges = super()._raw_ranges()
         max_route_dist = max(self.btn_range)
 
         ranges = ((star, neighbour) for (star, neighbour) in ranges
-                  if star.distance(neighbour) <= max_route_dist)
+                  if star.distance(neighbour) <= self._max_dist(star.wtn, neighbour.wtn, True))
         self.logger.info("Routes with endpoints more than " + str(max_route_dist) + " pc apart, trimmed")
 
         return ranges

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -48,7 +48,7 @@ class TradeCalculation(RouteCalculation):
     # and the system checks every other world in that range for trade 
     # opportunity. See the btn_jump_mod and min btn to see how  
     # worlds are excluded from this list. 
-    btn_range = [2, 9, 29, 59, 99, 299]
+    btn_range = [2, 9, 29, 59, 99, 299, 599]
 
     # Maximum WTN to process routes for
     max_wtn = 15
@@ -125,7 +125,7 @@ class TradeCalculation(RouteCalculation):
     def _max_dist(self, star_wtn, neighbour_wtn, maxjump=False):
         if neighbour_wtn < star_wtn:
             return self._max_dist(neighbour_wtn, star_wtn, maxjump)
-        max_dist = self.btn_range[min(max(0, max(star_wtn, neighbour_wtn) - self.min_wtn), 5)]
+        max_dist = self.btn_range[min(max(0, max(star_wtn, neighbour_wtn) - self.min_wtn), 6)]
         if maxjump:
             return max(max_dist, self.galaxy.max_jump_range)
         return max_dist

--- a/PyRoute/Pathfinding/ApproximateShortestPathTreeDistanceGraph.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathTreeDistanceGraph.py
@@ -62,12 +62,17 @@ class ApproximateShortestPathTreeDistanceGraph(ApproximateShortestPathTree):
                                                                          seeds=dropnodes, divisor=self._divisor)
 
     def lower_bound(self, source, target):
-        return abs(self._distances[source] - self._distances[target])
+        result = abs(self._distances[source] - self._distances[target])
+        if np.isinf(result):
+            return 0
+        return result
 
     def lower_bound_bulk(self, active_nodes, target):
         if self.floatinf == self._distances[target]:
             return np.zeros(len(active_nodes))
         result = np.abs(self._distances[active_nodes] - self._distances[target])
+        # Zero out infinite results, to keep the bulk heuristic consistent
+        result[np.isinf(result)] = 0
         return result
 
     def triangle_upbound(self, source, target):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -417,11 +417,11 @@ class TradeCodes(object):
     def rich(self):
         return 'Ri' in self.codeset
 
-    @property
+    @functools.cached_property
     def industrial(self):
         return 'In' in self.codeset
 
-    @property
+    @functools.cached_property
     def agricultural(self):
         return 'Ag' in self.codeset
 

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -405,15 +405,15 @@ class TradeCodes(object):
             return [code if len(code) > 6 else 'C:' + sector_name[0:4] + '-' + code[2:]
                     for code in self.owned if code.startswith('C:')]
 
-    @property
+    @functools.cached_property
     def homeworld(self):
         return sorted(self.homeworld_list)
 
-    @property
+    @functools.cached_property
     def sophonts(self):
         return sorted(self.sophont_list)
 
-    @property
+    @functools.cached_property
     def rich(self):
         return 'Ri' in self.codeset
 
@@ -429,75 +429,75 @@ class TradeCodes(object):
     def needs_agricultural(self):
         return self.nonagricultural or self.extreme
 
-    @property
+    @functools.cached_property
     def poor(self):
         return 'Po' in self.codeset
 
-    @property
+    @functools.cached_property
     def nonagricultural(self):
         return 'Na' in self.codeset
 
-    @property
+    @functools.cached_property
     def barren(self):
         return 'Ba' in self.codeset or 'Di' in self.codeset
 
-    @property
+    @functools.cached_property
     def low(self):
         return 'Lo' in self.codeset
 
-    @property
+    @functools.cached_property
     def nonindustrial(self):
         return 'Ni' in self.codeset
 
-    @property
+    @functools.cached_property
     def high(self):
         return 'Hi' in self.codeset
 
-    @property
+    @functools.cached_property
     def asteroid(self):
         return 'As' in self.codeset
 
-    @property
+    @functools.cached_property
     def desert(self):
         return 'De' in self.codeset
 
-    @property
+    @functools.cached_property
     def fluid(self):
         return 'Fl' in self.codeset
 
-    @property
+    @functools.cached_property
     def vacuum(self):
         return 'Va' in self.codeset and 'As' not in self.codeset
 
-    @property
+    @functools.cached_property
     def waterworld(self):
         return 'Wa' in self.codeset or 'Oc' in self.codeset
 
-    @property
+    @functools.cached_property
     def extreme(self):
         return len(self.ex_codes & set(self.codeset)) > 0
 
-    @property
+    @functools.cached_property
     def capital(self):
         return 'Cp' in self.dcode or 'Cx' in self.dcode or 'Cs' in self.dcode
 
-    @property
+    @functools.cached_property
     def subsector_capital(self):
         return 'Cp' in self.dcode
 
-    @property
+    @functools.cached_property
     def sector_capital(self):
         return 'Cs' in self.dcode
 
-    @property
+    @functools.cached_property
     def other_capital(self):
         return 'Cx' in self.dcode
 
-    @property
+    @functools.cached_property
     def research_station(self):
         return set(self.research.keys()).intersection(self.dcode)
 
-    @property
+    @functools.cached_property
     def research_station_char(self):
         stations = self.research_station
         if len(stations) == 1:
@@ -506,11 +506,11 @@ class TradeCodes(object):
         else:
             return None
 
-    @property
+    @functools.cached_property
     def pcode_color(self):
         return self.pcolor.get(self.pcode, '#44ff44')
 
-    @property
+    @functools.cached_property
     def low_per_capita_gwp(self):
         return self.extreme or self.poor or self.nonindustrial or self.low
 

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -3,6 +3,7 @@ Created on Oct 3, 2017
 
 @author: tjoneslo
 """
+import functools
 import itertools
 import re
 import logging
@@ -423,6 +424,10 @@ class TradeCodes(object):
     @property
     def agricultural(self):
         return 'Ag' in self.codeset
+
+    @functools.cached_property
+    def needs_agricultural(self):
+        return self.nonagricultural or self.extreme
 
     @property
     def poor(self):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -514,6 +514,12 @@ class TradeCodes(object):
     def low_per_capita_gwp(self):
         return self.extreme or self.poor or self.nonindustrial or self.low
 
+    def match_ag_codes(self, code):
+        return (self.agricultural and code.needs_agricultural) or (self.needs_agricultural and code.agricultural)
+
+    def match_in_codes(self, code):
+        return (self.industrial and code.nonindustrial) or (self.nonindustrial and code.industrial)
+
     def is_well_formed(self):
         msg = ""
         for code in self.codeset:

--- a/Tests/Pathfinding/testApproximateShortestPathTree.py
+++ b/Tests/Pathfinding/testApproximateShortestPathTree.py
@@ -138,7 +138,7 @@ class testApproximateShortestPathTree(baseTest):
 
         result = approx.lower_bound_bulk(active_nodes, target)
         self.assertIsNotNone(result)
-        expected = np.array([57.5, 56.666667, 0])
+        expected = np.array([57.5, 56.667, 0])
         np.testing.assert_array_almost_equal(expected, result, 0.000001, "Unexpected bounds array")
 
     def test_drop_first_level_intermediate_nodes_in_same_component(self):
@@ -293,6 +293,7 @@ class testApproximateShortestPathTree(baseTest):
 
         graph = galaxy.stars
         stars = list(graph.nodes)
+        self.assertEqual(37, len(stars))
         source = stars[0]
         leafnode = stars[30]
 

--- a/Tests/testTradeCalculation.py
+++ b/Tests/testTradeCalculation.py
@@ -145,6 +145,27 @@ class testTradeCalculation(unittest.TestCase):
         tradecalc.multilateral_balance_trade()
         tradecalc.is_sector_trade_balanced()
 
+    def test_max_dist(self):
+        galaxy = Galaxy(min_btn=13)
+        tradecalc = TradeCalculation(galaxy)
+        self.assertEqual(8, tradecalc.min_wtn)
+
+        cand_wtn = [
+            (8, 2),
+            (9, 9),
+            (10, 29),
+            (11, 59),
+            (12, 99),
+            (13, 299),
+            (14, 299),
+            (15, 299),
+        ]
+
+        for wtn, exp_dist in cand_wtn:
+            with self.subTest(msg="WTN " + str(wtn)):
+                act_dist = tradecalc._max_dist(wtn, wtn)
+                self.assertEqual(exp_dist, act_dist)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/testTradeCalculation.py
+++ b/Tests/testTradeCalculation.py
@@ -157,8 +157,8 @@ class testTradeCalculation(unittest.TestCase):
             (11, 59),
             (12, 99),
             (13, 299),
-            (14, 299),
-            (15, 299),
+            (14, 599),
+            (15, 599),
         ]
 
         for wtn, exp_dist in cand_wtn:


### PR DESCRIPTION
Speed up trade graph generation by increasing the amount of work not done:

Memoise things that are hit repeatedly in tight loops:
1.  Whether systems are agricultural, or need an agricultural partner;
2. Likewise for industrial systems/partners;
3. BTN distance penalties;
4. Maximum distance values given endpoint WTNs;

Filter distance-busts from _candidate_ route list up front, rather than spinning through the entirety of the **RouteCalculation.generate_base_routes()** malarkey.

And finally, filter out more doomed route candidates:
L153 of status-quo **RouteCalculation** quoth:
`max_btn = (min(star1.wtn, star2.wtn) * 2) + 1`

This combines with the specified minimum route BTN to imply (letting largest doubled-WTN that can't support a trade route be W):
```
min_route_btn > W * 2 + 1
min_route_btn - 1 > W * 2
(min_route_btn - 1) / 2 > W
W < (min_route_btn - 1) / 2
```
As W must be integral, the RHS rounds down
`W < (min_route_btn - 1) // 2`

Frinstance, with a min_route_btn setting of 11 (goes one louder), the W threshold becomes 5 - doubled Star WTN values less than 5 need to be filtered out of _route_ generation, but not _edge_ generation.  Although such stars can't support trade routes on their own, trade routes connecting other systems can still flow through them.

Likewise, the default min_route_btn setting of 13 implies a W threshold of 6.  As does a min_route_btn setting of 14.

Adding that to **TradeCalculation.base_route_filter()** as a bilateral filter was easier, even though it was actually a unilateral filter, than deconvolving the existing range and link filtering.


Over the 32 imperial sectors, status quo route generation:
2024-03-30 18:25:11,699 - INFO - generating jumps...
2024-03-30 18:33:46,852 - INFO - base routes: 145219  -  ranges: 835401
2024-03-30 18:33:46,853 - INFO - calculating routes...
2024-03-30 18:33:47,579 - INFO - Final route count 142326

Graph generation took 8 min 36s on my box, or 516s.

With this PR:
2024-03-30 18:09:10,126 - INFO - generating jumps...
2024-03-30 18:09:10,315 - INFO - Routes with endpoints more than 599 pc apart, trimmed
2024-03-30 18:15:13,846 - INFO - base routes: 145219  -  ranges: 835401
2024-03-30 18:15:13,846 - INFO - calculating routes...
2024-03-30 18:15:14,589 - INFO - Final route count 142326

Graph generation now takes 6 min 4 s on my box, or 364s.

It's a small speedup - 29% less time taken to generate the graph - off the second biggest chunk of runtime in the full-charted-space run (pathfinding dominates graph generation less with smaller input sizes).  I took the chance to incorporate @tjoneslo 's feedback to resolve #104  while I was at it.