### PR TITLE
Expand breach reduction when delta debugging

### DIFF
--- a/PyRoute/DeltaDebug/DeltaDebug.py
+++ b/PyRoute/DeltaDebug/DeltaDebug.py
@@ -102,7 +102,7 @@ def process():
     delta.add_argument('--no-line', dest="run_line", default=True, action='store_false',
                        help="Skip line-level reduction.")
     delta.add_argument('--two-reduce', dest="two_min", default=False, action='store_true',
-                       help="Try all pairs of star lines to see if any can be removed.  At least one of sector, subsector, line and two-line reduction must be selected")
+                       help="Try all pairs of star lines to see if any can be removed.")
     delta.add_argument('--within-line', dest="run_within", default=False, action='store_true',
                        help="Try to remove irrelevant components (eg base codes) from _within_ individual lines")
     delta.add_argument('--allegiance', dest="run_allegiance", default=False, action='store_true',
@@ -114,7 +114,7 @@ def process():
     args = parser.parse_args()
 
     # sanity check run arguments
-    if not (args.two_min or args.run_sector or args.run_subsector or args.run_line):
+    if not (args.two_min or args.run_sector or args.run_subsector or args.run_line or args.run_within or args.run_allegiance):
         raise ValueError("Must select at least one reduction pass to run")
 
     galaxy = Galaxy(args.btn, args.max_jump)

--- a/PyRoute/DeltaPasses/AllegianceReducer.py
+++ b/PyRoute/DeltaPasses/AllegianceReducer.py
@@ -25,6 +25,7 @@ class AllegianceReducer(object):
         num_chunks = len(segment) if singleton_only else 2
         short_msg = None
         best_sectors = self.reducer.sectors
+        old_length = len(segment)
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
@@ -69,3 +70,7 @@ class AllegianceReducer(object):
         self.reducer.sectors = best_sectors
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)
+
+        # At least one allegiance was shown to be irrelevant, write out the intermediate result
+        if old_length > len(segment):
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SectorReducer.py
+++ b/PyRoute/DeltaPasses/SectorReducer.py
@@ -26,6 +26,7 @@ class SectorReducer(object):
         short_msg = None
         best_sectors = self.reducer.sectors
         singleton_run = singleton_only
+        old_length = len(segment)
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
@@ -72,3 +73,7 @@ class SectorReducer(object):
         self.reducer.sectors = best_sectors
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)
+
+        # At least one sector was shown to be irrelevant, write out the intermediate result
+        if old_length > len(segment):
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SingleLineReducer.py
+++ b/PyRoute/DeltaPasses/SingleLineReducer.py
@@ -82,8 +82,19 @@ class SingleLineReducer(object):
                                 reverse=True,
                                 best_sectors=best_sectors
                             )
-                            msg = "Widening breach complete"
+
+                        if i < num_chunks - 1:  # now try expanding hole forwards
+                            msg = "Widening breach forwards"
                             self.reducer.logger.error(msg)
+                            startloc = bounds[i - 1][1]
+                            best_sectors = self.breacher.run(
+                                start_pos=startloc,
+                                reverse=False,
+                                best_sectors=best_sectors
+                            )
+
+                        msg = "Widening breach complete"
+                        self.reducer.logger.error(msg)
 
             if 0 < len(remove):
                 num_chunks -= len(remove)

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -27,6 +27,7 @@ class SubsectorReducer(object):
         num_chunks = len(segment) if singleton_only else 2
         short_msg = None
         best_sectors = self.reducer.sectors
+        old_length = len(segment)
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
@@ -98,3 +99,7 @@ class SubsectorReducer(object):
         self.reducer.sectors = best_sectors
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)
+
+        # At least one subsector was shown to be irrelevant, write out the intermediate result
+        if old_length > len(segment):
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/TwoLineReducer.py
+++ b/PyRoute/DeltaPasses/TwoLineReducer.py
@@ -25,7 +25,7 @@ class TwoLineReducer(object):
         best_sectors = self.reducer.sectors
         gap = 1
         while gap < len(segment):
-            msg = "# of lines: " + str(len(best_sectors.lines))
+            msg = "# of lines: " + str(len(best_sectors.lines)) + f", gap {gap}"
             self.reducer.logger.error(msg)
 
             i = 0

--- a/Tests/testDeltaPasses.py
+++ b/Tests/testDeltaPasses.py
@@ -1,4 +1,5 @@
 import argparse
+import tempfile
 import unittest.main
 
 from PyRoute.DeltaPasses.AllegianceReducer import AllegianceReducer
@@ -378,6 +379,7 @@ class testDeltaPasses(baseTest):
         args.output = ''
         args.mp_threads = 1
         args.debug_flag = False
+        args.mindir = tempfile.gettempdir()
         return args
 
     def _make_args_no_line(self):

--- a/Tests/testDeltaReduce.py
+++ b/Tests/testDeltaReduce.py
@@ -34,7 +34,7 @@ class testDeltaReduce(baseTest):
             expected = 0
             affix = " not empty after subsector reduction"
             if subsector_name == 'Pact':
-                expected = 40
+                expected = 39
                 affix = " empty after subsector reduction"
             actual = 0 if reducer.sectors['Dagudashaag'][subsector_name].items is None else len(reducer.sectors['Dagudashaag'][subsector_name].items)
             self.assertEqual(expected, actual, subsector_name + affix)
@@ -401,6 +401,7 @@ class testDeltaReduce(baseTest):
         args.output = tempfile.gettempdir()
         args.mp_threads = 1
         args.debug_flag = False
+        args.mindir = tempfile.gettempdir()
         return args
 
     def _make_args_no_line(self):


### PR DESCRIPTION
Expand breaches found somewhat more aggressively during delta debugging.

Breach reduction starts with finding some reduction in another pass, then (either forwards or backwards), iteratively removing 1, 2, 4, 8, etc lines until the removed lines were interesting.

First, widen breaches both forward and backwards in single-line reduction.
Second, widen breaches both forward and backwards in subsector-level reduction.
Third, write out still-interesting sector files at end of both allegiance and sector level reduction.