### PR TITLE
Wring out trade codes parsing

### DIFF
--- a/PyRoute/Errors/MultipleWPopError.py
+++ b/PyRoute/Errors/MultipleWPopError.py
@@ -1,0 +1,10 @@
+"""
+Created on Jan 01, 2025
+
+@author: CyberiaResurrection
+"""
+
+
+class MultipleWPopError(ValueError):
+
+    pass

--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -73,7 +73,12 @@ class ParseStarInput:
             if 'Input UWP malformed' == str(e):
                 return None
             raise e
-        star.tradeCode = TradeCodes(data[3].strip())
+        try:
+            star.tradeCode = TradeCodes(data[3].strip())
+        except ValueError as e:
+            if 'Can only have at most one W-pop sophont' == str(e):
+                return None
+            raise e
         star.ownedBy = star.tradeCode.owned_by(star)
 
         raw_economics = data[6].strip().upper() if data[6] else None

--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -7,6 +7,7 @@ import re
 
 from lark import UnexpectedCharacters, UnexpectedEOF
 
+from PyRoute.Errors.MultipleWPopError import MultipleWPopError
 from PyRoute.Inputs.StarlineStationParser import StarlineStationParser
 from PyRoute.Inputs.StarlineStationTransformer import StarlineStationTransformer
 from PyRoute.Inputs.StarlineTransformer import StarlineTransformer
@@ -75,10 +76,8 @@ class ParseStarInput:
             raise e
         try:
             star.tradeCode = TradeCodes(data[3].strip())
-        except ValueError as e:
-            if 'Can only have at most one W-pop sophont' == str(e):
-                return None
-            raise e
+        except MultipleWPopError:
+            return None
         star.ownedBy = star.tradeCode.owned_by(star)
 
         raw_economics = data[6].strip().upper() if data[6] else None

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -9,6 +9,8 @@ import re
 import logging
 import sys
 
+from PyRoute.Errors.MultipleWPopError import MultipleWPopError
+
 
 class TradeCodes(object):
     """
@@ -118,7 +120,7 @@ class TradeCodes(object):
             m_pop = [item for item in homeworld_major if item.endswith(']')]
             s_pop = [item for item in self.sophont_list if item.endswith('W')]
             if 1 < (len(w_pop) + len(m_pop) + len(s_pop)):
-                raise ValueError("Can only have at most one W-pop sophont")
+                raise MultipleWPopError("Can only have at most one W-pop sophont")
 
         # catch pseudo-[homeworld] candidates
         pseudo_major = [item for item in self.codes if item.startswith('[') and (1 < item.count('[') and 1 < item.count(']'))]

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -237,6 +237,13 @@ class TradeCodes(object):
         left_bracket = raw[0]
         right_bracket = ']' if '[' == left_bracket else ')'
 
+        if '(' == left_bracket:
+            raw = '(' + raw.lstrip('(')
+            raw = raw.rstrip(')') + ')'
+        elif '[' == left_bracket:
+            raw = '[' + raw.lstrip('[')
+            raw = raw.rstrip(']') + ']'
+
         trim = raw[1:-1]
         if 35 < len(trim):
             trim = trim[0:35]

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -155,7 +155,9 @@ class TradeCodes(object):
         # "(Carte Blanche)", and bolt them together
         num_codes = len(raw_codes)
         codes = []
-        for i in range(0, num_codes):
+        i = -1
+        while i < num_codes - 1:
+            i += 1
             raw = raw_codes[i]
             # Filter duplicates
             if raw in codes:
@@ -170,6 +172,11 @@ class TradeCodes(object):
                 raw = '[' + raw.lstrip('[')
             if raw.startswith('(('):
                 raw = '(' + raw.lstrip('(')
+            if 2 < len(raw):
+                if raw.startswith('[]'):
+                    raw = raw[2:]
+                elif raw.startswith('()'):
+                    raw = raw[2:]
             if raw.startswith('Di('):
                 if not raw.endswith(')') and i < num_codes - 1:
                     next = raw_codes[i + 1]
@@ -215,9 +222,8 @@ class TradeCodes(object):
                 stub = raw[moshdex:]
                 raw = raw[:moshdex]
                 codes.append(raw)
-                if i < num_codes - 1:
-                    raw_codes.insert(i + 1, stub)
-                    num_codes += 1
+                raw_codes.insert(i + 1, stub)
+                num_codes += 1
                 continue
             if not raw.startswith('(') and not raw.endswith(')') and '(' in raw and ')' in raw:
                 if not raw.startswith('[') and not raw.endswith(']'):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -140,6 +140,10 @@ class TradeCodes(object):
             self._process_major_race_homeworld(homeworld, homeworlds_found)
         for deadworld in deadworlds:
             self._process_deadworld(deadworld, homeworlds_found)
+        # bolt on pseudo_major results so they don't get counted as something else
+        homeworlds_found.extend(pseudo_major)
+        for item in pseudo_major:
+            self.codes.remove(item)
         return homeworlds_found
 
     def _preprocess_initial_codes(self, initial_codes):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -112,6 +112,13 @@ class TradeCodes(object):
         homeworld_matches = TradeCodes.dieback.findall(initial_codes)
         # bolt on direct [homeworld] candidates
         homeworld_major = [item for item in self.codes if item.startswith('[') and 1 == item.count('[') and 1 == item.count(']')]
+        # reject homeworld matches that are strict subsect of any major homeworld matches
+        if 0 < len(homeworld_matches) and 0 < len(homeworld_major):
+            for match in homeworld_matches:
+                over = [item for item in homeworld_major if match in item]
+                if 0 < len(over):
+                    homeworld_matches.remove(match)
+
         deadworlds = [item for item in self.codes if 5 == len(item) and 'X' == item[4]]
         for homeworld in homeworld_matches:
             self._process_homeworld(homeworld, homeworlds_found, initial_codes)

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -136,6 +136,8 @@ class TradeCodes(object):
                 continue
             if ')' == raw:
                 continue
+            if raw.startswith(')]') or raw.startswith('])'):
+                continue
             if raw.startswith('Di('):
                 if not raw.endswith(')') and i < num_codes - 1:
                     next = raw_codes[i + 1]

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -217,11 +217,6 @@ class TradeCodes(object):
                     pop = raw[1]
                     codes.append('Droy' + pop)
                     continue
-            if not raw.startswith('(') and '(' in raw and raw.endswith(')'):
-                continue
-            if not raw.endswith(')') and ')' in raw and raw.startswith('(') and 7 > len(raw):
-                if not (')' == raw[-2] and (raw[-1] in 'WX?' or raw[-1].isdigit())):
-                    continue
             if 3 < len(raw) and 'Di(' in raw:
                 moshdex = raw.find('Di(')
                 stub = raw[moshdex:]
@@ -230,10 +225,16 @@ class TradeCodes(object):
                 raw_codes.insert(i + 1, stub)
                 num_codes += 1
                 continue
+            if not raw.startswith('(') and '(' in raw and raw.endswith(')'):
+                continue
+            if not raw.endswith(')') and ')' in raw and raw.startswith('(') and 7 > len(raw):
+                if not (')' == raw[-2] and (raw[-1] in 'WX?' or raw[-1].isdigit())):
+                    continue
             if not raw.startswith('(') and not raw.endswith(')') and '(' in raw and ')' in raw:
                 if not raw.startswith('[') and not raw.endswith(']'):
                     continue
-            if 7 == len(raw) and '(' == raw[0] and ')' == raw[5]:  # Let preprocessed sophont codes through
+            if 7 <= len(raw) and '(' == raw[0] and ')' == raw[5]:  # Let preprocessed sophont codes through
+                raw = raw[0:7]
                 codes.append(raw)
                 continue
             if not raw.startswith('(') and not raw.startswith('['):  # this isn't a sophont code

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -124,6 +124,7 @@ class TradeCodes(object):
 
         # catch pseudo-[homeworld] candidates
         pseudo_major = [item for item in self.codes if item.startswith('[') and (1 < item.count('[') and 1 < item.count(']'))]
+        pseudo_major.extend([item for item in self.codes if item.startswith('[]')])
         # reject homeworld matches that are strict subsect of any major homeworld matches
         if 0 < len(homeworld_matches) and 0 < len(homeworld_major):
             for match in homeworld_matches:
@@ -298,6 +299,8 @@ class TradeCodes(object):
         @type homeworld: string
         @type homeworlds_found: list
         """
+        if homeworld.startswith('[]'):
+            return
         full_name = re.sub(r'\[([^)]+)\][\d|W]?', r'\1', homeworld)
         pop = 'W' if ']' == homeworld[-1] else homeworld[-1]
         homeworlds_found.append(homeworld)

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -78,7 +78,7 @@ class TradeCodes(object):
         Constructor
         """
         self.logger = logging.getLogger('PyRoute.TradeCodes')
-        self.codes, initial_codes = self._preprocess_initial_codes(initial_codes)
+        self.codes, initial_codes = self._preprocess_initial_codes(initial_codes.strip())
         self.pcode = set(TradeCodes.pcodes) & set(self.codes)
         self.dcode = set(TradeCodes.dcodes) & set(self.codes)
         self.xcode = TradeCodes.ext_codes & set(self.codes)

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -67,7 +67,7 @@ class TradeCodes(object):
 
     # Search regexen
     search = re.compile(r'\w{,2}\(([^)]{,4})[^)]*\)(\d|W|X|\?)?')
-    search_major = re.compile(r'\w{,2}\[([^)]{,4})[^)]*\](\d|W|X|\?)?')
+    search_major = re.compile(r'\w{,2}\[([^()]{,4})[^)]*\](\d|W|X|\?)?')
     sophont = re.compile(r"[A-Za-z\'!]{1}[\w\'!]{2,4}(\d|W|\?)")
     dieback = re.compile(r"[Di]*\([^)]+\)\d?")
 
@@ -184,7 +184,7 @@ class TradeCodes(object):
                         combo = raw + ' ' + next
                         codes.append(combo)
                         raw_codes[i + 1] = ''
-                    elif ')' == next[-2] and next[-1].isdigit():
+                    elif 2 < len(next) and ')' == next[-2] and next[-1].isdigit():
                         combo = raw + ' ' + next[:-1]
                         codes.append(combo)
                         raw_codes[i + 1] = ''
@@ -201,6 +201,11 @@ class TradeCodes(object):
                 if not (raw[-1] in 'WX?' or raw[-1].isdigit()):
                     raw = raw[:-1]
                     raw = self._trim_overlong_homeworld_code(raw)  # trim overlong _major_ race homeworld
+                else:
+                    pop = raw[-1]
+                    raw = raw[:-1]
+                    raw = self._trim_overlong_homeworld_code(raw)
+                    raw = raw + pop
                 codes.append(raw)
                 continue
             if 2 == len(raw) and ('W' == raw[1] or raw[1].isdigit()):
@@ -284,6 +289,8 @@ class TradeCodes(object):
             raw = raw.rstrip(']') + ']'
 
         trim = raw[1:-1]
+        trim = trim.replace(left_bracket, '')
+        trim = trim.replace(right_bracket, '')
         if 35 < len(trim):
             trim = trim[0:35]
 

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -116,8 +116,8 @@ class TradeCodes(object):
         homeworld_major = [item for item in self.codes if item.startswith('[') and 1 == item.count('[') and 1 == item.count(']')]
         # catch situation with two or more W-pop sophonts - can't happen
         if 1 < (len(homeworld_matches) + len(homeworld_major) + len(self.sophont_list)):
-            w_pop = [item for item in homeworld_matches if item.endswith(')')]
-            m_pop = [item for item in homeworld_major if item.endswith(']')]
+            w_pop = [item for item in homeworld_matches if item.endswith(')') or item.endswith('W')]
+            m_pop = [item for item in homeworld_major if item.endswith(']') or item.endswith('W')]
             s_pop = [item for item in self.sophont_list if item.endswith('W')]
             if 1 < (len(w_pop) + len(m_pop) + len(s_pop)):
                 raise MultipleWPopError("Can only have at most one W-pop sophont")
@@ -658,7 +658,7 @@ class TradeCodes(object):
         big_sophs = [code for code in self.sophont_list if code.endswith('W')]
         if 1 < len(big_sophs):
             sophs = ' '.join(big_sophs)
-            msg = "Can have at most one W-pop sophont.  Have " + sophs
+            msg = "Can only have at most one W-pop sophont.  Have " + sophs
             return False, msg
 
         return result, msg

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -166,6 +166,10 @@ class TradeCodes(object):
                 continue
             if raw.startswith(')]') or raw.startswith('])'):
                 continue
+            if raw.startswith('[['):
+                raw = '[' + raw.lstrip('[')
+            if raw.startswith('(('):
+                raw = '(' + raw.lstrip('(')
             if raw.startswith('Di('):
                 if not raw.endswith(')') and i < num_codes - 1:
                     next = raw_codes[i + 1]

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -118,6 +118,10 @@ class TradeCodes(object):
                 over = [item for item in homeworld_major if match in item]
                 if 0 < len(over):
                     homeworld_matches.remove(match)
+        # reject homeworld matches that contain major homeworld fragments or are otherwise empty
+        if 0 < len(homeworld_matches):
+            homeworld_matches = [item for item in homeworld_matches if ']' not in item and '[' not in item]
+            homeworld_matches = [item for item in homeworld_matches if '' != item[1:-1].strip()]
 
         deadworlds = [item for item in self.codes if 5 == len(item) and 'X' == item[4]]
         for homeworld in homeworld_matches:

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -64,8 +64,8 @@ class TradeCodes(object):
     }
 
     # Search regexen
-    search = re.compile(r'\w{,2}\(([^)]{,4})[^)]*\)(\d|W|\?)?')
-    search_major = re.compile(r'\w{,2}\[([^)]{,4})[^)]*\](\d|W|\?)?')
+    search = re.compile(r'\w{,2}\(([^)]{,4})[^)]*\)(\d|W|X|\?)?')
+    search_major = re.compile(r'\w{,2}\[([^)]{,4})[^)]*\](\d|W|X|\?)?')
     sophont = re.compile(r"[A-Za-z\'!]{1}[\w\'!]{2,4}(\d|W|\?)")
     dieback = re.compile(r"[Di]*\([^)]+\)\d?")
 
@@ -178,15 +178,17 @@ class TradeCodes(object):
                 codes.append(raw)
                 continue
             if not raw.startswith('(') and not raw.startswith('['):  # this isn't a sophont code
-                codes.append(raw)
-                continue
+                if not raw.endswith(')') and not raw.endswith(']'):
+                    codes.append(raw)
+                    continue
             if raw.endswith(')') or raw.endswith(']'):  # this _is_ a sophont code
-                if raw.startswith('[') and raw.endswith(']'):
-                    raw = self._trim_overlong_homeworld_code(raw)  # trim overlong _major_ race homeworld
-                elif raw.startswith('(') and raw.endswith(')'):
-                    raw = self._trim_overlong_homeworld_code(raw)  # trim overlong _minor_ race homeworld
-                codes.append(raw)
-                continue
+                if raw.startswith('(') or raw.startswith('['):
+                    if raw.startswith('[') and raw.endswith(']'):
+                        raw = self._trim_overlong_homeworld_code(raw)  # trim overlong _major_ race homeworld
+                    elif raw.startswith('(') and raw.endswith(')'):
+                        raw = self._trim_overlong_homeworld_code(raw)  # trim overlong _minor_ race homeworld
+                    codes.append(raw)
+                    continue
             if i < num_codes - 1:
                 next = raw_codes[i + 1]
                 if next.endswith(')') or next.endswith(']'):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -112,6 +112,16 @@ class TradeCodes(object):
         homeworld_matches = TradeCodes.dieback.findall(initial_codes)
         # bolt on direct [homeworld] candidates
         homeworld_major = [item for item in self.codes if item.startswith('[') and 1 == item.count('[') and 1 == item.count(']')]
+        # catch situation with two or more W-pop sophonts - can't happen
+        if 1 < (len(homeworld_matches) + len(homeworld_major) + len(self.sophont_list)):
+            w_pop = [item for item in homeworld_matches if item.endswith(')')]
+            m_pop = [item for item in homeworld_major if item.endswith(']')]
+            s_pop = [item for item in self.sophont_list if item.endswith('W')]
+            if 1 < (len(w_pop) + len(m_pop) + len(s_pop)):
+                raise ValueError("Can only have at most one W-pop sophont")
+
+        # catch pseudo-[homeworld] candidates
+        pseudo_major = [item for item in self.codes if item.startswith('[') and (1 < item.count('[') and 1 < item.count(']'))]
         # reject homeworld matches that are strict subsect of any major homeworld matches
         if 0 < len(homeworld_matches) and 0 < len(homeworld_major):
             for match in homeworld_matches:

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -172,6 +172,10 @@ class TradeCodes(object):
                         combo = raw + ' ' + next
                         codes.append(combo)
                         raw_codes[i + 1] = ''
+                    elif ')' == next[-2] and next[-1].isdigit():
+                        combo = raw + ' ' + next[:-1]
+                        codes.append(combo)
+                        raw_codes[i + 1] = ''
                 else:
                     codes.append(raw)
                 continue
@@ -199,6 +203,15 @@ class TradeCodes(object):
             if not raw.startswith('(') and '(' in raw and raw.endswith(')'):
                 continue
             if not raw.endswith(')') and ')' in raw and raw.startswith('(') and 7 > len(raw):
+                continue
+            if 3 < len(raw) and 'Di(' in raw:
+                moshdex = raw.find('Di(')
+                stub = raw[moshdex:]
+                raw = raw[:moshdex]
+                codes.append(raw)
+                if i < num_codes - 1:
+                    raw_codes.insert(i + 1, stub)
+                    num_codes += 1
                 continue
             if not raw.startswith('(') and not raw.endswith(')') and '(' in raw and ')' in raw:
                 if not raw.startswith('[') and not raw.endswith(']'):

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -100,6 +100,9 @@ class testTradeCodes(unittest.TestCase):
     @example('0000000000Di( 0')
     @example('000 [DDi(0)]0]0')
     @example('(0000)00 DDi(0)')
+    @example('(00000000) [0]W')
+    @example('(00000000)W [0]')
+    @example('(00000000)W [0]W')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -71,6 +71,7 @@ class testTradeCodes(unittest.TestCase):
     @example(' Ga Lt (minor)  ')
     @example('[000000000(] ])')
     @example('[00000000(] ])A')
+    @example('[00000000(0)A0]')
     def test_parse_text_to_trade_code(self, s):
         trade = TradeCodes(s)
 

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -92,6 +92,8 @@ class testTradeCodes(unittest.TestCase):
     @example('0000000 [0]?Di(')
     @example('0000000 (0)?Di(')
     @example('0000000 [0]ADi(')
+    @example('0000 [[DDi(0)]0')
+    @example('0000 ((DDi(0))0')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -83,6 +83,8 @@ class testTradeCodes(unittest.TestCase):
     @example('[00000000] A00W')
     @example('((0000000))A 00')
     @example('[[0000000]]A 00')
+    @example('0000000DDi( 1)0')
+    @example('000000DDi(0 1)0')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -70,6 +70,7 @@ class testTradeCodes(unittest.TestCase):
     @example(' 000000000000( )   ')
     @example(' Ga Lt (minor)  ')
     @example('[000000000(] ])')
+    @example('[00000000(] ])A')
     def test_parse_text_to_trade_code(self, s):
         trade = TradeCodes(s)
 

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -72,6 +72,11 @@ class testTradeCodes(unittest.TestCase):
     @example('[000000000(] ])')
     @example('[00000000(] ])A')
     @example('[00000000(0)A0]')
+    @example('[00000000(] a)A')
+    @example('[00000000( )(0)')
+    @example('(0000000000)(0)')
+    @example('[0000000000[]]A')
+    @example('[000000000)] 0(')
     def test_parse_text_to_trade_code(self, s):
         trade = TradeCodes(s)
 

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -96,6 +96,9 @@ class testTradeCodes(unittest.TestCase):
     @example('0000 ((DDi(0))0')
     @example('0000 []DDi(0)]0')
     @example('0000 ()DDi(0))0')
+    @example('000 [0[DDi(0)]0')
+    @example('0000000000Di( 0')
+    @example('000 [DDi(0)]0]0')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -87,6 +87,11 @@ class testTradeCodes(unittest.TestCase):
     @example('000000DDi(0 1)0')
     @example('0000009e []ADi(')
     @example('0000009e ()ADi(')
+    @example('0000000 [0]0Di(')
+    @example('0000000 (0)0Di(')
+    @example('0000000 [0]?Di(')
+    @example('0000000 (0)?Di(')
+    @example('0000000 [0]ADi(')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -99,6 +99,7 @@ class testTradeCodes(unittest.TestCase):
     @example('000 [0[DDi(0)]0')
     @example('0000000000Di( 0')
     @example('000 [DDi(0)]0]0')
+    @example('(0000)00 DDi(0)')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -77,8 +77,16 @@ class testTradeCodes(unittest.TestCase):
     @example('(0000000000)(0)')
     @example('[0000000000[]]A')
     @example('[000000000)] 0(')
+    @example('[000000000] (0)')
+    @example('o 00000000000 s')
+    @example('[00000000] A00W')
     def test_parse_text_to_trade_code(self, s):
-        trade = TradeCodes(s)
+        trade = None
+        try:
+            trade = TradeCodes(s)
+        except ValueError as e:
+            if 'Can only have at most one W-pop sophont' == str(e):
+                assume(False)
 
         result, msg = trade.is_well_formed()
         self.assertTrue(result, msg)

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -5,6 +5,7 @@ from hypothesis import given, assume, example, HealthCheck, settings
 from hypothesis.strategies import text, from_regex, composite, sampled_from, lists, floats, booleans
 
 from PyRoute.AreaItems.Sector import Sector
+from PyRoute.Errors.MultipleWPopError import MultipleWPopError
 from PyRoute.TradeCodes import TradeCodes
 from PyRoute.Star import Star
 from PyRoute.SystemData.UWP import UWP
@@ -86,9 +87,8 @@ class testTradeCodes(unittest.TestCase):
         trade = None
         try:
             trade = TradeCodes(s)
-        except ValueError as e:
-            if 'Can only have at most one W-pop sophont' == str(e):
-                assume(False)
+        except MultipleWPopError as e:
+            assume(False)
 
         result, msg = trade.is_well_formed()
         if not msg.endswith(' not in allowed list'):

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -94,6 +94,8 @@ class testTradeCodes(unittest.TestCase):
     @example('0000000 [0]ADi(')
     @example('0000 [[DDi(0)]0')
     @example('0000 ((DDi(0))0')
+    @example('0000 []DDi(0)]0')
+    @example('0000 ()DDi(0))0')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -89,13 +89,15 @@ class testTradeCodes(unittest.TestCase):
                 assume(False)
 
         result, msg = trade.is_well_formed()
-        self.assertTrue(result, msg)
+        if not msg.endswith(' not in allowed list'):
+            self.assertTrue(result, msg)
 
         trade_string = str(trade)
 
         nu_trade = TradeCodes(trade_string)
         result, msg = nu_trade.is_well_formed()
-        self.assertTrue(result, msg)
+        if not msg.endswith(' not in allowed list'):
+            self.assertTrue(result, msg)
 
         nu_trade_string = str(nu_trade)
         msg = "Re-parsed TradeCodes string does not equal original parsed string"

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -69,6 +69,7 @@ class testTradeCodes(unittest.TestCase):
     @example('00000000000(0)0  ')
     @example(' 000000000000( )   ')
     @example(' Ga Lt (minor)  ')
+    @example('[000000000(] ])')
     def test_parse_text_to_trade_code(self, s):
         trade = TradeCodes(s)
 

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -85,6 +85,8 @@ class testTradeCodes(unittest.TestCase):
     @example('[[0000000]]A 00')
     @example('0000000DDi( 1)0')
     @example('000000DDi(0 1)0')
+    @example('0000009e []ADi(')
+    @example('0000009e ()ADi(')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -80,6 +80,8 @@ class testTradeCodes(unittest.TestCase):
     @example('[000000000] (0)')
     @example('o 00000000000 s')
     @example('[00000000] A00W')
+    @example('((0000000))A 00')
+    @example('[[0000000]]A 00')
     def test_parse_text_to_trade_code(self, s):
         trade = None
         try:


### PR DESCRIPTION
Much like the previous PR ( #132 ) , wring out trade code parsing according to the following property, with HypoFuzz (13 h 0 min, 5.49M inputs without new path for first batch (up to `[Assume out not-in-allowed-list well-formed failures]` inclusive), 10 h 30 min, 5.69M inputs without new path for second batch  (up to `Blow up on explicit homeworld-code W-pop counts` inclusive):

Given a string conforming to the trade code part of the `ParseStarInput.starline` regex (in practice, _any_ characters), it either:

1.  Is cleanly parsed by the `TradeCodes` constructor; or
2. Blows up with a subclass of `ValueError` exception.

Given 1 above, I'm also checking that feeding the string representation of a `TradeCodes` object into the constructor results in a new `TradeCodes` object with the _same_ string representation - the same idempotence-of-string-representation-under-reparsing that I enforced for starlines.