### PR TITLE
Bump numpy to 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-lint.select = ["E", "F", "TID252", "E231"]
+lint.select = ["E", "F", "TID252", "E231", "NPY201"]
 lint.ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ hypothesis >= 6.97.0
 jinja2
 jsonpickle
 lark==1.1.8
-numpy
+numpy >= 2.0
 pytest >= 8.0.0
 pytest-console-scripts
 pytest-randomly


### PR DESCRIPTION
As per https://numpy.org/devdocs/release/2.0.0-notes.html , bump numpy dep to 2.0+ and (surprisingly) find no obsolete-call blowups to fix.