### PR TITLE
Add star canonicalisation

### DIFF
--- a/PyRoute/DeltaPasses/Canonicalisation.py
+++ b/PyRoute/DeltaPasses/Canonicalisation.py
@@ -20,7 +20,7 @@ class Canonicalisation(object):
         # build substitution list - canonicalise _everything_
         subs_list = []
         for line in self.reducer.sectors.lines:
-            canon = DeltaStar.reduce(line)
+            canon = DeltaStar.reduce(line, canonicalise=True)
             assert isinstance(canon, str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
             subs_list.append((line, canon))
 

--- a/PyRoute/DeltaPasses/Canonicalisation.py
+++ b/PyRoute/DeltaPasses/Canonicalisation.py
@@ -22,6 +22,7 @@ class Canonicalisation(object):
         for line in self.reducer.sectors.lines:
             canon = DeltaStar.reduce(line, canonicalise=True)
             assert isinstance(canon, str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            canon = DeltaStar.reduce(canon, canonicalise=True)
             subs_list.append((line, canon))
 
         if 0 == len(subs_list):

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -13,12 +13,14 @@ from PyRoute.TradeCodes import TradeCodes
 class DeltaStar(Star):
 
     @staticmethod
-    def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False, drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False, reset_tl=False, reset_sophont=False, reset_capitals=False):
+    def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False, drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False, reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False):
         sector = Sector("# dummy", "# 0, 0")
         star = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
         if not isinstance(star, DeltaStar):
             return None
 
+        if canonicalise:
+            star.canonicalise()
         if drop_routes:
             star.reduce_routes()
         if drop_trade_codes:
@@ -49,7 +51,7 @@ class DeltaStar(Star):
 
     @staticmethod
     def reduce_all(original):
-        return DeltaStar.reduce(original, drop_routes=True, drop_trade_codes=True, drop_noble_codes=True, drop_base_codes=True, drop_trade_zone=True, drop_extra_stars=True, reset_pbg=True, reset_worlds=True, reset_port=True, reset_tl=True, reset_sophont=True)
+        return DeltaStar.reduce(original, drop_routes=True, drop_trade_codes=True, drop_noble_codes=True, drop_base_codes=True, drop_trade_zone=True, drop_extra_stars=True, reset_pbg=True, reset_worlds=True, reset_port=True, reset_tl=True, reset_sophont=True, canonicalise=True)
 
     @staticmethod
     def reduce_auxiliary(original):

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -51,7 +51,7 @@ class DeltaStar(Star):
 
     @staticmethod
     def reduce_all(original):
-        return DeltaStar.reduce(original, drop_routes=True, drop_trade_codes=True, drop_noble_codes=True, drop_base_codes=True, drop_trade_zone=True, drop_extra_stars=True, reset_pbg=True, reset_worlds=True, reset_port=True, reset_tl=True, reset_sophont=True, canonicalise=True)
+        return DeltaStar.reduce(original, drop_routes=True, drop_trade_codes=True, drop_noble_codes=True, drop_base_codes=True, drop_trade_zone=True, drop_extra_stars=True, reset_pbg=True, reset_worlds=True, reset_port=True, reset_tl=True, reset_sophont=True, canonicalise=False)
 
     @staticmethod
     def reduce_auxiliary(original):

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -526,9 +526,9 @@ class Star(object):
         nu_symbols = None
         if 0 == pop and symbols != 0:
             nu_symbols = '0'
-        elif 0 != pop and symbols > max(1, self.tl - 5):
+        elif 0 != pop and symbols < max(1, self.tl - 5):
             nu_symbols = self._int_to_ehex(max(1, self.tl - 5))
-        elif 0 != pop and symbols < self.tl + 5:
+        elif 0 != pop and symbols > self.tl + 5:
             nu_symbols = self._int_to_ehex(self.tl + 5)
 
         if nu_symbols is not None:

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -481,6 +481,59 @@ class Star(object):
                 '{} - CX calculated symbols {} not in range {} - {}'.
                 format(self, symbols, max(1, self.tl - 5), self.tl + 5))
 
+    def fix_cx(self):
+        if not self.economics:
+            return
+        if not self.social:
+            return
+        pop = self.popCode
+
+        homogeneity = self._ehex_to_int(self.social[1])
+        nu_homogeneity = None
+        if 0 == pop and 0 != homogeneity:
+            nu_homogeneity = '0'
+        elif 0 != pop and homogeneity < max(1, pop - 5):
+            nu_homogeneity = self._int_to_ehex(max(1, pop - 5))
+        elif 0 != pop and homogeneity > pop + 5:
+            nu_homogeneity = self._int_to_ehex(pop + 5)
+
+        if nu_homogeneity is not None:
+            self.social = self.social[0] + nu_homogeneity + self.social[2:]
+
+        acceptance = self._ehex_to_int(self.social[2])
+        nu_acceptance = None
+        if 0 == pop and 0 != acceptance:
+            nu_acceptance = '0'
+        elif 0 != pop and max(1, pop + self.importance) != acceptance:
+            nu_acceptance = self._int_to_ehex(max(1, pop + self.importance))
+
+        if nu_acceptance is not None:
+            self.social = self.social[0:2] + nu_acceptance + self.social[3:]
+
+        strangeness = self._ehex_to_int(self.social[3])
+        nu_strangeness = None
+        if 0 == pop and 0 != strangeness:
+            nu_strangeness = '0'
+        elif 0 != pop and 1 > strangeness:
+            nu_strangeness = self._int_to_ehex(1)
+        elif 0 != pop and 10 < strangeness:
+            nu_strangeness = self._int_to_ehex(10)
+
+        if nu_strangeness is not None:
+            self.social = self.social[0:3] + nu_strangeness + self.social[4:]
+
+        symbols = self._ehex_to_int(self.social[4])
+        nu_symbols = None
+        if 0 == pop and symbols != 0:
+            nu_symbols = '0'
+        elif 0 != pop and symbols > max(1, self.tl - 5):
+            nu_symbols = self._int_to_ehex(max(1, self.tl - 5))
+        elif 0 != pop and symbols < self.tl + 5:
+            nu_symbols = self._int_to_ehex(self.tl + 5)
+
+        if nu_symbols is not None:
+            self.social = self.social[0:4] + nu_symbols + self.social[5:]
+
     def calculate_ru(self, ru_calc):
         if not self.economics:
             self.ru = 0
@@ -697,5 +750,6 @@ class Star(object):
         self.uwp.canonicalise()
         self.tradeCode.canonicalise(self)
         self.fix_ex()
+        self.fix_cx()
         self.star_list_object.canonicalise()
         self.calculate_importance()

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -692,3 +692,10 @@ class Star(object):
         capital = 2 if self.tradeCode.sector_capital or self.tradeCode.other_capital else 1 if \
             self.tradeCode.subsector_capital else 0
         self._pax_btn_mod = rich + capital
+
+    def canonicalise(self):
+        self.uwp.canonicalise()
+        self.tradeCode.canonicalise(self)
+        self.fix_ex()
+        self.star_list_object.canonicalise()
+        self.calculate_importance()

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -66,7 +66,12 @@ def canonical_check(draw):
 
     return rawline
 
+
 class testStar(unittest.TestCase):
+
+    def setUp(self) -> None:
+        logger = logging.getLogger('PyRoute.Star')
+        logger.setLevel(logging.INFO)
 
     """
     Given a regex-matching string, parse_line_to_star should return either a valid Star object or None
@@ -217,7 +222,7 @@ class testStar(unittest.TestCase):
 
     @given(canonical_check())
     @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(200))
-    # @example('0000 000000000000000 ????1??-? 000000000000000 - (000-0) [0000]  - - A 000    00')
+    @example('1919 Khula                ???????-? Hi In Pz Di(Khulans)      {0}  (000-0) [0000] BEf  N  A 510 10 ImDv M0 V')
     def test_star_canonicalise(self, s):
         hyp_line = "Hypothesis input: " + s
         sector = Sector('# Core', '# 0, 0')
@@ -230,6 +235,8 @@ class testStar(unittest.TestCase):
         foo = Star.parse_line_into_star(s, sector, pop_code, ru_calc)
         logger.setLevel(logging.INFO)
         tradelogger.setLevel(logging.INFO)
+        logger.manager.disable = 10
+        self.assertTrue(logger.isEnabledFor(logging.INFO))
         assume(foo is not None)
         assume(foo.economics is not None)
         assume(foo.social is not None)
@@ -245,7 +252,6 @@ class testStar(unittest.TestCase):
             cm.output,
             hyp_line
         )
-
 
 
 if __name__ == '__main__':

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -47,6 +47,25 @@ def importance_starline(draw):
 
     return rawline
 
+@composite
+def canonical_check(draw):
+    rawline = '1919 Khula                B575A77-E Hi In Pz Di(Khulans)      { 4 }  (D9G+4) [AE5E] BEf  N  A 510 10 ImDv M0 V'
+    uwp_match = r'(\w\w\w\w\w\w\w-\w|\?\?\?\?\?\?\?-\?|[\w\?]{7,7}-[\w\?])'
+    imp_match = r'\{ *[+-]?[0-6] ?\}'
+    econ_match = r'\([0-9A-Z]{3}[+-]\d\)'
+    soc_match = r'\[[0-9A-Z]{4}\]'
+
+    uwp_draw = draw(from_regex(uwp_match))
+    rawline.replace('B575A77-E', uwp_draw)
+    imp_draw = draw(from_regex(imp_match))
+    rawline.replace('{ 4 }', imp_draw)
+    econ_draw = draw(from_regex(econ_match))
+    rawline.replace('(D9G+4)', econ_draw)
+    soc_draw = draw(from_regex(soc_match))
+    rawline.replace('[AE5E]', soc_draw)
+
+    return rawline
+
 class testStar(unittest.TestCase):
 
     """
@@ -196,9 +215,8 @@ class testStar(unittest.TestCase):
         foo.allegiance_base = foo.alg_base_code
         self.assertTrue(foo.is_well_formed())
 
-    @given(from_regex(regex=ParseStarInput.starline, alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*'))
-    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)],
-              deadline=timedelta(200))
+    @given(canonical_check())
+    @settings(deadline=timedelta(200))
     @example('0000 000000000000000 ????1??-? 000000000000000 - (000-0) [0000]  - - A 000    00')
     def test_star_canonicalise(self, s):
         hyp_line = "Hypothesis input: " + s

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -56,13 +56,13 @@ def canonical_check(draw):
     soc_match = r'\[[0-9A-Z]{4}\]'
 
     uwp_draw = draw(from_regex(uwp_match))
-    rawline.replace('B575A77-E', uwp_draw)
+    rawline = rawline.replace('B575A77-E', uwp_draw)
     imp_draw = draw(from_regex(imp_match))
-    rawline.replace('{ 4 }', imp_draw)
+    rawline = rawline.replace('{ 4 }', imp_draw)
     econ_draw = draw(from_regex(econ_match))
-    rawline.replace('(D9G+4)', econ_draw)
+    rawline = rawline.replace('(D9G+4)', econ_draw)
     soc_draw = draw(from_regex(soc_match))
-    rawline.replace('[AE5E]', soc_draw)
+    rawline = rawline.replace('[AE5E]', soc_draw)
 
     return rawline
 
@@ -216,8 +216,8 @@ class testStar(unittest.TestCase):
         self.assertTrue(foo.is_well_formed())
 
     @given(canonical_check())
-    @settings(deadline=timedelta(200))
-    @example('0000 000000000000000 ????1??-? 000000000000000 - (000-0) [0000]  - - A 000    00')
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(200))
+    # @example('0000 000000000000000 ????1??-? 000000000000000 - (000-0) [0000]  - - A 000    00')
     def test_star_canonicalise(self, s):
         hyp_line = "Hypothesis input: " + s
         sector = Sector('# Core', '# 0, 0')

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -198,7 +198,7 @@ class testStar(unittest.TestCase):
 
     @given(from_regex(regex=ParseStarInput.starline, alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*'))
     @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)],
-              deadline=timedelta(1000))
+              deadline=timedelta(200))
     @example('0000 000000000000000 ????1??-? 000000000000000 - (000-0) [0000]  - - A 000    00')
     def test_star_canonicalise(self, s):
         hyp_line = "Hypothesis input: " + s
@@ -216,7 +216,7 @@ class testStar(unittest.TestCase):
         assume(foo.economics is not None)
         assume(foo.social is not None)
 
-        foo.fix_ex()
+        foo.canonicalise()
         with self.assertLogs(logger) as cm:
             logger.info('Dummy log')
             foo.check_ex()

--- a/Tests/testDeltaPasses.py
+++ b/Tests/testDeltaPasses.py
@@ -35,7 +35,7 @@ class testDeltaPasses(baseTest):
         reducer.is_initial_state_interesting()
         # verify each line got reduced
         for line in reducer.sectors.lines:
-            reduced = DeltaStar.reduce(line)
+            reduced = DeltaStar.reduce(line, canonicalise=True)
             self.assertEqual(line, reduced, "Line not canonicalised")
 
     def test_canonicalisation_resets_hex_block(self):


### PR DESCRIPTION
Add method to canonicalise a given Star object - "canonical" in this case being with respect to the checks that already exist when reading a given starline in.

This pulls the star canonicalisation bits out of the mess that is #70 and into a form much more easily reviewable.