### PR TITLE
Add debug option to fix pop-based trade codes in flight

### DIFF
--- a/PyRoute/DataClasses/ReadSectorOptions.py
+++ b/PyRoute/DataClasses/ReadSectorOptions.py
@@ -1,0 +1,19 @@
+"""
+Created on Apr 04, 2023
+
+@author: CyberiaResurrection
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReadSectorOptions:
+    sectors: list
+    pop_code: str = 'scaled'
+    ru_calc: str = 'scaled'
+    route_reuse: int = 10
+    trade_choice: str = 'trade'
+    route_btn: int = 13
+    mp_threads: int = 1
+    debug_flag: bool = False
+    fix_pop: bool = False

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -60,9 +60,9 @@ class DeltaStar(Star):
         return DeltaStar.reduce(original, drop_trade_codes=True, drop_base_codes=True, reset_port=True, reset_tl=True)
 
     @staticmethod
-    def parse_line_into_star(line, sector, pop_code, ru_calc):
+    def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False):
         star = DeltaStar()
-        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc)
+        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop)
 
     def reduce_routes(self):
         self.routes = []

--- a/PyRoute/DrawArcsTest.py
+++ b/PyRoute/DrawArcsTest.py
@@ -2,6 +2,8 @@ import os
 import logging
 import math
 import itertools
+
+from DataClasses.ReadSectorOptions import ReadSectorOptions
 from .SubsectorMap2 import GraphicSubsectorMap
 from .Galaxy import Galaxy
 from PIL import Image, ImageDraw, ImageFont
@@ -171,9 +173,11 @@ def set_logging(level):
 
 if __name__ == '__main__':
     set_logging('INFO')
+    options = ReadSectorOptions(sectors=['./sectors/TNE/SpinwardMarches.sec'], pop_code='fixed', ru_calc='collapse')
     galaxy = Galaxy(15, 4, 8)
     galaxy.output_path = '.'
-    galaxy.read_sectors(['./sectors/TNE/SpinwardMarches.sec'], 'fixed', 'collapse')
+    # galaxy.read_sectors(['./sectors/TNE/SpinwardMarches.sec'], 'fixed', 'collapse')
+    galaxy.read_sectors(options)
     galaxy.set_borders('erode', 'collapse')
 
     graphMap = DrawArcsTest(galaxy, None)

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -413,7 +413,7 @@ class Galaxy(AreaItem):
         return state
 
     def read_sectors(self, sectors, pop_code, ru_calc,
-                     route_reuse, trade_choice, route_btn, mp_threads, debug_flag):
+                     route_reuse, trade_choice, route_btn, mp_threads, debug_flag, fix_pop=False):
         self._set_trade_object(route_reuse, trade_choice, route_btn, mp_threads, debug_flag)
         star_counter = 0
         loaded_sectors = set()
@@ -457,7 +457,7 @@ class Galaxy(AreaItem):
             for line in lines[lineno + 2:]:
                 if line.startswith('#') or len(line) < 20:
                     continue
-                star = Star.parse_line_into_star(line, sec, pop_code, ru_calc)
+                star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
                 if star:
                     assert star not in sec.worlds, "Star " + str(star) + " duplicated in sector " + str(sec)
                     star.index = star_counter

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -22,6 +22,7 @@ from PyRoute.Calculation.CommCalculation import CommCalculation
 from PyRoute.Calculation.OwnedWorldCalculation import OwnedWorldCalculation
 from PyRoute.Calculation.NoneCalculation import NoneCalculation
 from PyRoute.Calculation.XRouteCalculation import XRouteCalculation
+from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
 from PyRoute.Pathfinding.RouteLandmarkGraph import RouteLandmarkGraph
 from PyRoute.StatCalculation import ObjectStatistics
 from PyRoute.AllyGen import AllyGen
@@ -412,8 +413,19 @@ class Galaxy(AreaItem):
         del state['alg_sorted']
         return state
 
-    def read_sectors(self, sectors, pop_code, ru_calc,
-                     route_reuse, trade_choice, route_btn, mp_threads, debug_flag, fix_pop=False):
+    # def read_sectors(self, sectors, pop_code, ru_calc,
+    #                 route_reuse, trade_choice, route_btn, mp_threads, debug_flag, fix_pop=False):
+    def read_sectors(self, options):
+        assert isinstance(options, ReadSectorOptions)
+        route_reuse = options.route_reuse
+        trade_choice = options.trade_choice
+        route_btn = options.route_btn
+        mp_threads = options.mp_threads
+        debug_flag = options.debug_flag
+        sectors = options.sectors
+        pop_code = options.pop_code
+        ru_calc = options.ru_calc
+        fix_pop = options.fix_pop
         self._set_trade_object(route_reuse, trade_choice, route_btn, mp_threads, debug_flag)
         star_counter = 0
         loaded_sectors = set()

--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -124,7 +124,10 @@ class ParseStarInput:
                          'Resources': Utilities.ehex_to_int(star.economics[1]) if star.economics else 0
                          }
 
-        star.check_ex()
+        if fix_pop is True:
+            star.fix_ex()
+        else:
+            star.check_ex()
         star.check_cx()
 
         star.calculate_wtn()

--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -35,7 +35,7 @@ class ParseStarInput:
     transformer = None
 
     @staticmethod
-    def parse_line_into_star_core(star, line, sector, pop_code, ru_calc):
+    def parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=False):
         star.sector = sector
         star.logger.debug(line)
         data = ParseStarInput._unpack_starline(star, line)
@@ -97,7 +97,7 @@ class ParseStarInput:
         star.starportBudget = 0
         star.starportPop = 0
 
-        star.tradeCode.check_world_codes(star)
+        star.tradeCode.check_world_codes(star, fix_pop=fix_pop)
 
         if data[5]:
             imp = int(data[5][1:-1].strip())

--- a/PyRoute/Outputs/GraphMap.py
+++ b/PyRoute/Outputs/GraphMap.py
@@ -1,6 +1,8 @@
 from itertools import product
 import logging
 from PIL import Image, ImageDraw
+
+from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
 from PyRoute.Galaxy import Galaxy
 from PyRoute.Outputs.HexMap import HexMap
 from PyRoute.route import route
@@ -137,8 +139,8 @@ if __name__ == '__main__':
     route.set_logging('INFO')
     galaxy = Galaxy(8)
     galaxy.output_path = '../DeltaDebug'
-    galaxy.read_sectors(['../sectors_review/Spica.sec'],
-                        'fixed', 'collapse')
+    options = ReadSectorOptions(sectors=['../sectors_review/Spica.sec'], pop_code='fixed', ru_calc='collapse')
+    # galaxy.read_sectors(['../sectors_review/Spica.sec'], 'fixed', 'collapse')
     galaxy.set_borders('range', 'collapse')
     hexMap = GraphMap(galaxy, None)
     hexMap.write_dot_map()

--- a/PyRoute/Outputs/SubsectorMap2.py
+++ b/PyRoute/Outputs/SubsectorMap2.py
@@ -7,6 +7,7 @@ import os
 import logging
 import math
 
+from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
 from PyRoute.Position.Hex import Hex
 from PyRoute.Outputs.GraphicMap import GraphicMap
 from PyRoute.Galaxy import Galaxy
@@ -541,7 +542,9 @@ if __name__ == '__main__':
     # route.set_logging('DEBUG')
     galaxy = Galaxy(15, 4, 8)
     galaxy.output_path = '.'
-    galaxy.read_sectors(['../sectors_tne/SpinwardMarches.sec'], 'fixed', 'collapse')
+    options = ReadSectorOptions(sectors=['../sectors_tne/SpinwardMarches.sec'], pop_code='fixed', ru_calc='collapse')
+    # galaxy.read_sectors(['../sectors_tne/SpinwardMarches.sec'], 'fixed', 'collapse')
+    galaxy.read_sectors(options)
     galaxy.set_borders('erode', 'collapse')
 
     graphMap = GraphicSubsectorMap(galaxy, None)

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -397,6 +397,36 @@ class Star(object):
             self.logger.warning('{} - EX Calculated infrastructure {} not in range 0 - {}'.
                                 format(self, infrastructure, 12 + self.importance))
 
+    def fix_ex(self):
+        if not self.economics:
+            return
+
+        labor = self._ehex_to_int(self.economics[2])
+        infrastructure = self._ehex_to_int(self.economics[3])
+
+        if labor != max(self.popCode - 1, 0):
+            nu_labour = self._int_to_ehex(max(self.popCode - 1, 0))
+            self.economics = self.economics[0:2] + nu_labour + self.economics[3:]
+
+        nu_infrastructure = None
+        if self.tradeCode.barren and infrastructure != 0:
+            nu_infrastructure = '0'
+        elif self.tradeCode.low and infrastructure != max(self.importance, 0):
+            nu_infrastructure = self._int_to_ehex(max(self.importance, 0))
+        elif self.tradeCode.nonindustrial and not 0 <= infrastructure <= 6 + self.importance:
+            if 0 > infrastructure:
+                nu_infrastructure = '0'
+            else:
+                nu_infrastructure = self._int_to_ehex(6 + self.importance)
+        elif not 0 <= infrastructure <= 12 + self.importance:
+            if 0 > infrastructure:
+                nu_infrastructure = '0'
+            else:
+                nu_infrastructure = self._int_to_ehex(12 + self.importance)
+
+        if nu_infrastructure is not None:
+            self.economics = self.economics[0:3] + nu_infrastructure + self.economics[4:]
+
     def check_cx(self):
         if not self.economics:
             return

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -122,10 +122,10 @@ class Star(object):
         setattr(self, key, value)
 
     @staticmethod
-    def parse_line_into_star(line, sector, pop_code, ru_calc):
+    def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False):
         from PyRoute.Inputs.ParseStarInput import ParseStarInput
         star = Star()
-        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc)
+        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop)
 
     def parse_to_line(self):
         result = str(self.position) + " "

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -353,11 +353,7 @@ class TradeCodes(object):
         check = self._check_planet_code(star, 'Va', None, '0', None, msg) and check
         check = self._check_planet_code(star, 'Wa', '3456789', '3456789DEF', 'A', msg) and check
 
-        check = self._check_pop_code(star, 'Ba', '0', msg) and check
-        check = self._check_pop_code(star, 'Lo', '123', msg) and check
-        check = self._check_pop_code(star, 'Ni', '456', msg) and check
-        check = self._check_pop_code(star, 'Ph', '8', msg) and check
-        check = self._check_pop_code(star, 'Hi', '9ABCD', msg) and check
+        check = self._check_all_pop_codes(check, msg, star)
 
         check = self._check_econ_code(star, 'Pa', '456789', '45678', '48', msg) and check
         check = self._check_econ_code(star, 'Ag', '456789', '45678', '567', msg) and check
@@ -368,6 +364,14 @@ class TradeCodes(object):
         check = self._check_econ_code(star, 'Ri', '68', None, '678', msg) and check
         if is_list:
             return msg
+        return check
+
+    def _check_all_pop_codes(self, check, msg, star):
+        check = self._check_pop_code(star, 'Ba', '0', msg) and check
+        check = self._check_pop_code(star, 'Lo', '123', msg) and check
+        check = self._check_pop_code(star, 'Ni', '456', msg) and check
+        check = self._check_pop_code(star, 'Ph', '8', msg) and check
+        check = self._check_pop_code(star, 'Hi', '9ABCD', msg) and check
         return check
 
     def owned_by(self, star):
@@ -656,11 +660,7 @@ class TradeCodes(object):
         self._fix_econ_code(star, 'In', '012479ABC', None, '9ABCD')
         self._fix_econ_code(star, 'Ri', '68', None, '678')
 
-        self._fix_pop_code(star, 'Ba', '0')
-        self._fix_pop_code(star, 'Lo', '123')
-        self._fix_pop_code(star, 'Ni', '456')
-        self._fix_pop_code(star, 'Ph', '8')
-        self._fix_pop_code(star, 'Hi', '9ABCD')
+        self._fix_all_pop_codes(star)
 
     def _fix_trade_code(self, star, code, size, atmo, hydro):
         size = '0123456789ABC' if size is None else size
@@ -704,6 +704,13 @@ class TradeCodes(object):
             self._drop_invalid_trade_code(code)
         elif pop_match and not code_match:
             self._add_missing_trade_code(code)
+
+    def _fix_all_pop_codes(self, star):
+        self._fix_pop_code(star, 'Ba', '0')
+        self._fix_pop_code(star, 'Lo', '123')
+        self._fix_pop_code(star, 'Ni', '456')
+        self._fix_pop_code(star, 'Ph', '8')
+        self._fix_pop_code(star, 'Hi', '9ABCD')
 
     def _drop_invalid_trade_code(self, targcode):
         self.codes = [code for code in self.codes if code != targcode]

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -338,7 +338,7 @@ class TradeCodes(object):
             self.logger.error(msg)
         return False
 
-    def check_world_codes(self, star, msg=None):
+    def check_world_codes(self, star, msg=None, fix_pop=False):
         is_list = isinstance(msg, list)
         msg = msg if is_list else None
         check = True
@@ -353,7 +353,10 @@ class TradeCodes(object):
         check = self._check_planet_code(star, 'Va', None, '0', None, msg) and check
         check = self._check_planet_code(star, 'Wa', '3456789', '3456789DEF', 'A', msg) and check
 
-        check = self._check_all_pop_codes(check, msg, star)
+        if fix_pop is True:
+            self._fix_all_pop_codes(star)
+        else:
+            check = self._check_all_pop_codes(check, msg, star)
 
         check = self._check_econ_code(star, 'Pa', '456789', '45678', '48', msg) and check
         check = self._check_econ_code(star, 'Ag', '456789', '45678', '567', msg) and check

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -341,7 +341,11 @@ class TradeCodes(object):
     def check_world_codes(self, star, msg=None, fix_pop=False):
         is_list = isinstance(msg, list)
         msg = msg if is_list else None
+
         check = True
+        if fix_pop is True:
+            self._fix_all_pop_codes(star)
+
         check = self._check_planet_code(star, 'As', '0', '0', '0', msg) and check
         check = self._check_planet_code(star, 'De', None, '23456789', '0', msg) and check
         check = self._check_planet_code(star, 'Fl', None, 'ABC', '123456789A', msg) and check
@@ -353,9 +357,7 @@ class TradeCodes(object):
         check = self._check_planet_code(star, 'Va', None, '0', None, msg) and check
         check = self._check_planet_code(star, 'Wa', '3456789', '3456789DEF', 'A', msg) and check
 
-        if fix_pop is True:
-            self._fix_all_pop_codes(star)
-        else:
+        if fix_pop is not True:
             check = self._check_all_pop_codes(check, msg, star)
 
         check = self._check_econ_code(star, 'Pa', '456789', '45678', '48', msg) and check

--- a/PyRoute/WikiCreateWorlds.py
+++ b/PyRoute/WikiCreateWorlds.py
@@ -7,6 +7,8 @@ Created on Dec 27, 2017
 import logging
 import argparse
 import os
+
+from DataClasses.ReadSectorOptions import ReadSectorOptions
 from .Galaxy import Galaxy
 from .WikiReview import WikiReview
 from wikitools.page import Page
@@ -240,7 +242,9 @@ No information yet available.
 
     def read_sector(self, sectors):
         galaxy = Galaxy(12)
-        galaxy.read_sectors(sectors, 'fixed', 'scaled')
+        options = ReadSectorOptions(sectors=sectors, pop_code='fixed', ru_calc='collapse')
+        # galaxy.read_sectors(sectors, 'fixed', 'scaled')
+        galaxy.read_sectors(options)
         return galaxy
 
 

--- a/PyRoute/route.py
+++ b/PyRoute/route.py
@@ -9,6 +9,8 @@ import argparse
 import logging
 import codecs
 import os
+
+from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
 from PyRoute.Galaxy import Galaxy
 from PyRoute.SpeculativeTrade import SpeculativeTrade
 from PyRoute.Outputs.HexMap import HexMap
@@ -99,9 +101,14 @@ def process():
         else:
             logger.warning(sector + " is duplicated")
 
-    galaxy.read_sectors(sectors_list, args.pop_code, args.ru_calc,
-                        args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag,
-                        fix_pop=args.fix_pop)
+    readparms = ReadSectorOptions(sectors=sectors_list, pop_code=args.pop_code, ru_calc=args.ru_calc,
+                                  route_reuse=args.route_reuse, trade_choice=args.routes, route_btn=args.route_btn,
+                                  mp_threads=args.mp_threads, debug_flag=args.debug_flag, fix_pop=args.fix_pop)
+    galaxy.read_sectors(readparms)
+
+    # galaxy.read_sectors(sectors_list, args.pop_code, args.ru_calc,
+    #                    args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag,
+    #                    fix_pop=args.fix_pop)
 
     logger.info("%s sectors read" % len(galaxy.sectors))
 

--- a/PyRoute/route.py
+++ b/PyRoute/route.py
@@ -72,6 +72,8 @@ def process():
     debugging = parser.add_argument_group('Debug', "Debugging flags")
     debugging.add_argument('--debug', dest="debug_flag", default=False, action=argparse.BooleanOptionalAction,
                            help="Turn on trade-route debugging")
+    debugging.add_argument('--fix-pop', dest="fix_pop", default=False, action=argparse.BooleanOptionalAction,
+                           help="Fix incorrect pop codes when loading stars")
 
     parser.add_argument('--version', action='version', version='%(prog)s 0.4')
     parser.add_argument('--log-level', default='INFO')
@@ -98,7 +100,8 @@ def process():
             logger.warning(sector + " is duplicated")
 
     galaxy.read_sectors(sectors_list, args.pop_code, args.ru_calc,
-                        args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
+                        args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag,
+                        fix_pop=args.fix_pop)
 
     logger.info("%s sectors read" % len(galaxy.sectors))
 


### PR DESCRIPTION
I got tired of 3 megabytes+ of crap filling up the logs of full-orchestra charted space runs, which I generally have to leave running overnight.

A shufti showed ~60% of those on the Dec 23, 2023 TravellerMap data were invalid/missing population trade code complaints (including the infamous 'Ba Lo Ni' combo on actually-barren systems).

Thus, I added a fix_pop debug option, to fix those problems as their respective starlines were parsed, which did the following:
approx 25,700 parsing complaints as at status quo;
approx 10,770 parsing complaints as at this PR;
that giving a 58.0% net reduction in the number of complaints filling up the logs in a full-orchestra run, and (big surprise) reducing crap buildup by ~1.8 megabytes.

The remaining trade-code related complaints (using the categorisation in TradeCodes) not addressed by this PR break down as:
|Code | Type | Invalid | Calculated | Total |
| ----- | -----: |  -----: |  -----: |  -----: |
| Ag | Econ | 502 | 122 | 624 |
| In | Econ | 496 | 224 | 720 |
| Na | Econ | 154 | 138 | 292 |
| Pa | Econ | 0 | 1,228 | 1,228 |
| Pi | Econ | 0 | 1,552 | 1,552 |
| Pr | Econ | 12 | 902 | 914 |
| Ri | Econ | 98 | 622 | 720 |
| **Econ** | **Subtotal** | **1,262** | **4,788** | **6,050** |
| As | Planet | 2 | 6 | 8 |
| De | Planet | 226 | 37 | 263 |
| Fl | Planet | 204 | 41 | 245 |
| Ga | Planet | 6 | 865 | 871 |
| He | Planet | 1 | 1,141 | 1,142 |
| Ic | Planet | 1 | 33 | 34 |
| Oc | Planet | 7 | 97 | 104 |
| Po | Planet | 86 | 74 | 160 |
| Va | Planet | 2 | 604 | 606 |
| Wa | Planet | 177 | 29 | 206 |
| **Planet** | **Subtotal** | **712** | **2,927** | **3,639** |
| **GRAND** | **TOTAL** | **1,974** | **7,715** | **9,689** |

The remaining 1,081 complaints break down as:

Disallowed residual trade code - 38
Importance mismatch - 11
Acceptance mismatch - 927
Symbols mismatch - 2
Misc - 103