### PR TITLE
Wring out individual-star canonicalisation

### DIFF
--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -213,7 +213,7 @@ class DeltaStar(Star):
         self._check_trade_code(msg, 'Po', None, '2345', '0123')
         self._check_trade_code(msg, 'He', '3456789ABC', '2479ABC', '012')
         self._check_trade_code(msg, 'Wa', '3456789', '3456789DEF', 'A')
-        self._check_trade_code(msg, 'Oc', 'ABCD', '3456789DEF', 'A')
+        self._check_trade_code(msg, 'Oc', 'ABCDEF', '3456789DEF', 'A')
         self._check_trade_code(msg, 'Va', None, '0', None)
 
         code = 'Ba'

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -147,13 +147,10 @@ class DeltaStar(Star):
                                                                                          12 + self.importance)
                 msg.append(line)
 
-        self._check_trade_code(msg, 'Va', None, '0', None)
         if not self.tradeCode.barren and 0 == efficiency:
             line = '{} - EX Calculated efficiency 0 should be coded as 1 (implied by p18, book 3 of T5.10)'.format(self)
 
             msg.append(line)
-
-        self._check_trade_code(msg, 'As', '0', '0', '0')
 
         if ('O:' + self.position) in self.tradeCode.codes:
             line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, 'O:' + self.position, self.tradeCode.codes)
@@ -203,6 +200,7 @@ class DeltaStar(Star):
                                                                                           max(self.popCode - 1, 0))
                 msg.append(line)
 
+        self._check_trade_code(msg, 'As', '0', '0', '0')
         self._check_trade_code(msg, 'De', None, '23456789', '0')
         self._check_trade_code(msg, 'Ga', '678', '568', '567')
         self._check_trade_code(msg, 'Fl', None, 'ABC', '123456789A')

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -125,8 +125,9 @@ class DeltaStar(Star):
         efficiency = None
 
         if self.economics is not None:
-            infrastructure = self._ehex_to_int(self.economics[3] if self.economics is not None else '0')
+            infrastructure = self._ehex_to_int(self.economics[3])
             efficiency = self._ehex_to_int(self.economics[5])
+            labor = self._ehex_to_int(self.economics[2])
             if self.tradeCode.barren and infrastructure != 0:
                 line = '{} - EX Calculated infrastructure {} does not match generated infrastructure {}'.format(self,
                                                                                                                 infrastructure,
@@ -146,6 +147,10 @@ class DeltaStar(Star):
                 line = '{} - EX Calculated infrastructure {} not in range 0 - {}'.format(self, infrastructure,
                                                                                          12 + self.importance)
                 msg.append(line)
+            if labor != max(self.popCode - 1, 0):
+                line = '{} - EX Calculated labor {} does not match generated labor {}'.format(self, labor,
+                                                                                          max(self.popCode - 1, 0))
+                msg.append(line)
 
         if not self.tradeCode.barren and 0 == efficiency:
             line = '{} - EX Calculated efficiency 0 should be coded as 1 (implied by p18, book 3 of T5.10)'.format(self)
@@ -160,11 +165,10 @@ class DeltaStar(Star):
             msg.append(line)
 
         if self.social is not None:
-            symbols = self._ehex_to_int(self.social[4] if self.social is not None else '1')  # TL + flux, min 1
-            strangeness = self._ehex_to_int(self.social[3] if self.social is not None else '1')  # flux + 5
-            acceptance = self._ehex_to_int(self.social[2] if self.social is not None else '1')  # pop + Ix, min 1
-            homogeneity = self._ehex_to_int(self.social[1] if self.social is not None else '1')  # pop + flux, min 1
-            labor = self._ehex_to_int(self.economics[2] if self.economics is not None else '0')
+            symbols = self._ehex_to_int(self.social[4])  # TL + flux, min 1
+            strangeness = self._ehex_to_int(self.social[3])  # flux + 5
+            acceptance = self._ehex_to_int(self.social[2])  # pop + Ix, min 1
+            homogeneity = self._ehex_to_int(self.social[1])  # pop + flux, min 1
             pop = self.popCode
             if pop == 0 and symbols != 0:
                 line = '{} - CX Calculated symbols {} should be 0 for barren worlds'.format(self, symbols)
@@ -194,10 +198,6 @@ class DeltaStar(Star):
             elif pop != 0 and not max(1, pop - 5) <= homogeneity <= pop + 5:
                 line = '{} - CX Calculated homogeneity {} not in range {} - {}'.format(self, homogeneity, max(1, pop - 5),
                                                                                    pop + 5)
-                msg.append(line)
-            if self.economics is not None and labor != max(self.popCode - 1, 0):
-                line = '{} - EX Calculated labor {} does not match generated labor {}'.format(self, labor,
-                                                                                          max(self.popCode - 1, 0))
                 msg.append(line)
 
         self._check_trade_code(msg, 'As', '0', '0', '0')

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -151,7 +151,7 @@ class DeltaStar(Star):
             code = 'Va'
             line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
             msg.append(line)
-        if 0 == efficiency:
+        if not self.tradeCode.barren and 0 == efficiency:
             line = '{} - EX Calculated efficiency 0 should be coded as 1 (implied by p18, book 3 of T5.10)'.format(self)
 
             msg.append(line)

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -203,7 +203,7 @@ class DeltaStar(Star):
                                                                                           max(self.popCode - 1, 0))
                 msg.append(line)
 
-        self._check_trade_code(msg, 'De', '0123456789ABC', '23456789', '0')
+        self._check_trade_code(msg, 'De', None, '23456789', '0')
         self._check_trade_code(msg, 'Ga', '678', '568', '567')
         self._check_trade_code(msg, 'Fl', None, 'ABC', '123456789A')
         self._check_trade_code(msg, 'Ic', None, '01', '123456789A')

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -117,3 +117,191 @@ class DeltaStar(Star):
                 nu_codes.append(code)
 
         self.tradeCode = TradeCodes(' '.join(nu_codes))
+
+    def check_canonical(self):
+        msg = list()
+
+        self._check_uwp()
+        efficiency = None
+
+        if self.economics is not None:
+            infrastructure = self._ehex_to_int(self.economics[3] if self.economics is not None else '0')
+            efficiency = self._ehex_to_int(self.economics[5])
+            if self.tradeCode.barren and infrastructure != 0:
+                line = '{} - EX Calculated infrastructure {} does not match generated infrastructure {}'.format(self,
+                                                                                                                infrastructure,
+                                                                                                                0)
+                msg.append(line)
+            elif self.tradeCode.low and infrastructure != max(self.importance, 0):
+                generated = max(self.importance, 0)
+                line = '{} - EX Calculated infrastructure {} does not match generated infrastructure {}'.format(self,
+                                                                                                                infrastructure,
+                                                                                                                generated)
+                msg.append(line)
+            elif self.tradeCode.nonindustrial and not 0 <= infrastructure <= 6 + self.importance:
+                line = '{} - EX Calculated infrastructure {} not in NI range 0 - {}'.format(self, infrastructure,
+                                                                                            6 + self.importance)
+                msg.append(line)
+            elif not 0 <= infrastructure <= 12 + self.importance:
+                line = '{} - EX Calculated infrastructure {} not in range 0 - {}'.format(self, infrastructure,
+                                                                                         12 + self.importance)
+                msg.append(line)
+
+        if '0' == str(self.atmo) and 'Va' not in self.tradeCode.codeset:
+            code = 'Va'
+            line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)
+        if 0 == efficiency:
+            line = '{} - EX Calculated efficiency 0 should be coded as 1 (implied by p18, book 3 of T5.10)'.format(self)
+
+            msg.append(line)
+
+        if '0' == str(self.atmo) and '0' == str(self.size) and '0' == str(self.hydro) and 'As' not in self.tradeCode.codeset:
+            code = 'As'
+            line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)
+        elif 'As' in self.tradeCode.codeset and not ('0' == str(self.atmo) and '0' == str(self.size) and '0' == str(self.hydro)):
+            code = 'As'
+            line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)
+
+        if self.social is not None:
+            symbols = self._ehex_to_int(self.social[4] if self.social is not None else '1')  # TL + flux, min 1
+            strangeness = self._ehex_to_int(self.social[3] if self.social is not None else '1')  # flux + 5
+            acceptance = self._ehex_to_int(self.social[2] if self.social is not None else '1')  # pop + Ix, min 1
+            homogeneity = self._ehex_to_int(self.social[1] if self.social is not None else '1')  # pop + flux, min 1
+            labor = self._ehex_to_int(self.economics[2] if self.economics is not None else '0')
+            pop = self.popCode
+            if pop == 0 and symbols != 0:
+                line = '{} - CX Calculated symbols {} should be 0 for barren worlds'.format(self, symbols)
+                msg.append(line)
+            elif pop != 0 and not max(1, self.tl - 5) <= symbols <= self.tl + 5:
+                line = '{} - CX Calculated symbols {} not in range {} - {}'.format(self, symbols, max(1, self.tl - 5),
+                                                                               self.tl + 5)
+                msg.append(line)
+            if pop == 0 and strangeness != 0:
+                line = '{} - CX Calculated strangeness {} should be 0 for barren worlds'.format(self, strangeness)
+                msg.append(line)
+            elif pop != 0 and not 1 <= strangeness <= 10:
+                line = '{} - CX Calculated strangeness {} not in range {} - {}'.format(self, strangeness, 1, 10)
+                msg.append(line)
+            pop_plus_imp = min(33, max(1, pop + self.importance))  # Cap out at 33 - converts to ehex as Z
+            if pop == 0 and acceptance != 0:
+                line = '{} - CX Calculated acceptance {} should be 0 for barren worlds'.format(self, acceptance)
+                msg.append(line)
+            elif pop != 0 and not pop_plus_imp == acceptance:
+                line = '{} - CX Calculated acceptance {} does not match generated acceptance {}'.format(self, acceptance,
+                                                                                                    max(1,
+                                                                                                        pop + self.importance))
+                msg.append(line)
+            if pop == 0 and homogeneity != 0:
+                line = '{} - CX Calculated homogeneity {} should be 0 for barren worlds'.format(self, homogeneity)
+                msg.append(line)
+            elif pop != 0 and not max(1, pop - 5) <= homogeneity <= pop + 5:
+                line = '{} - CX Calculated homogeneity {} not in range {} - {}'.format(self, homogeneity, max(1, pop - 5),
+                                                                                   pop + 5)
+                msg.append(line)
+            if self.economics is not None and labor != max(self.popCode - 1, 0):
+                line = '{} - EX Calculated labor {} does not match generated labor {}'.format(self, labor,
+                                                                                          max(self.popCode - 1, 0))
+                msg.append(line)
+
+        self._check_trade_code(msg, 'De', '0123456789ABC', '23456789', '0')
+        self._check_trade_code(msg, 'Ga', '678', '568', '567')
+        self._check_trade_code(msg, 'Fl', None, 'ABC', '123456789A')
+        self._check_trade_code(msg, 'Ic', None, '01', '123456789A')
+        self._check_trade_code(msg, 'Po', None, '2345', '0123')
+        self._check_trade_code(msg, 'He', '3456789ABC', '2479ABC', '012')
+        self._check_trade_code(msg, 'Wa', '3456789', '3456789DEF', 'A')
+        self._check_trade_code(msg, 'Oc', 'ABCD', '3456789DEF', 'A')
+        self._check_trade_code(msg, 'Va', None, '0', None)
+
+        code = 'Ba'
+        pop = '0'
+        self._check_pop_code(msg, code, pop)
+
+        code = 'Lo'
+        pop = '123'
+        self._check_pop_code(msg, code, pop)
+
+        code = 'Ni'
+        pop = '456'
+        self._check_pop_code(msg, code, pop)
+
+        code = 'Ph'
+        pop = '8'
+        self._check_pop_code(msg, code, pop)
+
+        code = 'Hi'
+        pop = '9ABCDEF'
+        self._check_pop_code(msg, code, pop)
+
+        self._check_econ_code(msg, 'Na', '0123', '0123', '6789ABCD')
+        self._check_econ_code(msg, 'Pi', '012479', None, '78')
+        self._check_econ_code(msg, 'In', '012479ABC', None, '9ABCD')
+        self._check_econ_code(msg, 'Pr', '68', None, '59')
+        self._check_econ_code(msg, 'Pa', '456789', '45678', '48')
+        self._check_econ_code(msg, 'Ri', '68', None, '678')
+        self._check_econ_code(msg, 'Ag', '456789', '45678', '567')
+        ParseStarInput.check_tl(self, fullmsg=msg)
+
+        return 0 == len(msg), msg
+
+    def _check_uwp(self):
+        if self.atmo not in '0123456789ABCDEF':
+            self.logger.warning('{}-{} Atmospheric code "{}" out of range - not in range 0-F'
+                                .format(self, self.uwp, self.atmo))
+        if self.hydro not in '0123456789A':
+            self.logger.warning('{}-{} Hydrographic code "{}" out of range - not in range 0-A'
+                                .format(self, self.uwp, self.hydro))
+
+        if 'X' == self.gov:  # Line up with how Lintsec treats 'X' government codes
+            self.logger.warning(
+                '{}-{} Calculated government code "{}" out of range - should be {}'.
+                    format(self, self.uwp, 'X', '0'))
+
+    def _check_trade_code(self, msg, code, size, atmo, hydro):
+        size = '0123456789ABCDEF' if size is None else size
+        atmo = '0123456789ABCDEF' if atmo is None else atmo
+        hydro = '0123456789A' if hydro is None else hydro
+
+        code_match = code in self.tradeCode.codeset
+        system_match = self.size in size and self.atmo in atmo and self.hydro in hydro
+
+        if code_match and not system_match:
+            line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)
+        elif system_match and not code_match:
+            line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)
+
+    def _check_pop_code(self, msg, code, pop):
+        check = True
+
+        pop_match = self.pop in pop
+        code_match = code in self.tradeCode.codeset
+
+        if pop_match and not code_match:
+            line = '{} - Calculated "{}" not in trade codes {}'.format(self, code, self.tradeCode.codeset)
+            msg.append(line)
+        if code_match and not pop_match:
+            line = '{} - Found invalid "{}" code on world with {} population: {}'.format(self, code, self.pop,
+                                                                                       self.tradeCode.codeset)
+            msg.append(line)
+            check = False
+        return check
+
+    def _check_econ_code(self, msg, code, atmo, hydro, pop):
+        atmo = '0123456789ABCDEF' if atmo is None else atmo
+        hydro = '0123456789A' if hydro is None else hydro
+        pop = '0123456789ABCD' if pop is None else pop
+
+        code_match = code in self.tradeCode.codeset
+        phys_match = self.atmo in atmo and self.hydro in hydro and self.pop in pop
+
+        if phys_match and not code_match:
+            line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)
+        if code_match and not phys_match:
+            line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, code, self.tradeCode.codeset)
+            msg.append(line)

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -156,14 +156,7 @@ class DeltaStar(Star):
 
             msg.append(line)
 
-        if '0' == str(self.atmo) and '0' == str(self.size) and '0' == str(self.hydro) and 'As' not in self.tradeCode.codeset:
-            code = 'As'
-            line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
-            msg.append(line)
-        elif 'As' in self.tradeCode.codeset and not ('0' == str(self.atmo) and '0' == str(self.size) and '0' == str(self.hydro)):
-            code = 'As'
-            line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, code, self.tradeCode.codeset)
-            msg.append(line)
+        self._check_trade_code(msg, 'As', '0', '0', '0')
 
         if ('O:' + self.position) in self.tradeCode.codes:
             line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, 'O:' + self.position, self.tradeCode.codes)

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -165,6 +165,13 @@ class DeltaStar(Star):
             line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, code, self.tradeCode.codeset)
             msg.append(line)
 
+        if ('O:' + self.position) in self.tradeCode.codes:
+            line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, 'O:' + self.position, self.tradeCode.codes)
+            msg.append(line)
+        if ('C:' + self.position) in self.tradeCode.codeset:
+            line = '{}-{} Found invalid "{}" in trade codes: {}'.format(self, self.uwp, 'C:' + self.position, self.tradeCode.codes)
+            msg.append(line)
+
         if self.social is not None:
             symbols = self._ehex_to_int(self.social[4] if self.social is not None else '1')  # TL + flux, min 1
             strangeness = self._ehex_to_int(self.social[3] if self.social is not None else '1')  # flux + 5

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -147,10 +147,7 @@ class DeltaStar(Star):
                                                                                          12 + self.importance)
                 msg.append(line)
 
-        if '0' == str(self.atmo) and 'Va' not in self.tradeCode.codeset:
-            code = 'Va'
-            line = '{}-{} Calculated "{}" not in trade codes {}'.format(self, self.uwp, code, self.tradeCode.codeset)
-            msg.append(line)
+        self._check_trade_code(msg, 'Va', None, '0', None)
         if not self.tradeCode.barren and 0 == efficiency:
             line = '{} - EX Calculated efficiency 0 should be coded as 1 (implied by p18, book 3 of T5.10)'.format(self)
 

--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -219,3 +219,55 @@ class ParseStarInput:
             transformed = ParseStarInput.transformer.transform(result)
 
         return transformed, is_station
+
+    @staticmethod
+    def check_tl(star, fullmsg=None):
+        if '???-' in str(star.uwp) or star.tl_unknown:
+            return
+
+        max_tl, min_tl = ParseStarInput.check_tl_core(star)
+
+        if min_tl <= star.tl <= max_tl:
+            return
+
+        msg = '{}-{} Calculated TL "{}" not in range {}-{}'.format(star, star.uwp, star.tl, min_tl, max_tl)
+
+        if not isinstance(fullmsg, list):
+            star.logger.error(msg)
+        else:
+            fullmsg.append(msg)
+
+    @staticmethod
+    def check_tl_core(star):
+        mod = 0
+        if star.size in '01':
+            mod += 2
+        elif star.size in '234':
+            mod += 1
+        if star.atmo in '0123ABCDEF':
+            mod += 1
+        if star.hydro in '9A':
+            mod += 1
+        if 'A' == star.hydro:
+            mod += 1
+        if star.pop in '123459ABCDEF':
+            mod += 1
+        if star.pop in '9ABCDEF':
+            mod += 1
+        if star.pop in 'ABCDEF':
+            mod += 2
+        if star.gov in '05':
+            mod += 1
+        elif 'D' == star.gov:
+            mod -= 2
+        if 'X' == star.port:
+            mod -= 4
+        if star.port in 'ABC':
+            mod += 2
+        if star.port in 'AB':
+            mod += 2
+        if 'A' == star.port:
+            mod += 2
+        min_tl = max(0, mod + 1)
+        max_tl = mod + 6
+        return max_tl, min_tl

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -13,6 +13,7 @@ import math
 from PyRoute.Position.Hex import Hex
 
 from PyRoute.Allies.AllyGen import AllyGen
+from PyRoute.Inputs.ParseStarInput import ParseStarInput
 from PyRoute.SystemData.Utilities import Utilities
 from collections import OrderedDict
 
@@ -138,6 +139,8 @@ class Star(object):
         result += str(self.uwp)
         star_list = str(self.star_list_object)
         result += " " + str(self.tradeCode).ljust(38)
+        if " " != result[-1]:
+            result += " "
         if self.oldskool:  # If Ix, Ex and Cx were all missing on the way _in_, they should be missing on the way _out_
             imp_chunk = ' '
             econ = ' '
@@ -560,6 +563,14 @@ class Star(object):
         if nu_symbols is not None:
             self.social = self.social[0:4] + nu_symbols + self.social[5:]
 
+    def fix_tl(self):
+        if self.tl_unknown:  # if TL is unknown, no point canonicalising it
+            return
+
+        max_tl, min_tl = ParseStarInput.check_tl_core(self)
+        new_tl = max(min_tl, min(max_tl, self.tl))
+        self.tl = Utilities.int_to_ehex(new_tl)
+
     def calculate_ru(self, ru_calc):
         if not self.economics:
             self.ru = 0
@@ -775,7 +786,9 @@ class Star(object):
     def canonicalise(self):
         self.uwp.canonicalise()
         self.tradeCode.canonicalise(self)
+        self.fix_tl()
         self.calculate_importance()
         self.fix_ex()
         self.fix_cx()
         self.star_list_object.canonicalise()
+        self.calculate_importance()

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -278,6 +278,10 @@ class Star(object):
         self.uwp.tl = value
 
     @property
+    def tl_unknown(self):
+        return '?' == self.uwp.tl
+
+    @property
     def star_list(self):
         return self.star_list_object.stars_list
 
@@ -462,16 +466,16 @@ class Star(object):
         homogeneity = self._ehex_to_int(self.social[1])  # pop + flux, min 1
         if pop == 0 and homogeneity != 0:
             self.logger.warning(
-                '{} - CX calculated homogeneity {} should be 0 for barren worlds'.format(self, homogeneity))
+                '{} - CX Calculated homogeneity {} should be 0 for barren worlds'.format(self, homogeneity))
         elif pop != 0 and not max(1, pop - 5) <= homogeneity <= pop + 5:
             self.logger.warning(
-                '{} - CX calculated homogeneity {} not in range {} - {}'.
+                '{} - CX Calculated homogeneity {} not in range {} - {}'.
                 format(self, homogeneity, max(1, pop - 5), pop + 5))
 
         acceptance = self._ehex_to_int(self.social[2])  # pop + Ix, min 1
         if pop == 0 and acceptance != 0:
             self.logger.warning(
-                '{} - CX calculated acceptance {} should be 0 for barren worlds'.format(self, acceptance))
+                '{} - CX Calculated acceptance {} should be 0 for barren worlds'.format(self, acceptance))
         elif pop != 0 and not max(1, pop + self.importance) == acceptance:
             self.logger.warning(
                 '{} - CX Calculated acceptance {} does not match generated acceptance {}'.
@@ -480,17 +484,17 @@ class Star(object):
         strangeness = self._ehex_to_int(self.social[3])  # flux + 5
         if pop == 0 and strangeness != 0:
             self.logger.warning(
-                '{} - CX calculated strangeness {} should be 0 for barren worlds'.format(self, strangeness))
+                '{} - CX Calculated strangeness {} should be 0 for barren worlds'.format(self, strangeness))
         elif pop != 0 and not 1 <= strangeness <= 10:
             self.logger.warning(
-                '{} - CX calculated strangeness {} not in range {} - {}'.format(self, strangeness, 1, 10))
+                '{} - CX Calculated strangeness {} not in range {} - {}'.format(self, strangeness, 1, 10))
 
         symbols = self._ehex_to_int(self.social[4])  # TL + flux, min 1
         if pop == 0 and symbols != 0:
-            self.logger.warning('{} - CX calculated symbols {} should be 0 for barren worlds'.format(self, symbols))
+            self.logger.warning('{} - CX Calculated symbols {} should be 0 for barren worlds'.format(self, symbols))
         elif pop != 0 and not max(1, self.tl - 5) <= symbols <= self.tl + 5:
             self.logger.warning(
-                '{} - CX calculated symbols {} not in range {} - {}'.
+                '{} - CX Calculated symbols {} not in range {} - {}'.
                 format(self, symbols, max(1, self.tl - 5), self.tl + 5))
 
     def fix_cx(self):

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -470,8 +470,6 @@ class Star(object):
             self.economics = self.economics[0:5] + nu_efficiency + self.economics[6:]
 
     def check_cx(self):
-        if not self.economics:
-            return
         if not self.social:
             return
         pop = self.popCode
@@ -511,8 +509,6 @@ class Star(object):
                 format(self, symbols, max(1, self.tl - 5), self.tl + 5))
 
     def fix_cx(self):
-        if not self.economics:
-            return
         if not self.social:
             return
         pop = self.popCode

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -765,7 +765,7 @@ class Star(object):
     def canonicalise(self):
         self.uwp.canonicalise()
         self.tradeCode.canonicalise(self)
+        self.calculate_importance()
         self.fix_ex()
         self.fix_cx()
         self.star_list_object.canonicalise()
-        self.calculate_importance()

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -424,6 +424,7 @@ class Star(object):
         resources = self._ehex_to_int(self.economics[1])
         labor = self._ehex_to_int(self.economics[2])
         infrastructure = self._ehex_to_int(self.economics[3])
+        efficiency = self._ehex_to_int(self.economics[5])
 
         if 8 > self.uwp.tl_code:
             nu_resources = self._int_to_ehex(max(0, min(12, resources)))
@@ -455,6 +456,15 @@ class Star(object):
 
         if nu_infrastructure is not None:
             self.economics = self.economics[0:3] + nu_infrastructure + self.economics[4:]
+
+        nu_efficiency = None
+        if self.tradeCode.barren:
+            nu_efficiency = '0'
+        elif efficiency == 0:
+            nu_efficiency = '1'
+
+        if nu_efficiency is not None:
+            self.economics = self.economics[0:5] + nu_efficiency + self.economics[6:]
 
     def check_cx(self):
         if not self.economics:

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -690,6 +690,7 @@ class TradeCodes(object):
             self._add_missing_trade_code(code)
 
     def _fix_econ_code(self, star, code, atmo, hydro, pop):
+        mapping = {'In': 'industrial', 'Ri': 'rich', 'Ag': 'agricultural'}
         atmo = '0123456789ABCDEF' if atmo is None else atmo
         hydro = '0123456789A' if hydro is None else hydro
         pop = '0123456789ABCD' if pop is None else pop
@@ -704,8 +705,13 @@ class TradeCodes(object):
             self._drop_invalid_trade_code(code)
         elif phys_match and not code_match:
             self._add_missing_trade_code(code)
+        if code in mapping:
+            mappi = mapping[code]
+            if mappi in self.__dict__:
+                del self.__dict__[mappi]
 
     def _fix_pop_code(self, star, code, pop):
+        mapping = {'Lo': 'low', 'Hi': 'high', 'Ni': 'nonindustrial', 'Ba': 'barren'}
         pop_match = star.pop in pop
         code_match = code in self.codeset
 
@@ -716,6 +722,10 @@ class TradeCodes(object):
             self._drop_invalid_trade_code(code)
         elif pop_match and not code_match:
             self._add_missing_trade_code(code)
+        if code in mapping:
+            mappi = mapping[code]
+            if mappi in self.__dict__:
+                del self.__dict__[mappi]
 
     def _fix_all_pop_codes(self, star):
         self._fix_pop_code(star, 'Ba', '0')

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -673,6 +673,8 @@ class TradeCodes(object):
         self._fix_econ_code(star, 'Ri', '68', None, '678')
 
         self._fix_all_pop_codes(star)
+        self._drop_invalid_trade_code('O:' + star.position)
+        self._drop_invalid_trade_code('C:' + star.position)
 
     def _fix_trade_code(self, star, code, size, atmo, hydro):
         size = '0123456789ABCDEF' if size is None else size

--- a/Tests/Hypothesis/Inputs/testHypothesisStarlineParser.py
+++ b/Tests/Hypothesis/Inputs/testHypothesisStarlineParser.py
@@ -76,7 +76,9 @@ def comparison_line(draw):
         '0000 000000000000000 0000000-0 [00000000000000 - -  [0000] - - A 000   00?',
         '0000 000000000000000 0000000-0 (00000000000000       B A A 000 0 0?)0000000000',
         ' 0 0000000-0 (00000000000000 - (000-0) - B A A 000   0?'
-        '0111 -2Z4ig11RbxW010 0000001-1 wJED9E(E(T (HN6 -  (113-0) -  - - B  114       00y'
+        '0111 -2Z4ig11RbxW010 0000001-1 wJED9E(E(T (HN6 -  (113-0) -  - - B  114       00y',
+        '0000 000000000000000 ???????-? (00000000000 )B       - - A 000   ?00',
+        '0000 000000000000000 ???????-? (0 0000000000)A       - - A 000    ?0'
     ]
 
     candidate = draw(from_regex(regex=ParseStarInput.starline, alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*'))
@@ -331,6 +333,8 @@ class testHypothesisStarlineParser(unittest.TestCase):
     @example('0000 000000000000000 0000000-0 [00000000000000 - -  [0000] - - A 000   00?', 'weird')
     @example('0000 000000000000000 0000000-0 (00000000000000       B A A 000 0 0?)0000000000', 'weird')
     @example('0000 000000000000000 0000000-0 (00000000000000 - (000-0) -  B A A 000   0?', 'weird')
+    @example('0000 000000000000000 ???????-? (00000000000 )B       - - A 000   ?00', 'weird')
+    @example('0000 000000000000000 ???????-? (0 0000000000)A       - - A 000    ?0', 'weird')
     def test_starline_parser_against_regex(self, s, match):
         # if it's a known weird-parse case, assume it out now
         assume(match != 'weird')

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -335,6 +335,9 @@ class testDeltaStar(unittest.TestCase):
     @example('0101 0                    A00B000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
     @example('0101 0                    A000E00-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 0                    A320000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000E00-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    AD00000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    AD20000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     def test_canonicalise_missing_trade_codes(self, starline):
         sector = Sector('# Core', '# 0, 0')
         star1 = None

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -251,6 +251,121 @@ class testDeltaStar(unittest.TestCase):
                     "Mismatch between parsing logs and canonical-check: " + starline + '\n' + tail
                 )
 
+    @given(starline())
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))
+    @example('0101 0                    A000000-0 As De                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Ga                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Fl                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As He                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A001000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Ic                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Oc                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Po                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A010000-0 As Va                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Wa                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Na                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Ag                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Pa                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Pi                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Pr                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As In                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Ri                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Lo                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Ph                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Ni                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As Hi                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    AE0A000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    def test_canonicalise_invalid_trade_codes(self, starline):
+        sector = Sector('# Core', '# 0, 0')
+        star1 = None
+        allowed_errors = [
+            'Input UWP malformed'
+        ]
+
+        try:
+            star1 = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
+        except ValueError as e:
+            rep = str(e)
+
+            if rep in allowed_errors:
+                pass
+            else:
+                raise e
+        assume(star1 is not None)
+
+        star1.index = 0
+        star1.allegiance_base = 'NaHu'
+
+        canonical_result, canonical_messages = star1.check_canonical()
+
+        star1.canonicalise()
+
+        nu_result, nu_messages = star1.check_canonical()
+        invalid = [item for item in nu_messages if 'Found invalid' in item and ('trade codes' in item or 'code on world' in item)]
+
+        self.assertTrue(
+            len(canonical_messages) >= len(nu_messages),
+            'New canonical-check messages should not happen: \n' + starline
+        )
+        self.assertEqual(0, len(invalid), 'At least one invalid trade code remaining: \n' + starline)
+
+    @given(starline())
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))
+    @example('0101 0                    A000000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000100-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 De De                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000400-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A001000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A020000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000600-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000700-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A0A1000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000800-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A044400-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000900-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000900-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A044500-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A320000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A33A000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A060500-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    AA3A000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A060600-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A655000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A00B000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000E00-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    def test_canonicalise_missing_trade_codes(self, starline):
+        sector = Sector('# Core', '# 0, 0')
+        star1 = None
+        allowed_errors = [
+            'Input UWP malformed'
+        ]
+
+        try:
+            star1 = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
+        except ValueError as e:
+            rep = str(e)
+
+            if rep in allowed_errors:
+                pass
+            else:
+                raise e
+        assume(star1 is not None)
+        star1.index = 0
+        star1.allegiance_base = 'NaHu'
+
+        canonical_result, canonical_messages = star1.check_canonical()
+
+        star1.canonicalise()
+
+        nu_result, nu_messages = star1.check_canonical()
+        invalid = [item for item in nu_messages if 'not in trade codes' in item]
+
+        self.assertTrue(
+            len(canonical_messages) >= len(nu_messages),
+            'New canonical-check messages should not happen: \n' + starline
+        )
+        badline = '' if 0 == len(invalid) else invalid[0]
+        self.assertEqual(0, len(invalid), 'At least one missing trade code not added: \n' + starline + '\n' + badline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -521,6 +521,8 @@ class testDeltaStar(unittest.TestCase):
     @example('0101 0                    A000000-0 As Ri                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 0                    A244500-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 0                    A000000-0 As As                                  { 0 } (001+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    A244500-0 As As O:0101                           { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    A244500-0 As As C:0101                           { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 000000000000000 ???????-? 000000000000000       - - A 000 0 00')
     @example('0101 000000000000000 ???????-? 000000000000000 - -  [0001] B - A 000   00')
     def test_canonicalise_from_regex_match_and_verify_idempotency(self, starline):

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -413,6 +413,91 @@ class testDeltaStar(unittest.TestCase):
         badline = '' if 0 == len(invalid) else invalid[0]
         self.assertEqual(0, len(invalid), 'At least one characteristic not canonicalised: \n' + starline + '\n' + badline)
 
+    @given(starline())
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))
+    @example('0101 0                    A000100-0 As As                                  { 0 } (001+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000100-0 As As                                  { 0 } (010+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000400-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000400-0 As As                                  { 0 } (006+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000700-0 As As                                  { 0 } (00D+0) [0000] - - A 000 0 NaHu G5 V')
+    def test_canonicalise_ex_on_non_barren_worlds(self, starline):
+        sector = Sector('# Core', '# 0, 0')
+        star1 = None
+        allowed_errors = [
+            'Input UWP malformed'
+        ]
+
+        try:
+            star1 = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
+        except ValueError as e:
+            rep = str(e)
+            if rep in allowed_errors:
+                pass
+            else:
+                raise e
+        assume(star1 is not None)
+        star1.index = 0
+        star1.allegiance_base = 'NaHu'
+
+        assume(not '0' == str(star1.pop) and 'Ba' not in star1.tradeCode.codes)
+
+        canonical_result, canonical_messages = star1.check_canonical()
+
+        star1.canonicalise()
+
+        nu_result, nu_messages = star1.check_canonical()
+        invalid = [item for item in nu_messages if (' - EX Calculated ' in item)]
+
+        self.assertTrue(
+            len(canonical_messages) >= len(nu_messages),
+            'New canonical-check messages should not happen: \n' + starline
+        )
+        badline = '' if 0 == len(invalid) else invalid[0]
+        self.assertEqual(0, len(invalid), 'At least one characteristic not canonicalised: \n' + starline + '\n' + badline)
+
+    @given(starline())
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))
+    @example('0101 0                    A000100-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000900-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 Coruscant            A000F00-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000100-0 As As                                  { 0 } (000+0) [7000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000100-0 As As                                  { 0 } (000+0) [00F0] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A140620-9 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    def test_canonicalise_cx_on_non_barren_worlds(self, starline):
+        sector = Sector('# Core', '# 0, 0')
+        star1 = None
+        allowed_errors = [
+            'Input UWP malformed'
+        ]
+
+        try:
+            star1 = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
+        except ValueError as e:
+            rep = str(e)
+            if rep in allowed_errors:
+                pass
+            else:
+                raise e
+        assume(star1 is not None)
+        star1.index = 0
+        star1.allegiance_base = 'NaHu'
+
+        assume(not '0' == str(star1.pop) and 'Ba' not in star1.tradeCode.codes)
+
+        canonical_result, canonical_messages = star1.check_canonical()
+
+        star1.canonicalise()
+
+        nu_result, nu_messages = star1.check_canonical()
+        invalid = [item for item in nu_messages if (' - CX Calculated ' in item)]
+
+        self.assertTrue(
+            len(canonical_messages) >= len(nu_messages),
+            'New canonical-check messages should not happen: \n' + starline
+        )
+        badline = '' if 0 == len(invalid) else invalid[0]
+        self.assertEqual(0, len(invalid), 'At least one characteristic not canonicalised: \n' + starline + '\n' + badline)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -521,23 +521,20 @@ class testDeltaStar(unittest.TestCase):
     @example('0101 0                    A000000-0 As Ri                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 0                    A244500-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 0                    A000000-0 As As                                  { 0 } (001+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 000000000000000 ???????-? 000000000000000       - - A 000 0 00')
+    @example('0101 000000000000000 ???????-? 000000000000000 - -  [0001] B - A 000   00')
     def test_canonicalise_from_regex_match_and_verify_idempotency(self, starline):
+        assume('00' != starline[0:2] and '00' != starline[2:4])
+        assume(33 > int(starline[0:2]) and 41 > int(starline[2:4]))
+
         sector = Sector('# Core', '# 0, 0')
         foo = None
-        allowed_errors = [
-            'Input UWP malformed',
-            'No stars found'
-        ]
 
         try:
             foo = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
         except ValueError as e:
-            rep = str(e)
+            pass
 
-            if rep in allowed_errors:
-                pass
-            else:
-                raise e
         assume(foo is not None)
 
         foo.index = 0

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -105,15 +105,15 @@ class testDeltaStar(unittest.TestCase):
             #('0917 Deyis II             E874000-0 Ba Da (Kebkh) Re                      { -3 } (200-5) [0000] -     -  A 000 10 ImDi K4 II                                                        ',
             # '0917 Deyis II             E874000-2 Ba Da Di(Kebkh) Re                    { -3 } (200-5) [0000] -    -  A 000 10 ImDi K4 II                                                   '),
             ('0235 Oduart               C7B3004-5 Fl Di(Oduart) Da             { -2 } (800+2) [0000] - M  A 004 10 HvFd G4 V M3 V M7 V',
-             '0235 Oduart               C7B3004-5 Ba Da Di(Oduart) Fl                   { -2 } (800+2) [0000] -    M  A 004 10 HvFd G4 V M3 V M7 V                                          '),
+             '0235 Oduart               C7B3004-5 Ba Da Di(Oduart) Fl                   { -2 } (800+0) [0000] -    M  A 004 10 HvFd G4 V M3 V M7 V                                          '),
             ('0101                      X73A000-0 Ba Lo Ni Wa                         - -  - 012   --',
              '0101                      X738000-3 Ba                                    { -3 } -       -      -    -  - 012 0  --                                                           '),
             ('0527 Wellington Base      AEFA422-E Ht Ni Oc                            - M  R 711   He',
-             '0527 Wellington Base      AEFA422-A Ht Ni Oc                              { 1 }  -       -      -    M  R 711 0  He                                                           '),
+             '0527 Wellington Base      AEFA422-B Ht Ni Oc                              { 1 }  -       -      -    M  R 711 0  He                                                           '),
             ('0239 Etromen              CFB8558-B Fl Ni                               - -  A 523   Na',
              '0239 Etromen              CFB8558-8 Fl Ni                                 { -2 } -       -      -    -  A 523 0  Na                                                           '),
             ('1220 Gateway              A002688-B As Ic Na Ni Va Cx      { 1 }  (C55+1) [675B] - -  - 822 16 GaFd A2 V F0 V',
-             '1220 Gateway              A000688-9 As Cx Na Ni Va                        { 0 }  (C55+1) [675B] -    -  - 822 16 GaFd A2 V F0 V                                               '),
+             '1220 Gateway              A000688-A As Cx Na Ni Va                        { 1 }  (C55+1) [675B] -    -  - 822 16 GaFd A2 V F0 V                                               '),
             ('0825 Corstation           C005100-8 As Ic Lo Va            { -2 } (500-5) [1113] - -  - 211 14 GaFd M0 V M1 V',
              '0825 Corstation           C000100-8 As Lo Va                              { -2 } (500-5) [1113] -    -  - 211 14 GaFd M0 V M1 VI                                              '),
             ('3222 Ardh                           C001554-A As Ic Ni Va          {+0} (843+1) [658A] - C - 601   Ve F9 V',
@@ -122,22 +122,22 @@ class testDeltaStar(unittest.TestCase):
              '2738 Taen                 B000685-8 As Na Ni Va                           { -1 } (J52-2) [3559] -    N  - 533 0  Ve   M9 V                                                    '),
             # Population zero, TL 0, alongside a specific dieback should keep the barren
             ('0924 Ognar                X867000-0 Ba Ga Di(Ogna)       {-3 } (300+1) [0000] - -  R 004 10 Og K1 V',
-             '0924 Ognar                X867000-2 Ba Di(Ogna) Ga                        { -3 } (300+1) [0000] -    -  R 004 10 Og   K1 V                                                    '),
+             '0924 Ognar                X867000-2 Ba Di(Ogna) Ga                        { -3 } (300+0) [0000] -    -  R 004 10 Og   K1 V                                                    '),
             # Dieback of two-word sophont name tripped things up
             ('2117 Sabmiqys             A560056-H De Fo Di(Gya Ks)          { 2 }  (600-4) [0000] -    -  R 004 9  ImDa G3 V          ',
-             '2117 Sabmiqys             A561056-6 Ba Di(Gya Ks) Fo                      { -1 } (600-4) [0000] -    -  R 004 9  ImDa G3 V                                                    '),
+             '2117 Sabmiqys             A561056-8 Ba Di(Gya Ks) Fo                      { -1 } (600-0) [0000] -    -  R 004 9  ImDa G3 V                                                    '),
             # Treat Gov code X with population as Gov 0
             ('1702 Eslalyat             B493AXB-A Hi In                               - M  R 211   Dr        ',
-             '1702 Eslalyat             B494A5A-A Hi In                                 { 4 }  -       -      -    M  R 211 0  Dr                                                           '),
+             '1702 Eslalyat             B494A5A-B Hi In                                 { 4 }  -       -      -    M  R 211 0  Dr                                                           '),
             # <TL8 worlds should have max resources 12
             ('1620 Daydyor Yashas       X683973-4 Hi Pr                { 1 }  (E8D+2) [9AAD] - -  - 323 14 NaXX F7 V',
              '1620 Daydyor Yashas       X683973-4 Hi Pr                                 { -1 } (C8B+2) [98A9] -    -  - 323 14 NaXX F7 V                                                    '),
             # Atmo should be capped to F, hydro capped to A
             ('1920 Rainbow Sun          AAVV997-D Hi In Sp                            - KM - 223   Na',
-             '1920 Rainbow Sun          AAFA997-B Hi Oc Sp                              { 5 }  -       -      -    KM - 223 0  Na                                                           '),
+             '1920 Rainbow Sun          AAFA997-C Hi Oc Sp                              { 4 }  -       -      -    KM - 223 0  Na                                                           '),
             # TL8+ worlds should have max resources 12 + belts + GGs
             ('1620 Daydyor Yashas       X683973-D Hi Pr                { 1 }  (F8D+2) [9AAD] - -  - 311 14 NaXX F7 V',
-             '1620 Daydyor Yashas       X683973-8 Hi Pr                                 { -1 } (E8D+2) [9AAD] -    -  - 311 14 NaXX F7 V                                                    '),
+             '1620 Daydyor Yashas       X683973-4 Hi Pr                                 { -1 } (C8B+2) [98A9] -    -  - 311 14 NaXX F7 V                                                    '),
         ]
 
         sector = Sector('# Core', '# 0, 0')

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -1,7 +1,99 @@
+import copy
+from datetime import timedelta
+import logging
 import unittest
+
+from hypothesis import given, assume, example, HealthCheck, settings
+from hypothesis.strategies import text, lists, from_regex, composite, booleans, sampled_from, integers, floats
 
 from PyRoute.AreaItems.Sector import Sector
 from PyRoute.DeltaStar import DeltaStar
+from PyRoute.Inputs.ParseStarInput import ParseStarInput
+from PyRoute.TradeCodes import TradeCodes
+
+tradecodes = []
+
+
+@composite
+def trade_code(draw):
+    if 0 == len(tradecodes):
+        tradecodes.extend(TradeCodes.pcodes)
+        tradecodes.extend(TradeCodes.dcodes)
+        tradecodes.extend(TradeCodes.ext_codes)
+        tradecodes.extend(TradeCodes.allowed_residual_codes)
+
+    strat = sampled_from(tradecodes)
+
+    return draw(lists(strat, min_size=2, max_size=12))
+
+
+@composite
+def starline(draw):
+    col = draw(integers(min_value=1, max_value=32))
+    row = draw(integers(min_value=1, max_value=40))
+    posn = str(col).rjust(2, '0') + str(row).rjust(2, '0')
+
+    name = draw(text(min_size=1, max_size=15)).ljust(20)
+
+    port = draw(text(min_size=1, max_size=1, alphabet="ABCDEX"))
+    uwp_alphabet = '0123456789ABCDEFGH'
+
+    uwp = port + draw(text(min_size=6, max_size=6, alphabet=uwp_alphabet)) + '-' + draw(text(min_size=1, max_size=1, alphabet=uwp_alphabet))
+
+    # TODO - tradecode picks
+    trade_array = draw(trade_code())
+    tradeCodes = ' '.join(trade_array)
+
+    extension_alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    # importance gets autogenned
+    importance = '{ 0 }'
+
+    # ex
+    ex_tail = draw(integers(min_value=-5, max_value=5))
+    if 0 > ex_tail:
+        stub = str(ex_tail)
+    else:
+        stub = '+' + str(ex_tail)
+
+    ex = '(' + draw(text(min_size=3, max_size=3, alphabet=extension_alphabet)) + stub + ')'
+
+    # cx
+    cx = '[' + draw(text(min_size=4, max_size=4, alphabet=extension_alphabet)) + ']'
+
+    flip = draw(floats(min_value=0.0, max_value=1.0))
+
+    noble_alphabet = 'BcCDeEfFGH'
+    if 0.7 < flip:
+        nobles = '-'
+    else:
+        nobles = draw(text(min_size=1, max_size=5, alphabet=noble_alphabet))
+
+    base = '-'
+    tradezone = draw(text(min_size=1, max_size=1, alphabet='-ARUF--'))
+
+    pbg = draw(text(min_size=3, max_size=3, alphabet='0123456789'))
+
+    worlds = str(draw(integers(min_value=0, max_value=12)))
+
+    alg = 'NaHu'
+
+    star = 'G5 V'
+
+    starline = posn + ' ' + name + ' ' + uwp + ' ' + tradeCodes.ljust(38) + ' ' + importance + ' ' + ex + ' ' + cx + ' ' \
+               + nobles + ' ' + base + ' ' + tradezone + ' ' + pbg + ' ' + worlds + ' ' + alg + ' ' + star
+
+    return starline
+
+
+@composite
+def mixed_starline(draw):
+    choice = draw(floats(min_value=0.0, max_value=1.0))
+    if 0.5 < choice:
+        res = from_regex(regex=ParseStarInput.starline,
+                      alphabet='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWYXZ -{}()[]?\'+*')
+    else:
+        res = starline()
+    return draw(res)
 
 
 class testDeltaStar(unittest.TestCase):
@@ -57,6 +149,107 @@ class testDeltaStar(unittest.TestCase):
                 foo_string = foo.parse_to_line()
 
                 self.assertEqual(expected, foo_string, 'Unexpected canonicalisation result')
+
+    """
+    Given a Star object read in from a starline, trapping log error messages, ensure DeltaStar.check_canonical returns
+    same number of messages
+    """
+    @given(starline())
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))
+    @example('0101 0                    A000000-0                                       { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V ')
+    @example('0101 0                    A000000-0                                       { 0 } (000+0) [0000] BBBBB - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As                                     { 0 } (000+0) [0001] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 De                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 Ga                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As                                     { 0 } (000+0) [0010] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As                                     { 0 } (000+0) [0100] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000100-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000200-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A00B000-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000400-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 Fl                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 As                                     { 0 } (00C+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A001000-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000600-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000700-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000900-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A020000-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 He                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 Wa                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A060500-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A044400-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 Oc                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A010000-0 Va                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 Ri                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 \n                    A000000-0 As                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000000-0 Ag                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000900-0 Lo                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A00B000-0 Va                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
+    @example('0101 0                    A000E00-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    AD01000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    def test_check_canonicalisation(self, starline):
+        outer_logger = logging.getLogger("PyRoute.Star")
+        inner_logger = logging.getLogger("PyRoute.TradeCodes")
+
+        outer_logger.manager.disable = 0
+        outer_logger.setLevel(10)
+        inner_logger.manager.disable = 0
+        inner_logger.setLevel(10)
+
+        sector = Sector('# Core', '# 0, 0')
+
+        with self.assertLogs(outer_logger, "DEBUG") as outer_logs:
+            self.assertTrue(outer_logger.isEnabledFor(10), "Outer logger disabled for DEBUG")
+            self.assertTrue(inner_logger.isEnabledFor(10), "Inner logger disabled for DEBUG")
+            with self.assertLogs(inner_logger, "DEBUG") as inner_logs:
+                outer_logger.debug(
+                    'Dummy log entry to shut assertion up now that canonicalisation has been straightened out'
+                )
+                self.assertEqual(1, len(outer_logs.output), "Dummy log message not in outer_logs")
+                inner_logger.debug(
+                    'Dummy log entry to shut assertion up now that canonicalisation has been straightened out'
+                )
+                self.assertEqual(1, len(inner_logs.output), "Dummy log message not in inner_logs")
+
+                star1 = None
+                allowed_errors = [
+                    'Input UWP malformed'
+                ]
+
+                try:
+                    star1 = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
+                except ValueError as e:
+                    rep = str(e)
+
+                    if rep in allowed_errors:
+                        pass
+                    else:
+                        raise e
+                assume(star1 is not None)
+                star1.index = 0
+                star1.allegiance_base = 'NaHu'
+                self.assertIsNotNone(star1, "Fatal failure parsing line: " + starline)
+                self.assertTrue(isinstance(star1, DeltaStar), "Error parsing line: " + starline)
+
+                output = copy.deepcopy(outer_logs.output)
+                output.extend(inner_logs.output)
+                self.assertTrue(0 < len(output), "At least one log message expected")
+                # trim complaints about calculated importance - that's fixed on import
+                output = [line for line in output if "Calculated importance" not in line]
+                # trim log lines of less than warning severity - "DEBUG" is set to ensure there will be output to grab
+                output = [line for line in output if 'DEBUG:' not in line and 'INFO:' not in line]
+
+                canonical_result, canonical_messages = star1.check_canonical()
+                for msg in canonical_messages:
+                    output = [line for line in output if msg not in line]
+
+                num_output = len(output)
+                tail = output[0] if 0 < len(output) else ''
+                self.assertEqual(
+                    0,
+                    num_output,
+                    "Mismatch between parsing logs and canonical-check: " + starline + '\n' + tail
+                )
 
 
 if __name__ == '__main__':

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -187,6 +187,7 @@ class testDeltaStar(unittest.TestCase):
     @example('0101 0                    A00B000-0 Va                                     { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
     @example('0101 0                    A000E00-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 0                    AD01000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    AD20000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     def test_check_canonicalisation(self, starline):
         outer_logger = logging.getLogger("PyRoute.Star")
         inner_logger = logging.getLogger("PyRoute.TradeCodes")
@@ -333,6 +334,7 @@ class testDeltaStar(unittest.TestCase):
     @example('0101 0                    A655000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
     @example('0101 0                    A00B000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
     @example('0101 0                    A000E00-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
+    @example('0101 0                    A320000-0 As As                                  { 0 } (000+0) [0000] - - A 000 0 NaHu G5 V')
     def test_canonicalise_missing_trade_codes(self, starline):
         sector = Sector('# Core', '# 0, 0')
         star1 = None
@@ -525,6 +527,7 @@ class testDeltaStar(unittest.TestCase):
     @example('0101 0                    A244500-0 As As C:0101                           { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     @example('0101 000000000000000 ???????-? 000000000000000       - - A 000 0 00')
     @example('0101 000000000000000 ???????-? 000000000000000 - -  [0001] B - A 000   00')
+    @example('0101 0                    A201000-0 As As                                  { 0 } (000+0) [0000] B - A 000 0 NaHu G5 V')
     def test_canonicalise_from_regex_match_and_verify_idempotency(self, starline):
         assume('00' != starline[0:2] and '00' != starline[2:4])
         assume(33 > int(starline[0:2]) and 41 > int(starline[2:4]))

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -221,7 +221,7 @@ class testStar(unittest.TestCase):
         self.assertTrue(foo.is_well_formed())
 
     @given(canonical_check())
-    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(1000))
+    @settings(suppress_health_check=[HealthCheck(3), HealthCheck(2)], deadline=timedelta(3000))
     @example('1919 Khula                ???????-? Hi In Pz Di(Khulans)      {0}  (000-0) [0000] BEf  N  A 510 10 ImDv M0 V')
     def test_star_canonicalise(self, s):
         hyp_line = "Hypothesis input: " + s


### PR DESCRIPTION
Big one here is making individual-star canonicalisation _idempotent_ - canonicalising a given star _once_ and _more than once_ has the same net effect.

It allows the user to be confident that they will only need to canonicalise a given star once, and it won't hurt anything if it's canonicalised more than once.