### PR TITLE
Tune Astar

### DIFF
--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -297,7 +297,8 @@ class TradeCalculation(RouteCalculation):
 
             mincost = self.star_graph.min_cost(active_nodes, target.index, indirect=True)
             rawroute, diag = astar_path_numpy(self.star_graph, star.index, target.index,
-                                           self.galaxy.heuristic_distance_bulk, min_cost=mincost, upbound=upbound)
+                                              self.galaxy.heuristic_distance_bulk, min_cost=mincost, upbound=upbound,
+                                              diagnostics=self.debug_flag)
 
             if self.debug_flag:
                 moshdex = np.where(self.pathfinding_data['branch_factor'] == -1.0)[0][0]

--- a/PyRoute/Galaxy.py
+++ b/PyRoute/Galaxy.py
@@ -771,19 +771,9 @@ class Galaxy(AreaItem):
     def heuristic_distance_bulk(self, active_nodes, target):
         raw = self.trade.shortest_path_tree.lower_bound_bulk(active_nodes, target)
         distances = self.trade.star_graph.distances_from_target(active_nodes, target)
+        # Case-wise maximum of 2 or more admissible heuristics (approx-SP bound, existing route distances) is itself
+        # admissible
         raw = np.maximum(raw, distances)
-
-        # The minimum edge cost on each node is itself an admissible heuristic:
-        # If u is the target, min-edge-cost is special-cased to 0, which equals the cost to target.
-        # If the target is connected to node u via the least-cost edge, u's min-edge-cost equals the cost to target.
-        # If the target is connected to node u via some other edge, u's min-edge-cost underestimates cost to target.
-        # If the target is not directly connected to node u, the target is at least the sum of two nodes' min-edge costs
-        # away, so u's min-edge-cost again underestimates cost to target.
-        min_cost = self.trade.star_graph.min_cost(active_nodes, target, indirect=True)
-
-        # Case-wise maximum of 2 or more admissible heuristics (approx-SP bound, existing route distances and min-cost
-        # edges) is itself admissible
-        raw = np.maximum(raw, min_cost)
 
         return 1.005 * raw
 

--- a/PyRoute/Pathfinding/LandmarkSchemes/LandmarksTriaxialExtremes.py
+++ b/PyRoute/Pathfinding/LandmarkSchemes/LandmarksTriaxialExtremes.py
@@ -190,4 +190,4 @@ class LandmarksTriaxialExtremes:
 
     @staticmethod
     def _size_to_landmarks(size):
-        return math.ceil(3 * math.log10(size))
+        return math.ceil(4 * math.log10(size))

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -51,7 +51,7 @@ def _calc_branching_factor(nodes_queued, path_len):
     return round(new, 3)
 
 
-def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=None):
+def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=None, diagnostics=False):
 
     G_succ = G._arcs  # For speed-up
 
@@ -98,6 +98,8 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
                 path.append(node)
                 node = explored[node]
             path.reverse()
+            if diagnostics is not True:
+                return path, {}
             branch = _calc_branching_factor(queue_counter, len(path) - 1)
             neighbour_bound = node_counter - 1 + revis_continue - revisited
             un_exhausted = neighbour_bound - f_exhausted - g_exhausted - targ_exhausted

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -193,14 +193,15 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             # As we have a tighter upper bound, apply it to the neighbours as well
             keep = np.logical_and(keep, augmented_weights < upbound)
             active_nodes = active_nodes[keep]
-            active_weights = active_weights[keep]
-            augmented_weights = augmented_weights[keep]
 
             # if there _was_ one neighbour to process, that was the target, so neighbour list is now empty.
             # Likewise, if the new upper bound has emptied the neighbour list, go around.
             if 1 == num_neighbours or 0 == len(active_nodes):
                 targ_exhausted += 1
                 continue
+
+            active_weights = active_weights[keep]
+            augmented_weights = augmented_weights[keep]
 
         # Now we have the latest upper bound, use it to filter out nodes whose augmented weights will bust the upper
         # bound. We still need to _queue_ the bound-busting nodes' active costs, as that allows us to dodge about a

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -169,15 +169,16 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             up_threshold = upbound - min_cost
             if 0 < len(queue):
                 queue = [item for item in queue if item[0] < upbound]
-                # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
-                queue = [item for item in queue if not (item[1] > distances[item[2]])]
-                # And while we're here, trim elements who are too close to upbound
-                queue = [item for item in queue if item[1] + min_cost[item[2]] <= upbound]
-                # Finally, dedupe the queue after cleaning all bound-busts out and 2 or more elements are left.
-                # Empty or single-element sets cannot require deduplication, and are already heaps themselves.
-                if 1 < len(queue):
-                    queue = list(set(queue))
-                    heapify(queue)
+                if 0 < len(queue):
+                    # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
+                    queue = [item for item in queue if not (item[1] > distances[item[2]])]
+                    # And while we're here, trim elements who are too close to upbound
+                    queue = [item for item in queue if item[1] + min_cost[item[2]] <= upbound]
+                    # Finally, dedupe the queue after cleaning all bound-busts out and 2 or more elements are left.
+                    # Empty or single-element sets cannot require deduplication, and are already heaps themselves.
+                    if 1 < len(queue):
+                        queue = list(set(queue))
+                        heapify(queue)
             # heappush(queue, (ncost + 0, ncost, target, curnode))
             heappush(queue, (ncost, ncost, target, curnode))
             queue_counter += 1

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -201,11 +201,8 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             active_weights = active_weights[keep]
             augmented_weights = augmented_weights[keep]
 
-        # Now we have the latest upper bound, use it to filter out nodes whose augmented weights will bust the upper
-        # bound. We still need to _queue_ the bound-busting nodes' active costs, as that allows us to dodge about a
-        # quarter of the nodes we would otherwise have to spin through - if it's stupid, but it works, it isn't stupid.
-        # As a result, unconditionally queue _all_ nodes that are still active, and filter out the bound-busting
-        # neighbours.
+        # Now unconditionally queue _all_ nodes that are still active, worrying about filtering out the bound-busting
+        # neighbours later.
         distances[active_nodes] = active_weights
         num_nodes = len(active_nodes)
 

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -53,9 +53,6 @@ def _calc_branching_factor(nodes_queued, path_len):
 
 def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=None):
 
-    push = heappush
-    pop = heappop
-
     G_succ = G._arcs  # For speed-up
 
     # The queue stores priority, cost to reach, node,  and parent.
@@ -91,7 +88,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
 
     while queue:
         # Pop the smallest item from queue.
-        _, dist, curnode, parent = pop(queue)
+        _, dist, curnode, parent = heappop(queue)
         node_counter += 1
 
         if curnode == target:
@@ -180,8 +177,8 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
                 if 1 < len(queue):
                     queue = list(set(queue))
                     heapify(queue)
-            # push(queue, (ncost + 0, ncost, target, curnode))
-            push(queue, (ncost, ncost, target, curnode))
+            # heappush(queue, (ncost + 0, ncost, target, curnode))
+            heappush(queue, (ncost, ncost, target, curnode))
             queue_counter += 1
             #  If target node is only active node, and is neighbour node of only active queue element, bail out now
             #  and dodge the now-known-to-be-pointless neighbourhood bookkeeping.
@@ -214,6 +211,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
         queue_counter += num_nodes
 
         for i in range(num_nodes):
-            push(queue, (augmented_weights[i], active_weights[i], active_nodes[i], curnode))
+            heappush(queue, (augmented_weights[i], active_weights[i], active_nodes[i], curnode))
 
     raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -186,10 +186,9 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             if 1 == len(queue) and 1 == len(active_nodes):
                 targ_exhausted += 1
                 continue
-            # target node has been processed, drop it from neighbours
-            keep = active_nodes != target
-            # As we have a tighter upper bound, apply it to the neighbours as well
-            keep = np.logical_and(keep, augmented_weights < upbound)
+            # As we have a tighter upper bound, apply it to the neighbours as well - target will be excluded because
+            # its augmented weight is _equal_ to upbound
+            keep = augmented_weights < upbound
             active_nodes = active_nodes[keep]
 
             # if there _was_ one neighbour to process, that was the target, so neighbour list is now empty.

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -208,11 +208,11 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
         # As a result, unconditionally queue _all_ nodes that are still active, and filter out the bound-busting
         # neighbours.
         distances[active_nodes] = active_weights
+        num_nodes = len(active_nodes)
 
-        remain = zip(augmented_weights, active_weights, active_nodes)
-        queue_counter += len(active_nodes)
+        queue_counter += num_nodes
 
-        for augmented_weight, active_weight, active_node in remain:
-            push(queue, (augmented_weight, active_weight, active_node, curnode))
+        for i in range(num_nodes):
+            push(queue, (augmented_weights[i], active_weights[i], active_nodes[i], curnode))
 
     raise nx.NetworkXNoPath(f"Node {target} not reachable from {source}")

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -77,6 +77,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
     # pre-calc the minimum-cost edge on each node
     min_cost = np.zeros(len(G)) if min_cost is None else min_cost
     min_cost[target] = 0
+    up_threshold = upbound - min_cost
 
     node_counter = 0
     queue_counter = 0
@@ -138,7 +139,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
         active_weights = dist + raw_nodes[1]
         # filter out nodes whose active weights exceed _either_ the node's distance label _or_ the current upper bound
         # - the current node can _not_ result in a shorter path
-        keep = active_weights <= np.minimum(distances[active_nodes], upbound - min_cost[active_nodes])
+        keep = active_weights <= np.minimum(distances[active_nodes], up_threshold[active_nodes])
         # if we're not keeping anything, go around
         active_nodes = active_nodes[keep]
         num_neighbours = len(active_nodes)
@@ -167,6 +168,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
             upbound = ncost
             new_upbounds += 1
             distances[target] = ncost
+            up_threshold = upbound - min_cost
             if 0 < len(queue):
                 queue = [item for item in queue if item[0] < upbound]
                 # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value

--- a/PyRoute/Pathfinding/astar_numpy.py
+++ b/PyRoute/Pathfinding/astar_numpy.py
@@ -83,7 +83,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=N
     f_exhausted = 0
     new_upbounds = 0
     targ_exhausted = 0
-    un_exhausted = 0
     revis_continue = 0
 
     while queue:

--- a/Tests/Pathfinding/testApproximateShortestPathForest.py
+++ b/Tests/Pathfinding/testApproximateShortestPathForest.py
@@ -33,7 +33,7 @@ class testApproximateShortestPathForest(baseTest):
         source = stars[0]
 
         approx = ApproximateShortestPathForestDistanceGraph(source, graph, 0.2, sources=landmarks)
-        self.assertEqual(9, len(approx._trees), "Unexpected number of approx-SP trees")
+        self.assertEqual(11, len(approx._trees), "Unexpected number of approx-SP trees")
 
         src = stars[2]
         targ = stars[80]
@@ -43,7 +43,7 @@ class testApproximateShortestPathForest(baseTest):
         self.assertAlmostEqual(expected, actual, 3, "Unexpected lower bound value")
 
         approx = ApproximateShortestPathForestDistanceGraph(source, graph, 0.2, sources=landmarks)
-        self.assertEqual(9, len(approx._trees), "Unexpected number of approx-SP trees")
+        self.assertEqual(11, len(approx._trees), "Unexpected number of approx-SP trees")
 
         src = stars[2]
         targ = stars[80]
@@ -81,7 +81,7 @@ class testApproximateShortestPathForest(baseTest):
         source = stars[0]
 
         approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
-        self.assertEqual(9, approx._num_trees)
+        self.assertEqual(11, approx._num_trees)
 
         active_nodes = [2, 80]
         target = 80
@@ -101,7 +101,7 @@ class testApproximateShortestPathForest(baseTest):
         source = stars[0]
 
         approx = ApproximateShortestPathForestUnified(source, graph, 0.2, sources=landmarks)
-        self.assertEqual(9, approx._num_trees)
+        self.assertEqual(11, approx._num_trees)
 
     def test_unified_can_handle_bulk_lobound_from_singleton_component(self):
         galaxy = self.set_up_zarushagar_sector()

--- a/Tests/Pathfinding/testAstarNumpy.py
+++ b/Tests/Pathfinding/testAstarNumpy.py
@@ -39,9 +39,9 @@ class testAStarNumpy(baseTest):
         heuristic = galaxy.heuristic_distance_bulk
 
         exp_route = [0, 8, 9, 15, 24, 36]
-        exp_diagnostics = {'branch_factor': 1.448, 'f_exhausted': 3, 'g_exhausted': 0, 'neighbour_bound': 8,
-                            'new_upbounds': 1, 'nodes_expanded': 9, 'nodes_queued': 11, 'nodes_revisited': 0,
-                            'num_jumps': 5, 'un_exhausted': 4, 'targ_exhausted': 1}
+        exp_diagnostics = {'branch_factor': 1.704, 'f_exhausted': 3, 'g_exhausted': 3, 'neighbour_bound': 14,
+                            'new_upbounds': 1, 'nodes_expanded': 16, 'nodes_queued': 18, 'nodes_revisited': 1,
+                            'num_jumps': 5, 'un_exhausted': 7, 'targ_exhausted': 1}
 
         upbound = galaxy.trade.shortest_path_tree.triangle_upbound(source, target) * 1.005
         act_route, diagnostics = astar_path_numpy(dist_graph, source.index, target.index, heuristic, upbound=upbound)

--- a/Tests/Pathfinding/testAstarNumpy.py
+++ b/Tests/Pathfinding/testAstarNumpy.py
@@ -44,6 +44,7 @@ class testAStarNumpy(baseTest):
                             'num_jumps': 5, 'un_exhausted': 7, 'targ_exhausted': 1}
 
         upbound = galaxy.trade.shortest_path_tree.triangle_upbound(source, target) * 1.005
-        act_route, diagnostics = astar_path_numpy(dist_graph, source.index, target.index, heuristic, upbound=upbound)
+        act_route, diagnostics = astar_path_numpy(dist_graph, source.index, target.index, heuristic, upbound=upbound,
+                                                  diagnostics=True)
         self.assertEqual(exp_route, act_route)
         self.assertEqual(exp_diagnostics, diagnostics)

--- a/Tests/Pathfinding/testTradeCalculationLandmarks.py
+++ b/Tests/Pathfinding/testTradeCalculationLandmarks.py
@@ -55,7 +55,7 @@ class testTradeCalculationLandmarks(baseTest):
         self.assertEqual(6, len(galaxy.trade.components), "Unexpected number of components at J-1")
 
         landmarks, components = galaxy.trade.get_landmarks()
-        self.assertEqual(4, len(landmarks), 'Should have one landmark per component')
+        self.assertEqual(6, len(landmarks), 'Should have one landmark per component')
         self.assertEqual("Dorevann (Zarushagar 0708)", str(landmarks[0][0]), "Unexpected landmark choice")
         self.assertEqual("Shadishi (Zarushagar 0310)", str(landmarks[0][2]), "Unexpected landmark choice")
         self.assertEqual("Gishin (Zarushagar 0804)", str(landmarks[0][4]), "Unexpected landmark choice")


### PR DESCRIPTION
Bunch of little tune-ups to speed up astar routine.

Under profiling **astar_path_numpy**, total pathfinding time over Reft + 4 orthogonals went from 3 min 0 sec (180 sec) to 2 min 27 sec (147 sec) - 18.3% speedup.