### PR TITLE
Extend ruff to cover Tests dir

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Lint with ruff - syntax errors & undefined names
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff check --select=E9,F63,F7,F82 --preview PyRoute
+          ruff check --select=E9,F63,F7,F82 --preview PyRoute Tests
       - name: Lint with ruff - configured options
         run: |
           # now run configured options
-          ruff check --preview PyRoute
+          ruff check --preview PyRoute Tests
       - name: Run non-cython tests
         run: |
           pytest -k testAstarOverSubsector

--- a/PyRoute/Allies/AllyGen.py
+++ b/PyRoute/Allies/AllyGen.py
@@ -218,7 +218,7 @@ class AllyGen(object):
         # base_match_only == true -> --ally-match=collapse
         # only what matches the base allegiances
         # base_match_only == false -> --ally-match=separate
-        # want the non-base code or the base codes for single code allegiances. 
+        # want the non-base code or the base codes for single code allegiances.
 
         if base_match_only:
             algs = [alg for alg in list(alg_list.values()) if alg.base]

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -34,7 +34,7 @@ class Galaxy(AreaItem):
     """
     classdocs
     """
- 
+
     def __init__(self, min_btn, max_jump=4):
         """
        Constructor

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -37,7 +37,7 @@ class TradeCalculation(RouteCalculation):
     # Weight for route over a distance. The relative cost for
     # moving freight between two worlds a given distance apart
     # in a single jump.
-    # These are made up from whole cloth.          
+    # These are made up from whole cloth.
     # distance_weight = [0, 30, 50, 70, 90, 120, 140 ]
 
     # GT Weights based upon one pass estimate
@@ -56,10 +56,10 @@ class TradeCalculation(RouteCalculation):
     max_connections = [6, 12, 18, 30, 45, 63, 84, 108, 135, 165]
 
     # Set an initial range for influence for worlds based upon their
-    # wtn. For a given world look up the range given by (wtn-8) (min 0), 
-    # and the system checks every other world in that range for trade 
-    # opportunity. See the btn_jump_mod and min btn to see how  
-    # worlds are excluded from this list. 
+    # wtn. For a given world look up the range given by (wtn-8) (min 0),
+    # and the system checks every other world in that range for trade
+    # opportunity. See the btn_jump_mod and min btn to see how
+    # worlds are excluded from this list.
     btn_range = [2, 9, 29, 59, 99, 299, 599]
 
     # Maximum WTN to process routes for
@@ -78,7 +78,7 @@ class TradeCalculation(RouteCalculation):
         self.min_wtn = route_btn
 
         # Override the default setting for route-reuse from the base class
-        # based upon program arguments. 
+        # based upon program arguments.
         self.route_reuse = route_reuse
         # Testing indicated that allowing a little more than 1 edge hit before tripping an update seemed to
         # strike the best space/time tradeoff, so default epsilon to sqrt(10/route_reuse).  The 0.1 cap is to speed up
@@ -175,18 +175,18 @@ class TradeCalculation(RouteCalculation):
             neighbor_routes = [(s, n, d) for (s, n, d) in self.galaxy.stars.edges([star], True)]
             # Need to do two sorts here:
             # BTN low to high to find them first
-            # Range high to low to find them first 
+            # Range high to low to find them first
             neighbor_routes.sort(key=lambda tn: tn[2]['btn'])
             neighbor_routes.sort(key=lambda tn: tn[2]['distance'], reverse=True)
 
             length = len(neighbor_routes)
 
-            # remove edges from the list which are 
+            # remove edges from the list which are
             # A) The most distant first
             # B) The lowest BTN for equal distant routes
             # If the neighbor has only a few (<15) connections don't remove that one
-            # until there are 20 connections left. 
-            # This may be reduced by other stars deciding you are too far away.             
+            # until there are 20 connections left.
+            # This may be reduced by other stars deciding you are too far away.
             for (s, n, d) in neighbor_routes:
                 if len(self.galaxy.stars[n]) < 15:
                     continue

--- a/PyRoute/StatCalculation.py
+++ b/PyRoute/StatCalculation.py
@@ -18,7 +18,7 @@ class Populations(object):
         self.homeworlds = []
         self.count = 0
         self.population = 0
-        
+
     def add_population(self, population, homeworld):
         self.count += 1
         self.population += population

--- a/PyRoute/WikiCreateWorlds.py
+++ b/PyRoute/WikiCreateWorlds.py
@@ -22,7 +22,7 @@ class WikiCreateWorld(object):
     """
     page_template = '''{{{{UWP
  |name    = {{{{World|{full name}|{sector}|{subsector}|{pos}}}}}
- |system  = 
+ |system  =
  |uc      = {uwp}
  |popc    = {popc}
  |zonec   = {zone}
@@ -43,14 +43,14 @@ class WikiCreateWorld(object):
 {{{{World summary {alg}|sector={sector}|subsector={subsector} }}}}
 * {{{{World summary allegiance|code={alg}|sector={sector}|subsector={subsector} }}}}{base summary}
 
-== Astrography and planetology == 
-No information yet available. 
- 
+== Astrography and planetology ==
+No information yet available.
+
 {star template}
 
 === System Data ===
-No information yet available. 
- 
+No information yet available.
+
 === Mainworld Data ===
 No information yet available.
 
@@ -64,7 +64,7 @@ No information yet available.
 No information yet available.
 
 == History and background ==
-No information yet available. 
+No information yet available.
 {nobility summary}
 === World Starport ===
 {{{{Starport|name= {name}|Starport={port} }}}}
@@ -73,37 +73,37 @@ No information yet available.
 {{{{WorldTech|name= {name}|WorldTech={tech} }}}}
 
 === World Government ===
-{{{{WorldGov|name= {name}|Government={gov} }}}}  
+{{{{WorldGov|name= {name}|Government={gov} }}}}
 
 ==== World Law Level ====
-No information yet available. 
+No information yet available.
 
 ==== World Military ====
-No information yet available. 
+No information yet available.
 
 === World Economy ===
-No information yet available. 
+No information yet available.
 
 ==== Trade Data ====
-No information yet available. 
+No information yet available.
 
 === World Demographics ===
-No information yet available. 
+No information yet available.
 
 === World Culture ===
-No information yet available. 
+No information yet available.
 
 ==== World Languages ====
-No information yet available. 
+No information yet available.
 
 ==== Urbanization ====
-No information yet available. 
+No information yet available.
 
 ==== World Infrastructure ====
-No information yet available. 
+No information yet available.
 
 === Historical Data ===
-No information yet available. 
+No information yet available.
 
 ==== World Timeline ====
 No information yet available.
@@ -123,12 +123,12 @@ No information yet available.
 {{{{MonostellarSystem
  |name        = {}
  |primary     = {}
-}}}} 
+}}}}
 '''
     binaryTemplate = '''
 {{{{BinaryStarSystem
  |name        = {}
- |primary     = {} 
+ |primary     = {}
  |secondary   = {}
 }}}}
 '''
@@ -230,7 +230,7 @@ No information yet available.
                       'alg': star.alg, 'pcode': pcode, 'nobility': str(star.nobles),
                       'bases': star.baseCode, 'stars': star.stars, 'belt': str(star.belts), 'worlds': star.worlds,
                       'ggcount': str(star.ggCount), 'trade': trade, 'class': classification,
-                      'star template': star_template, 'port': star.uwpCodes['Starport'], 
+                      'star template': star_template, 'port': star.uwpCodes['Starport'],
                       'tech': star.uwpCodes['Tech Level'], 'gov': star.uwpCodes['Government'],
                       'comment summary': comments, 'base summary': bases,
                       'nobility summary': nobility, 'categories': categories,
@@ -266,7 +266,7 @@ def get_category_list(category_files):
 
 def get_sources_list(sources_files):
     sources_list = {}
-    
+
     for src in sources_files:
         src_worlds = get_skip_list(src)
         src_name = src_worlds[0]
@@ -336,7 +336,7 @@ def process():
         wiki_page = wiki_review.get_page(star.wiki_short_name())
         wiki_page = wiki_page[0] if isinstance(wiki_page, (list, tuple)) else wiki_page
         if wiki_page is None:
-            
+
             logger.info("Unable to find: {}, creating new page".format(star.name))
             wiki_page = Page(site, star.wiki_short_name())
 

--- a/PyRoute/WikiUploadPDF.py
+++ b/PyRoute/WikiUploadPDF.py
@@ -7,7 +7,7 @@ Created on Apr 26, 2015
 
 # Requires wikitools and poster to run correctly
 # pip install wikitools
-# pip install poster 
+# pip install poster
 #
 #
 from wikitools_py3.exceptions import WikiError, NoPage
@@ -118,10 +118,10 @@ def uploadWorlds(site, sectorFile, economicFile, era):
     page_template = '''{{{{StellarDataQuery|name={{{{World|{0}|{1}|{2}|{3}}}}} }}}}
 
 == Astrography and planetology ==
-No information yet available. 
- 
+No information yet available.
+
 == History and background ==
-No information yet available. 
+No information yet available.
 
 == References and contributors ==
 {{{{Incomplete}}}}

--- a/PyRoute/__init__.py
+++ b/PyRoute/__init__.py
@@ -1,2 +1,7 @@
 
 __all__ = ["Galaxy", "Star", "SpeculativeTrade", "StatCalculation"]
+
+from PyRoute.AreaItems.Galaxy import Galaxy
+from PyRoute.SpeculativeTrade import SpeculativeTrade
+from PyRoute.Star import Star
+from PyRoute.StatCalculation import StatCalculation

--- a/PyRoute/downloadsec.py
+++ b/PyRoute/downloadsec.py
@@ -28,7 +28,7 @@ def get_url(url, sector, suffix, output_dir):
         ucontent = str(content, 'utf-8').replace('\r\n', '\n')
     else:
         ucontent = str(content, encoding).replace('\r\n', '\n')
-    
+
     path = os.path.join(output_dir, '%s.%s' % (sector, suffix))
 
     with codecs.open(path, 'wb', 'utf-8') as out:
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         if not success:
             print("Retrying " + sector)
             get_url(url, sector, 'sec', args.output_dir)
-        
+
         params = urllib.parse.urlencode({'sector': sector, 'accept': 'text/xml'})
         url = 'http://travellermap.com/api/metadata?%s' % params
         success = get_url(url, sector, 'xml', args.output_dir)

--- a/PyRoute/wikistats.py
+++ b/PyRoute/wikistats.py
@@ -93,7 +93,7 @@ class WikiStats(object):
         self.output_template('subsectors.wiki', 'subsectors.wiki',
                              {'sectors': self.galaxy.sectors,
                               'plural': self.plural})
-        
+
     def sector_data_template(self):
         for sector in self.galaxy.sectors.values():
             self.output_template('sector_data.wiki', sector.sector_name() + " Sector.sector.wiki",
@@ -127,7 +127,7 @@ class WikiStats(object):
         path = os.path.join(self.galaxy.output_path, 'stars.json')
         with open(path, "w+", encoding='utf8') as f:
             f.write(jsonpickle.encode(json_graph.node_link_data(self.galaxy.stars)))
-        
+
     def write_summary_lists(self):
         path = os.path.join(self.galaxy.output_path, 'sectors_list.txt')
         with open(path, 'w+') as f:
@@ -224,7 +224,7 @@ class WikiStats(object):
             f.write('|-\n')
             f.write('|Trade || {:,d} billion\n'.format(int(self.galaxy.stats.trade / 1e9)))
             f.write('\n|}\n')
-            
+
             f.write('===Summary Report===\n')
             self.write_uwp_counts(f)
             f.write('|-\n|colspan=20 align=center|Percent by Population\n')

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -61,5 +61,6 @@ class testHexHypothesis(unittest.TestCase):
         self.assertEqual(row, nu_row, "Row not round-tripped.  " + hyp_line)
         self.assertEqual(sector_y, nu_sector_y, "Sector_y not round-tripped.  " + hyp_line)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/Position/testHexHypothesis.py
+++ b/Tests/Hypothesis/Position/testHexHypothesis.py
@@ -1,7 +1,7 @@
 import unittest
 
-from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, integers
+from hypothesis import given, example
+from hypothesis.strategies import integers
 
 from PyRoute.AreaItems.Sector import Sector
 from PyRoute.Position.Hex import Hex

--- a/Tests/Hypothesis/testAllegiance.py
+++ b/Tests/Hypothesis/testAllegiance.py
@@ -25,7 +25,7 @@ def text_starts_with(draw, starts="Na", min_size=2, max_size=4):
     max_size = max(max_size, min_size)
     start_len = len(starts)
 
-    add = draw(text(min_size=min_size-start_len, max_size=max_size-start_len))
+    add = draw(text(min_size=min_size - start_len, max_size=max_size - start_len))
 
     return starts + add
 

--- a/Tests/Hypothesis/testAllegiance.py
+++ b/Tests/Hypothesis/testAllegiance.py
@@ -1,11 +1,7 @@
-import copy
-import logging
-import re
 import unittest
-from datetime import timedelta
 
 from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, from_regex, composite, integers, floats, lists, sampled_from, booleans
+from hypothesis.strategies import text, composite, floats, booleans
 
 from PyRoute.AreaItems.Allegiance import Allegiance
 

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -106,8 +106,8 @@ class testDeltaStar(unittest.TestCase):
         cases = [
             # Commented out for the moment - Barren/Dieback is a bit more intricate than other pop codes, and don't want
             # perfect to be the enemy of good
-            #('0917 Deyis II             E874000-0 Ba Da (Kebkh) Re                      { -3 } (200-5) [0000] -     -  A 000 10 ImDi K4 II                                                        ',
-            # '0917 Deyis II             E874000-2 Ba Da Di(Kebkh) Re                    { -3 } (200-5) [0000] -    -  A 000 10 ImDi K4 II                                                   '),
+            # ('0917 Deyis II             E874000-0 Ba Da (Kebkh) Re                      { -3 } (200-5) [0000] -     -  A 000 10 ImDi K4 II                                                        ',
+            #  '0917 Deyis II             E874000-2 Ba Da Di(Kebkh) Re                    { -3 } (200-5) [0000] -    -  A 000 10 ImDi K4 II                                                   '),
             ('0235 Oduart               C7B3004-5 Fl Di(Oduart) Da             { -2 } (800+2) [0000] - M  A 004 10 HvFd G4 V M3 V M7 V',
              '0235 Oduart               C7B3004-5 Ba Da Di(Oduart) Fl                   { -2 } (800+0) [0000] -    M  A 004 10 HvFd G4 V M3 V M7 V                                          '),
             ('0101                      X73A000-0 Ba Lo Ni Wa                         - -  - 012   --',

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -244,7 +244,7 @@ class testDeltaStar(unittest.TestCase):
                 # trim log lines of less than warning severity - "DEBUG" is set to ensure there will be output to grab
                 output = [line for line in output if 'DEBUG:' not in line and 'INFO:' not in line]
 
-                canonical_result, canonical_messages = star1.check_canonical()
+                _, canonical_messages = star1.check_canonical()
                 for msg in canonical_messages:
                     output = [line for line in output if msg not in line]
 
@@ -301,11 +301,11 @@ class testDeltaStar(unittest.TestCase):
         star1.index = 0
         star1.allegiance_base = 'NaHu'
 
-        canonical_result, canonical_messages = star1.check_canonical()
+        _, canonical_messages = star1.check_canonical()
 
         star1.canonicalise()
 
-        nu_result, nu_messages = star1.check_canonical()
+        _, nu_messages = star1.check_canonical()
         invalid = [item for item in nu_messages if 'Found invalid' in item and ('trade codes' in item or 'code on world' in item)]
 
         self.assertTrue(
@@ -362,11 +362,11 @@ class testDeltaStar(unittest.TestCase):
         star1.index = 0
         star1.allegiance_base = 'NaHu'
 
-        canonical_result, canonical_messages = star1.check_canonical()
+        _, canonical_messages = star1.check_canonical()
 
         star1.canonicalise()
 
-        nu_result, nu_messages = star1.check_canonical()
+        _, nu_messages = star1.check_canonical()
         invalid = [item for item in nu_messages if 'not in trade codes' in item]
 
         self.assertTrue(
@@ -408,11 +408,11 @@ class testDeltaStar(unittest.TestCase):
 
         assume('0' == str(star1.pop) and 'Ba' in star1.tradeCode.codes)
 
-        canonical_result, canonical_messages = star1.check_canonical()
+        _, canonical_messages = star1.check_canonical()
 
         star1.canonicalise()
 
-        nu_result, nu_messages = star1.check_canonical()
+        _, nu_messages = star1.check_canonical()
         invalid = [item for item in nu_messages if ('should be 0 for barren worlds' in item or 'does not match' in item)]
 
         self.assertTrue(
@@ -450,11 +450,11 @@ class testDeltaStar(unittest.TestCase):
 
         assume(not '0' == str(star1.pop) and 'Ba' not in star1.tradeCode.codes)
 
-        canonical_result, canonical_messages = star1.check_canonical()
+        _, canonical_messages = star1.check_canonical()
 
         star1.canonicalise()
 
-        nu_result, nu_messages = star1.check_canonical()
+        _, nu_messages = star1.check_canonical()
         invalid = [item for item in nu_messages if (' - EX Calculated ' in item)]
 
         self.assertTrue(
@@ -493,11 +493,11 @@ class testDeltaStar(unittest.TestCase):
 
         assume(not '0' == str(star1.pop) and 'Ba' not in star1.tradeCode.codes)
 
-        canonical_result, canonical_messages = star1.check_canonical()
+        _, canonical_messages = star1.check_canonical()
 
         star1.canonicalise()
 
-        nu_result, nu_messages = star1.check_canonical()
+        _, nu_messages = star1.check_canonical()
         invalid = [item for item in nu_messages if (' - CX Calculated ' in item)]
 
         self.assertTrue(
@@ -544,7 +544,7 @@ class testDeltaStar(unittest.TestCase):
 
         try:
             foo = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
-        except ValueError as e:
+        except ValueError:
             pass
 
         assume(foo is not None)
@@ -557,7 +557,7 @@ class testDeltaStar(unittest.TestCase):
         assume(well_formed)
 
         foo.canonicalise()
-        nu_result, nu_messages = foo.check_canonical()  # Should be in canonical form after canonicalise call
+        _, nu_messages = foo.check_canonical()  # Should be in canonical form after canonicalise call
 
         badline = '' if 0 == len(nu_messages) else nu_messages[0]
         self.assertEqual(0, len(nu_messages), 'At least one characteristic not canonicalised: \n' + starline + '\n' + badline)
@@ -568,7 +568,7 @@ class testDeltaStar(unittest.TestCase):
         self.assertIsNotNone(nu_foo, "Canonicalised line should parse cleanly")
         nu_foo.canonicalise()
 
-        nu_result, nu_messages = nu_foo.check_canonical()  # Should be in canonical form after canonicalise call
+        _, nu_messages = nu_foo.check_canonical()  # Should be in canonical form after canonicalise call
 
         badline = '' if 0 == len(nu_messages) else nu_messages[0]
         self.assertEqual(0, len(nu_messages), 'At least one characteristic not canonicalised: \n' + starline + '\n' + badline)

--- a/Tests/Hypothesis/testDeltaStar.py
+++ b/Tests/Hypothesis/testDeltaStar.py
@@ -4,7 +4,7 @@ import logging
 import unittest
 
 from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, lists, from_regex, composite, booleans, sampled_from, integers, floats
+from hypothesis.strategies import text, lists, from_regex, composite, sampled_from, integers, floats
 
 from PyRoute.AreaItems.Sector import Sector
 from PyRoute.DeltaStar import DeltaStar

--- a/Tests/Hypothesis/testNobles.py
+++ b/Tests/Hypothesis/testNobles.py
@@ -1,11 +1,7 @@
-import copy
-import logging
-import re
 import unittest
-from datetime import timedelta
 
-from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, from_regex, composite, integers, floats, lists, sampled_from, booleans, none
+from hypothesis import given, assume
+from hypothesis.strategies import text
 
 from PyRoute.Nobles import Nobles
 

--- a/Tests/Hypothesis/testSector.py
+++ b/Tests/Hypothesis/testSector.py
@@ -120,9 +120,9 @@ class testSector(unittest.TestCase):
             target.spinward = source
 
         result, msg = source.is_well_formed()
-        self.assertFalse(result)
+        self.assertFalse(result, msg)
         result, msg = target.is_well_formed()
-        self.assertFalse(result)
+        self.assertFalse(result, msg)
 
     def testSectorPositionRegressions(self):
         cases = [

--- a/Tests/Hypothesis/testSector.py
+++ b/Tests/Hypothesis/testSector.py
@@ -1,9 +1,8 @@
-import re
 import unittest
 from datetime import timedelta
 
-from hypothesis import given, assume, example, HealthCheck, settings, reproduce_failure
-from hypothesis.strategies import text, from_regex, composite, floats, integers
+from hypothesis import given, assume, example, HealthCheck, settings
+from hypothesis.strategies import text, composite, floats, integers
 
 from PyRoute.AreaItems.Sector import Sector
 

--- a/Tests/Hypothesis/testSector.py
+++ b/Tests/Hypothesis/testSector.py
@@ -135,5 +135,6 @@ class testSector(unittest.TestCase):
                 result, msg = sector.is_well_formed()
                 self.assertTrue(result)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/testSector.py
+++ b/Tests/Hypothesis/testSector.py
@@ -14,6 +14,7 @@ def position_string(draw):
 
     return '# ' + left + ',' + right
 
+
 @composite
 def sector_name(draw):
     stem = '#' + draw(text(min_size=1))

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -3,8 +3,8 @@ import re
 import unittest
 from datetime import timedelta
 
-from hypothesis import given, assume, example, HealthCheck, settings, reproduce_failure
-from hypothesis.strategies import text, from_regex, composite, booleans, none
+from hypothesis import given, assume, example, HealthCheck, settings
+from hypothesis.strategies import from_regex, composite, booleans, none
 
 from PyRoute.AreaItems.Sector import Sector
 from PyRoute.Inputs.ParseStarInput import ParseStarInput

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -371,5 +371,6 @@ class testStar(unittest.TestCase):
         foo.check_cx()
         foo.calculate_ru('fixed')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/testStar.py
+++ b/Tests/Hypothesis/testStar.py
@@ -14,6 +14,7 @@ from PyRoute.SystemData.StarList import StarList
 from PyRoute.SystemData.UWP import UWP
 from PyRoute.TradeCodes import TradeCodes
 
+
 @composite
 def importance_starline(draw):
     keep_econ = draw(booleans())
@@ -50,6 +51,7 @@ def importance_starline(draw):
         rawline = '01' + rawline[2:]
 
     return rawline
+
 
 @composite
 def canonical_check(draw):

--- a/Tests/Hypothesis/testStarList.py
+++ b/Tests/Hypothesis/testStarList.py
@@ -251,43 +251,6 @@ class testStarList(unittest.TestCase):
         if expected is not None:
             self.assertEqual(expected, str(list), "Unexpected final starline.  " + hyp_line)
 
-    def test_stargen_class_ordering(self):
-        cases = [
-            ('O6 VI', 'O6 VI'),
-            ('O6 VII', 'O6 D'),
-            ('A9 III', 'A9 III'),
-            ('A9 IV', 'A9 IV'),
-            ('M3 V', 'M3 V')
-        ]
-
-        for star_line, expected in cases:
-            starlist = StarList(star_line)
-            self.assertEqual(expected, str(starlist))
-
-    @given(star_list(max_stars=1))
-    @example('PSR ')
-    @example('A0Ia ')
-    @example('D')
-    @example('NS ')
-    @example('BH ')
-    @example('O0Ia ')
-    @example('B0Ia ')
-    @example('BD ')
-    @example('F0Ia ')
-    @example('G0Ia ')
-    @example('K0Ia ')
-    @example('M0Ia ')
-    def test_primary_flux_bounds(self, star_line):
-        hyp_line = "Hypothesis input: " + star_line
-
-        list = StarList(star_line)
-        max_flux, min_flux = list.primary_flux_bounds
-        if max_flux is None:
-            self.assertIsNone(min_flux, "If max-flux is None, so must be min-flux.  " + hyp_line)
-        else:
-            self.assertIsNotNone(min_flux, "if max-flux is not None, so must be min-flux.  " + hyp_line)
-            self.assertTrue(max_flux >= min_flux, "Min-flux cannot exceed max-flux.  " + hyp_line)
-
     def test_handle_missing_and_wonky_star_sizes(self):
         cases = [
             ('Wrenton 1901', 'G7 M4 V', 'G7 V M4 V'),

--- a/Tests/Hypothesis/testStarList.py
+++ b/Tests/Hypothesis/testStarList.py
@@ -1,8 +1,7 @@
 import unittest
-from datetime import timedelta
 
 from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, from_regex, none, composite, integers
+from hypothesis.strategies import from_regex, none, composite, integers
 
 from PyRoute.SystemData.StarList import StarList
 

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -107,7 +107,7 @@ class testTradeCodes(unittest.TestCase):
         trade = None
         try:
             trade = TradeCodes(s)
-        except MultipleWPopError as e:
+        except MultipleWPopError:
             assume(False)
 
         result, msg = trade.is_well_formed()

--- a/Tests/Hypothesis/testTradeCodes.py
+++ b/Tests/Hypothesis/testTradeCodes.py
@@ -238,5 +238,6 @@ class testTradeCodes(unittest.TestCase):
         badline = '' if result else msg[0]
         self.assertEqual(0, len(msg), "Canonicalisation failed.  " + badline + '\n' + hyp_input)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Hypothesis/testUWP.py
+++ b/Tests/Hypothesis/testUWP.py
@@ -1,8 +1,7 @@
 import unittest
-from datetime import timedelta
 
 from hypothesis import given, assume, example, HealthCheck, settings
-from hypothesis.strategies import text, from_regex, none
+from hypothesis.strategies import from_regex, none
 
 from PyRoute.SystemData.UWP import UWP
 

--- a/Tests/Inputs/testStarlineParser.py
+++ b/Tests/Inputs/testStarlineParser.py
@@ -612,5 +612,6 @@ class testStarlineParser(unittest.TestCase):
         self.assertEqual('00', transformed[16], 'Unexpected allegiance')
         self.assertEqual('', transformed[17], 'Unexpected residual')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Mapping/testAllyGenAllyGenCharacterise.py
+++ b/Tests/Mapping/testAllyGenAllyGenCharacterise.py
@@ -1,10 +1,7 @@
 from collections import defaultdict
 
-import pytest
-
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
-from PyRoute.Position.Hex import Hex
 from Tests.Mapping.testAllyGenBase import TestAllyGenBase
 
 

--- a/Tests/Mapping/testAllyGenAllyGenCharacterise.py
+++ b/Tests/Mapping/testAllyGenAllyGenCharacterise.py
@@ -171,7 +171,7 @@ class TestAllyGenAllyGenCharacterise(TestAllyGenBase):
                             (-31, 17): ['white', None, None], (-30, 2): ['white', 'white', None], (-30, 16): ['white', 'white', None],
                             (-29, 1): [None, 'white', None], (-29, 2): ['white', None, None], (-29, 15): [None, 'white', None],
                             (-29, 16): ['white', None, None], (-28, 2): ['white', None, 'white'], (-28, 15): ['white', 'white', None],
-                            (-27, 1): [None, 'white', None], (-27, 2): ['white', None, None],  (-27, 14): [None, 'white', None],
+                            (-27, 1): [None, 'white', None], (-27, 2): ['white', None, None], (-27, 14): [None, 'white', None],
                             (-27, 15): ['white', None, None], (-26, 2): ['white', None, 'white'], (-26, 15): ['white', None, 'white'],
                             (-25, 1): [None, 'white', None], (-25, 2): ['white', None, None], (-25, 14): ['white', None, 'white'],
                             (-24, 2): ['white', None, 'white'], (-24, 13): ['white', 'white', None], (-23, 1): [None, 'white', None],

--- a/Tests/Mapping/testAllyGenAllyGenCharacterise.py
+++ b/Tests/Mapping/testAllyGenAllyGenCharacterise.py
@@ -189,7 +189,6 @@ class TestAllyGenAllyGenCharacterise(TestAllyGenBase):
         sourcefile = self.unpack_filename('BorderGeneration/Far Frontiers.sec')
         mapfile = self.unpack_filename('BorderGeneration/Far Frontiers-allymap-allymap.json')
         borderfile = self.unpack_filename('BorderGeneration/Far Frontiers-allymap-border.json')
-        bordermapfile = self.unpack_filename('BorderGeneration/Far Frontiers-allymap-bordermap.json')
 
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()
@@ -264,7 +263,6 @@ class TestAllyGenAllyGenCharacterise(TestAllyGenBase):
         sourcefile = self.unpack_filename('BorderGeneration/Vanguard Reaches.sec')
         mapfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-allymap-allymap.json')
         borderfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-allymap-border.json')
-        bordermapfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-allymap-bordermap.json')
 
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()

--- a/Tests/Mapping/testAllyGenBase.py
+++ b/Tests/Mapping/testAllyGenBase.py
@@ -36,7 +36,7 @@ class TestAllyGenBase(baseTest):
         self.galaxy.sectors[4] = forn_sector
         self.borders = self.galaxy.borders
 
-    def setupOneWorldAllSectors(self, loc:str = "0102"):
+    def setupOneWorldAllSectors(self, loc: str = "0102"):
         for sector in range(5):
             sec = self.galaxy.sectors[sector]
             star = Star.parse_line_into_star(
@@ -44,7 +44,7 @@ class TestAllyGenBase(baseTest):
                 sec, 'fixed', 'negative')
             self.galaxy.add_star_to_galaxy(star, sector, sec)
 
-    def setupOneWorldCoreSector(self, loc:str, counter:int, allegiance:str = "Im"):
+    def setupOneWorldCoreSector(self, loc: str, counter: int, allegiance: str = "Im"):
         star = Star.parse_line_into_star(
             f"{loc} Shana Ma             E551112-7 Lo Po                {{ -3 }} (300-3) [1113] B     - A 913 9  {allegiance} K2 IV M7 V     ",
             self.galaxy.sectors[0], 'fixed', 'negative')

--- a/Tests/Mapping/testAllyGenBase.py
+++ b/Tests/Mapping/testAllyGenBase.py
@@ -9,9 +9,9 @@ from Tests.baseTest import baseTest
 
 
 class TestAllyGenBase(baseTest):
-    
+
     galaxy: Galaxy = None
-    
+
     def setUp(self):
         self.galaxy = Galaxy(min_btn=14)
         self.galaxy.debug_flag = True

--- a/Tests/Mapping/testAllyGenErodeCharacterise.py
+++ b/Tests/Mapping/testAllyGenErodeCharacterise.py
@@ -107,7 +107,7 @@ class TestAllyGenErodeCharacterise(TestAllyGenBase):
                              (-27, 12): 'ImDi', (-26, 3): 'ImDi', (-26, 4): 'ImDi', (-26, 5): 'ImDi', (-26, 6): 'ImDi',
                              (-26, 7): 'ImDi', (-26, 8): 'ImDi', (-26, 9): 'ImDi', (-26, 10): 'ImDi', (-26, 11): 'ImDi',
                              (-26, 12): 'ImDi', (-25, 5): 'ImDi', (-25, 6): 'ImDi', (-25, 7): 'ImDi', (-25, 8): 'ImDi',
-                             (-25, 9): 'ImDi', (-25, 10): 'ImDi', (-25, 11): 'ImDi' }
+                             (-25, 9): 'ImDi', (-25, 10): 'ImDi', (-25, 11): 'ImDi'}
         expected_borders = {(-32, 5): ['white', 'white', None], (-32, 6): [None, 'white', 'white'], (-32, 7): [None, 'white', 'white'],
                             (-32, 8): [None, 'white', 'white'], (-32, 9): [None, 'white', 'white'], (-32, 10): [None, 'white', 'white'],
                             (-32, 11): ['white', None, 'white'], (-32, 14): ['white', 'white', None], (-32, 15): ['white', None, 'white'],

--- a/Tests/Mapping/testAllyGenErodeCharacterise.py
+++ b/Tests/Mapping/testAllyGenErodeCharacterise.py
@@ -131,7 +131,6 @@ class TestAllyGenErodeCharacterise(TestAllyGenBase):
         sourcefile = self.unpack_filename('BorderGeneration/Far Frontiers.sec')
         mapfile = self.unpack_filename('BorderGeneration/Far Frontiers-erode-allymap.json')
         borderfile = self.unpack_filename('BorderGeneration/Far Frontiers-erode-border.json')
-        bordermapfile = self.unpack_filename('BorderGeneration/Far Frontiers-erode-bordermap.json')
 
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()
@@ -161,7 +160,6 @@ class TestAllyGenErodeCharacterise(TestAllyGenBase):
         sourcefile = self.unpack_filename('BorderGeneration/Vanguard Reaches.sec')
         mapfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-erode-allymap.json')
         borderfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-erode-border.json')
-        bordermapfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-erode-bordermap.json')
 
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()

--- a/Tests/Mapping/testAllyGenErodeCharacterise.py
+++ b/Tests/Mapping/testAllyGenErodeCharacterise.py
@@ -1,8 +1,5 @@
-import json
-
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
-from PyRoute.Position.Hex import Hex
 from Tests.Mapping.testAllyGenBase import TestAllyGenBase
 
 

--- a/Tests/Mapping/testAllyGenRangeCharacterise.py
+++ b/Tests/Mapping/testAllyGenRangeCharacterise.py
@@ -1,6 +1,5 @@
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
-from PyRoute.Position.Hex import Hex
 from Tests.Mapping.testAllyGenBase import TestAllyGenBase
 
 

--- a/Tests/Mapping/testAllyGenRangeCharacterise.py
+++ b/Tests/Mapping/testAllyGenRangeCharacterise.py
@@ -194,7 +194,6 @@ class TestAllyGenRangeCharacterise(TestAllyGenBase):
         sourcefile = self.unpack_filename('BorderGeneration/Far Frontiers.sec')
         mapfile = self.unpack_filename('BorderGeneration/Far Frontiers-range-allymap.json')
         borderfile = self.unpack_filename('BorderGeneration/Far Frontiers-range-border.json')
-        bordermapfile = self.unpack_filename('BorderGeneration/Far Frontiers-range-bordermap.json')
 
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()
@@ -224,7 +223,6 @@ class TestAllyGenRangeCharacterise(TestAllyGenBase):
         sourcefile = self.unpack_filename('BorderGeneration/Vanguard Reaches.sec')
         mapfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-range-allymap.json')
         borderfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-range-border.json')
-        bordermapfile = self.unpack_filename('BorderGeneration/Vanguard Reaches-range-bordermap.json')
 
         sector = SectorDictionary.load_traveller_map_file(sourcefile)
         delta = DeltaDictionary()

--- a/Tests/Mapping/testAllyGenRangeCharacterise.py
+++ b/Tests/Mapping/testAllyGenRangeCharacterise.py
@@ -140,7 +140,7 @@ class TestAllyGenRangeCharacterise(TestAllyGenBase):
                              (-33, 13): 'ImDi', (-33, 14): 'ImDi', (-33, 15): 'ImDi', (-33, 16): 'ImDi',
                              (-33, 17): 'ImDi', (-32, 4): 'ImDi', (-32, 5): 'ImDi', (-32, 6): 'ImDi', (-32, 7): 'ImDi',
                              (-32, 8): 'ImDi', (-32, 9): 'ImDi', (-32, 10): 'ImDi', (-32, 11): 'ImDi',
-                             (-32, 12): 'ImDi', (-32, 13): 'ImDi', (-32, 14): 'ImDi',(-32, 15): 'ImDi',
+                             (-32, 12): 'ImDi', (-32, 13): 'ImDi', (-32, 14): 'ImDi', (-32, 15): 'ImDi',
                              (-32, 16): 'ImDi', (-32, 17): 'ImDi', (-31, 4): 'ImDi', (-31, 5): 'ImDi', (-31, 6): 'ImDi',
                              (-31, 7): 'ImDi', (-31, 8): 'ImDi', (-31, 9): 'ImDi', (-31, 10): 'ImDi', (-31, 11): 'ImDi',
                              (-31, 12): 'ImDi', (-31, 13): 'ImDi', (-31, 14): 'ImDi', (-31, 15): 'ImDi',
@@ -165,7 +165,7 @@ class TestAllyGenRangeCharacterise(TestAllyGenBase):
                              (-24, 4): 'ImDi', (-24, 5): 'ImDi', (-24, 6): 'ImDi', (-24, 7): 'ImDi', (-24, 8): 'ImDi',
                              (-24, 9): 'ImDi', (-24, 10): 'ImDi', (-24, 11): 'ImDi', (-24, 12): 'ImDi',
                              (-23, 4): 'ImDi', (-23, 5): 'ImDi', (-23, 6): 'ImDi', (-23, 7): 'ImDi', (-23, 8): 'ImDi',
-                             (-23, 9): 'ImDi', (-23, 10): 'ImDi', (-23, 11): 'ImDi' }
+                             (-23, 9): 'ImDi', (-23, 10): 'ImDi', (-23, 11): 'ImDi'}
         expected_borders = {(-34, 5): ['white', 'white', None], (-34, 6): [None, 'white', 'white'], (-34, 7): [None, 'white', 'white'],
                             (-34, 8): [None, 'white', 'white'], (-34, 9): [None, 'white', 'white'], (-34, 10): [None, 'white', 'white'],
                             (-34, 11): [None, 'white', 'white'], (-34, 12): ['white', None, 'white'], (-34, 14): ['white', 'white', None],

--- a/Tests/Outputs/testHexMap.py
+++ b/Tests/Outputs/testHexMap.py
@@ -14,8 +14,6 @@ from PyRoute.Outputs.ClassicModePDFSectorMap import ClassicModePDFSectorMap
 from PyRoute.Outputs.SubsectorMap import SubsectorMap
 from PyRoute.Outputs.DarkModePDFSectorMap import DarkModePDFSectorMap
 from PyRoute.Outputs.LightModePDFSectorMap import LightModePDFSectorMap
-from PyRoute.Outputs.PDFHexMap import PDFHexMap
-from PyRoute.Outputs.SectorMap import SectorMap
 from PyRoute.Position.Hex import Hex
 from PyRoute.SpeculativeTrade import SpeculativeTrade
 from Tests.baseTest import baseTest
@@ -246,7 +244,6 @@ class testHexMap(baseTest):
 
                 secname = 'Zao Kfeng Ig Grilokh'
 
-                hexMap: SectorMap
                 if 'light' == map_type:
                     hexmap = LightModePDFSectorMap(galaxy, 'trade', args.output, "dense")
                 else:

--- a/Tests/Outputs/testMapDrawSector.py
+++ b/Tests/Outputs/testMapDrawSector.py
@@ -89,15 +89,15 @@ class TestMapDrawSector(baseTest):
 
         self.assertEqual(testmap.area_name, 'Dagudashaag')
         self.assertEqual(4429, len(testmap.lines))  # 4025 is the completed base map minus the map key
-                                                        # 262 is the borders
-                                                        # 12 for the Map Key
-                                                        # 130 is the comm routes
+                                                        # 262 is the borders  # noqa
+                                                        # 12 for the Map Key  # noqa
+                                                        # 130 is the comm routes  # noqa
         self.assertEqual(560, len(testmap.rects))   # 559 blanking rectangles behind the world name
-                                                        # 1 for the map key
+                                                        # 1 for the map key # noqa
         self.assertEqual(2177, len(testmap.texts))  # 12 is the completed base map minus the map key
-                                                        # 4 is the connected sectors
-                                                        #  9 is for the map key
-                                                        # 2152 is worlds (559 * 3 lines each)
+                                                        # 4 is the connected sectors # noqa
+                                                        #  9 is for the map key # noqa
+                                                        # 2152 is worlds (559 * 3 lines each) # noqa
         # Assert all the fonts used are in the default font list of names.
         for text in testmap.texts:
             self.assertIn(text[3], testmap.fonts)

--- a/Tests/Pathfinding/testApproximateShortestPathForest.py
+++ b/Tests/Pathfinding/testApproximateShortestPathForest.py
@@ -3,18 +3,13 @@ Created on Feb 19, 2024
 
 @author: CyberiaResurrection
 """
-import argparse
-import copy
 import json
-import os
-import tempfile
 import unittest
 
 import networkx as nx
 import numpy as np
 
 from PyRoute.Pathfinding.LandmarkSchemes.LandmarksTriaxialExtremes import LandmarksTriaxialExtremes
-from PyRoute.Pathfinding.LandmarkSchemes.LandmarksWTNExtremes import LandmarksWTNExtremes
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 try:

--- a/Tests/Pathfinding/testApproximateShortestPathForest.py
+++ b/Tests/Pathfinding/testApproximateShortestPathForest.py
@@ -129,7 +129,7 @@ class testApproximateShortestPathForest(baseTest):
             expected_distances[item] = exp_dist
 
         expected_distances[19] = float('+inf')
-        distance_check = list(expected_distances.values()) == approx.distances[:,0]
+        distance_check = list(expected_distances.values()) == approx.distances[:, 0]
         self.assertTrue(distance_check.all(), "Unexpected distances after SPT creation")
 
         # adjust weight

--- a/Tests/Pathfinding/testApproximateShortestPathTree.py
+++ b/Tests/Pathfinding/testApproximateShortestPathTree.py
@@ -4,9 +4,7 @@ Created on Aug 08, 2023
 @author: CyberiaResurrection
 """
 import argparse
-import copy
 import json
-import os
 import tempfile
 import unittest
 

--- a/Tests/Pathfinding/testApproximateShortestPathTree.py
+++ b/Tests/Pathfinding/testApproximateShortestPathTree.py
@@ -210,7 +210,6 @@ class testApproximateShortestPathTree(baseTest):
 
         leaf = [item for item in stars if -1 != graph.nodes[item]['star'].name.find('Dorsiki')][0]
         leafpath = paths[leaf]
-        mid = leafpath[-2]
         hi = leafpath[-3]
         inter = leafpath[-4]
 
@@ -241,7 +240,7 @@ class testApproximateShortestPathTree(baseTest):
 
         stars = list(graph.nodes)
         source = stars[0]
-        distances, paths = nx.single_source_dijkstra(graph, source)
+        _, paths = nx.single_source_dijkstra(graph, source)
         leafnode = stars[30]
         subnode = stars[paths[leafnode][-2]]
 
@@ -332,7 +331,6 @@ class testApproximateShortestPathTree(baseTest):
 
         # tell SPT weight has changed
         edge = (source, right)
-        dropnodes = [right]
 
         for item in expected_distances:
             if expected_distances[item] > 0 and 'Selsinia (Zarushagar 0201)' != str(graph.nodes[item]['star']):

--- a/Tests/Pathfinding/testApproximateShortestPathTreeRegressions.py
+++ b/Tests/Pathfinding/testApproximateShortestPathTreeRegressions.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import tempfile
 import unittest
 

--- a/Tests/Pathfinding/testAstarNumpy.py
+++ b/Tests/Pathfinding/testAstarNumpy.py
@@ -3,6 +3,10 @@ Created on Sep 21, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.Pathfinding.DistanceGraph import DistanceGraph
+from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
+from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
+from Tests.baseTest import baseTest
 goodimport = True
 try:
     from PyRoute.Pathfinding.ApproximateShortestPathForestUnified import ApproximateShortestPathForestUnified
@@ -12,10 +16,6 @@ except ModuleNotFoundError:
 except ImportError:
     from PyRoute.Pathfinding.ApproximateShortestPathForestUnifiedFallback import ApproximateShortestPathForestUnified
     goodimport = False
-from PyRoute.Pathfinding.DistanceGraph import DistanceGraph
-from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
-from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
-from Tests.baseTest import baseTest
 try:
     from PyRoute.Pathfinding.astar_numpy import astar_path_numpy
 except ModuleNotFoundError:

--- a/Tests/Pathfinding/testAstarNumpy.py
+++ b/Tests/Pathfinding/testAstarNumpy.py
@@ -25,6 +25,7 @@ except ImportError:
     from PyRoute.Pathfinding.astar_numpy_fallback import astar_path_numpy
     goodimport = False
 
+
 class testAStarNumpy(baseTest):
 
     def testAStarOverSubsector(self):

--- a/Tests/Pathfinding/testDistanceGraph.py
+++ b/Tests/Pathfinding/testDistanceGraph.py
@@ -3,9 +3,6 @@ Created on Mar 19, 2024
 
 @author: CyberiaResurrection
 """
-import numpy as np
-import networkx as nx
-
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from PyRoute.Pathfinding.DistanceGraph import DistanceGraph

--- a/Tests/Pathfinding/testDistanceGraph.py
+++ b/Tests/Pathfinding/testDistanceGraph.py
@@ -12,7 +12,7 @@ from Tests.baseTest import baseTest
 class testDistanceGraph(baseTest):
     def test_min_cost_in_single_component(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
-        galaxy, graph, source, stars = self._setup_graph(sourcefile)
+        galaxy, graph, _, _ = self._setup_graph(sourcefile)
         components = galaxy.trade.components
         self.assertEqual(2, len(components))
 
@@ -45,7 +45,7 @@ class testDistanceGraph(baseTest):
 
     def test_min_cost_in_multiple_components(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar.sec')
-        galaxy, graph, source, stars = self._setup_graph(sourcefile)
+        galaxy, graph, _, _ = self._setup_graph(sourcefile)
         components = galaxy.trade.components
         self.assertEqual(11, len(components))
 

--- a/Tests/Pathfinding/testRouteLandmarkGraph.py
+++ b/Tests/Pathfinding/testRouteLandmarkGraph.py
@@ -4,7 +4,6 @@ Created on Feb 25, 2024
 @author: CyberiaResurrection
 """
 import numpy as np
-import networkx as nx
 
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy

--- a/Tests/Pathfinding/testRouteLandmarkGraph.py
+++ b/Tests/Pathfinding/testRouteLandmarkGraph.py
@@ -15,7 +15,7 @@ class testRouteLandmarkGraph(baseTest):
 
     def test_subscript_bad(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
-        graph, source, stars = self._setup_graph(sourcefile)
+        graph, _, stars = self._setup_graph(sourcefile)
         num_stars = len(stars)
 
         rlg = RouteLandmarkGraph(graph)
@@ -35,7 +35,7 @@ class testRouteLandmarkGraph(baseTest):
 
     def test_subscript_empty(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
-        graph, source, stars = self._setup_graph(sourcefile)
+        graph, _, stars = self._setup_graph(sourcefile)
         num_stars = len(stars)
 
         rlg = RouteLandmarkGraph(graph)
@@ -54,7 +54,7 @@ class testRouteLandmarkGraph(baseTest):
 
     def test_add_single_then_subscript_nonempty(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
-        graph, source, stars = self._setup_graph(sourcefile)
+        graph, _, stars = self._setup_graph(sourcefile)
         num_stars = len(stars)
 
         rlg = RouteLandmarkGraph(graph)
@@ -76,7 +76,7 @@ class testRouteLandmarkGraph(baseTest):
 
     def test_add_single_edge_twice_should_update_in_place(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
-        graph, source, stars = self._setup_graph(sourcefile)
+        graph, _, stars = self._setup_graph(sourcefile)
         num_stars = len(stars)
 
         rlg = RouteLandmarkGraph(graph)
@@ -99,7 +99,7 @@ class testRouteLandmarkGraph(baseTest):
 
     def test_verify_position_creation(self):
         sourcefile = self.unpack_filename('DeltaFiles/Zarushagar-Ibara.sec')
-        graph, source, stars = self._setup_graph(sourcefile)
+        graph, _, stars = self._setup_graph(sourcefile)
         num_stars = len(stars)
 
         rlg = RouteLandmarkGraph(graph)

--- a/Tests/Pathfinding/testTradeCalculation.py
+++ b/Tests/Pathfinding/testTradeCalculation.py
@@ -5,8 +5,6 @@ Created on Aug 08, 2024
 """
 from PyRoute.AreaItems.Galaxy import Galaxy
 from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
-from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
-from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from Tests.baseTest import baseTest
 
 

--- a/Tests/Pathfinding/testTradeCalculationLandmarks.py
+++ b/Tests/Pathfinding/testTradeCalculationLandmarks.py
@@ -89,5 +89,6 @@ class testTradeCalculationLandmarks(baseTest):
         args.mp_threads = 1
         return args
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Pathfinding/testTradeCalculationLandmarks.py
+++ b/Tests/Pathfinding/testTradeCalculationLandmarks.py
@@ -54,7 +54,7 @@ class testTradeCalculationLandmarks(baseTest):
 
         self.assertEqual(7, len(galaxy.trade.components), "Unexpected number of components at J-1")
 
-        landmarks, components = galaxy.trade.get_landmarks()
+        landmarks, _ = galaxy.trade.get_landmarks()
         self.assertEqual(3, len(landmarks), 'Should have one landmark per component')
         self.assertEqual("Dorevann (Zarushagar 0708)", str(landmarks[0][0]), "Unexpected landmark choice")
         self.assertEqual("Shadishi (Zarushagar 0310)", str(landmarks[0][2]), "Unexpected landmark choice")

--- a/Tests/Pathfinding/testTradeCalculationLandmarks.py
+++ b/Tests/Pathfinding/testTradeCalculationLandmarks.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import tempfile
 import unittest
 

--- a/Tests/Pathfinding/testTradeCalculationLandmarks.py
+++ b/Tests/Pathfinding/testTradeCalculationLandmarks.py
@@ -64,7 +64,6 @@ class testTradeCalculationLandmarks(baseTest):
         self.assertEqual("Madagast (Zarushagar 0806)", str(landmarks[1][5]), "Unexpected landmark choice")
         self.assertEqual("Point Zulu (Zarushagar 0302)", str(landmarks[2][0]), "Unexpected landmark choice")
 
-
     def _make_args(self):
         args = argparse.ArgumentParser(description='PyRoute input minimiser.')
         args.btn = 8

--- a/Tests/Position/testHex.py
+++ b/Tests/Position/testHex.py
@@ -33,10 +33,10 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (31, -16))
         self.assertEqual(pos[4].hex_position(), (15, 12))
 
-        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1, 1), (1, 40), (32, 1), (32, 40), (16, 20)]):
             offset = Hex.dy_offset(y, (self.coreSector.dy // 40))
-            q,r = Hex.hex_to_axial(x + self.coreSector.dx - 1, offset)
-            self.assertEqual(pos[idx].hex_position(), (q,r))
+            q, r = Hex.hex_to_axial(x + self.coreSector.dx - 1, offset)
+            self.assertEqual(pos[idx].hex_position(), (q, r))
 
     def testAntaresSector(self):
         pos = [
@@ -52,10 +52,10 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (63, 8))
         self.assertEqual(pos[4].hex_position(), (47, 36))
 
-        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1, 1), (1, 40), (32, 1), (32, 40), (16, 20)]):
             offset = Hex.dy_offset(y, (self.antaresSector.dy // 40))
-            q,r = Hex.hex_to_axial(x + self.antaresSector.dx - 1, offset)
-            self.assertEqual(pos[idx].hex_position(), (q,r))
+            q, r = Hex.hex_to_axial(x + self.antaresSector.dx - 1, offset)
+            self.assertEqual(pos[idx].hex_position(), (q, r))
 
     def testFornast(self):
         pos = [
@@ -71,10 +71,10 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (63, -32))
         self.assertEqual(pos[4].hex_position(), (47, -4))
 
-        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1, 1), (1, 40), (32, 1), (32, 40), (16, 20)]):
             offset = Hex.dy_offset(y, (self.fornastSector.dy // 40))
-            q,r = Hex.hex_to_axial(x + self.fornastSector.dx - 1, offset)
-            self.assertEqual(pos[idx].hex_position(), (q,r))
+            q, r = Hex.hex_to_axial(x + self.fornastSector.dx - 1, offset)
+            self.assertEqual(pos[idx].hex_position(), (q, r))
 
     def testSetupOddColEvenRow(self):
         pos = Hex(self.coreSector, "0140")
@@ -134,10 +134,10 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (31, 24))
         self.assertEqual(pos[4].hex_position(), (15, 52))
 
-        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1, 1), (1, 40), (32, 1), (32, 40), (16, 20)]):
             offset = Hex.dy_offset(y, (self.lishunSector.dy // 40))
-            q,r = Hex.hex_to_axial(x + self.lishunSector.dx - 1, offset)
-            self.assertEqual(pos[idx].hex_position(), (q,r))
+            q, r = Hex.hex_to_axial(x + self.lishunSector.dx - 1, offset)
+            self.assertEqual(pos[idx].hex_position(), (q, r))
 
     def testDaguSector(self):
         pos = [
@@ -153,10 +153,10 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (-1, 0))
         self.assertEqual(pos[4].hex_position(), (-17, 28))
 
-        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1, 1), (1, 40), (32, 1), (32, 40), (16, 20)]):
             offset = Hex.dy_offset(y, (self.daguSector.dy // 40))
-            q,r = Hex.hex_to_axial(x + self.daguSector.dx - 1, offset)
-            self.assertEqual(pos[idx].hex_position(), (q,r))
+            q, r = Hex.hex_to_axial(x + self.daguSector.dx - 1, offset)
+            self.assertEqual(pos[idx].hex_position(), (q, r))
 
     def testCoreSector2(self):
         pos = [

--- a/Tests/Position/testHex.py
+++ b/Tests/Position/testHex.py
@@ -33,7 +33,7 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (31, -16))
         self.assertEqual(pos[4].hex_position(), (15, 12))
 
-        for idx, (x, y) in enumerate ([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
             offset = Hex.dy_offset(y, (self.coreSector.dy // 40))
             q,r = Hex.hex_to_axial(x + self.coreSector.dx - 1, offset)
             self.assertEqual(pos[idx].hex_position(), (q,r))
@@ -52,7 +52,7 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (63, 8))
         self.assertEqual(pos[4].hex_position(), (47, 36))
 
-        for idx, (x, y) in enumerate ([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
             offset = Hex.dy_offset(y, (self.antaresSector.dy // 40))
             q,r = Hex.hex_to_axial(x + self.antaresSector.dx - 1, offset)
             self.assertEqual(pos[idx].hex_position(), (q,r))
@@ -71,7 +71,7 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (63, -32))
         self.assertEqual(pos[4].hex_position(), (47, -4))
 
-        for idx, (x, y) in enumerate ([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
             offset = Hex.dy_offset(y, (self.fornastSector.dy // 40))
             q,r = Hex.hex_to_axial(x + self.fornastSector.dx - 1, offset)
             self.assertEqual(pos[idx].hex_position(), (q,r))
@@ -134,7 +134,7 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (31, 24))
         self.assertEqual(pos[4].hex_position(), (15, 52))
 
-        for idx, (x, y) in enumerate ([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
             offset = Hex.dy_offset(y, (self.lishunSector.dy // 40))
             q,r = Hex.hex_to_axial(x + self.lishunSector.dx - 1, offset)
             self.assertEqual(pos[idx].hex_position(), (q,r))
@@ -153,7 +153,7 @@ class testHex(unittest.TestCase):
         self.assertEqual(pos[3].hex_position(), (-1, 0))
         self.assertEqual(pos[4].hex_position(), (-17, 28))
 
-        for idx, (x, y) in enumerate ([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
+        for idx, (x, y) in enumerate([(1,1), (1,40), (32, 1), (32, 40), (16,20)]):
             offset = Hex.dy_offset(y, (self.daguSector.dy // 40))
             q,r = Hex.hex_to_axial(x + self.daguSector.dx - 1, offset)
             self.assertEqual(pos[idx].hex_position(), (q,r))

--- a/Tests/testDeltaDictionary.py
+++ b/Tests/testDeltaDictionary.py
@@ -1,7 +1,5 @@
-import codecs
 import unittest
 import sys
-from pathlib import Path
 
 from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary, SectorDictionary, SubsectorDictionary

--- a/Tests/testDeltaReduce.py
+++ b/Tests/testDeltaReduce.py
@@ -11,9 +11,6 @@ except ModuleNotFoundError:
     from PyRoute.Pathfinding.ApproximateShortestPathForestUnifiedFallback import ApproximateShortestPathForestUnified
 except ImportError:
     from PyRoute.Pathfinding.ApproximateShortestPathForestUnifiedFallback import ApproximateShortestPathForestUnified
-from PyRoute.SpeculativeTrade import SpeculativeTrade
-from PyRoute.StatCalculation import StatCalculation
-from PyRoute.route import set_logging
 from Tests.baseTest import baseTest
 
 

--- a/Tests/testDeltaStar.py
+++ b/Tests/testDeltaStar.py
@@ -155,5 +155,6 @@ class testDeltaStar(unittest.TestCase):
                 self.assertIsInstance(remix_star, Star)
                 self.assertFalse(remix_star.tradeCode.capital, "Remixed star should not be a capital")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/testDeltaStarReduction.py
+++ b/Tests/testDeltaStarReduction.py
@@ -112,5 +112,6 @@ class testDeltaStarReduction(baseTest):
         nu_actual = DeltaStar.reduce(actual)
         self.assertEqual(actual, nu_actual, "Canonicalisation did not round trip")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/testNobles.py
+++ b/Tests/testNobles.py
@@ -5,7 +5,6 @@ Created on Jan 1, 2019
 """
 
 import unittest
-import re
 import sys
 
 sys.path.append('../PyRoute')

--- a/Tests/testSpeculativeTrade.py
+++ b/Tests/testSpeculativeTrade.py
@@ -6,11 +6,8 @@ Created on Nov 28, 2024
 
 from PyRoute.AreaItems.Galaxy import Galaxy
 from PyRoute.AreaItems.Sector import Sector
-from PyRoute.Inputs.ParseStarInput import ParseStarInput
 from PyRoute.SpeculativeTrade import SpeculativeTrade
 from PyRoute.Star import Star
-from PyRoute.SystemData.UWP import UWP
-from PyRoute.TradeCodes import TradeCodes
 from Tests.baseTest import baseTest
 import unittest
 

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -341,7 +341,7 @@ class TestStar(unittest.TestCase):
                 target = chunk[1]
 
                 star1 = Star.parse_line_into_star(
-                    "0104 Shana Ma             E551112-"+letter+" Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
+                    "0104 Shana Ma             E551112-" + letter + " Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
                     Sector('# Core', '# 0, 0'), 'fixed', 'fixed')
 
                 self.assertEqual(target, star1.tl, "Unexpected mapping for TL " + letter)
@@ -361,7 +361,7 @@ class TestStar(unittest.TestCase):
                 target = chunk[1]
 
                 star1 = Star.parse_line_into_star(
-                    "0104 Shana Ma             E551112-"+letter+" Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
+                    "0104 Shana Ma             E551112-" + letter + " Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
                     Sector('# Core', '# 0, 0'), 'fixed', 'fixed')
 
                 self.assertEqual(target, star1.tl, "Unexpected mapping for TL " + letter)

--- a/Tests/testStar.py
+++ b/Tests/testStar.py
@@ -305,7 +305,7 @@ class TestStar(unittest.TestCase):
         self.assertEqual('[A935]', star1.social)
 
     def testStarSize(self):
-        star1 = Star.parse_line_into_star(
+        _ = Star.parse_line_into_star(
             "0104 Shana Ma             E551112-7 Lo Po                { -3 } (301-3) [1113] B     - - 913 9  Im K2 IV M7 V     ",
             Sector('# Core', '# 0, 0'), 'fixed', 'fixed')
 

--- a/Tests/testStarDistances.py
+++ b/Tests/testStarDistances.py
@@ -111,6 +111,7 @@ param_list = [
     ('3 sectors trailing, 3 sectors rimward', +3, +3, 165, 165),
 ]
 
+
 class testStarDistances(unittest.TestCase):
 
     def test_core_0101(self):
@@ -585,6 +586,7 @@ class testStarDistances(unittest.TestCase):
                 self.assertEqual(expected_alt_distance, distance, "Unexpected distance")
                 distance = star2.distance(star1)
                 self.assertEqual(expected_alt_distance, distance, "Unexpected reverse distance")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/testTradeCalculation.py
+++ b/Tests/testTradeCalculation.py
@@ -1,5 +1,4 @@
 import unittest
-import re
 import sys
 
 from PyRoute.Calculation.TradeCalculation import TradeCalculation

--- a/Tests/testTradeCalculation.py
+++ b/Tests/testTradeCalculation.py
@@ -50,16 +50,16 @@ class testTradeCalculation(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_positive_route_weight_doesnt_trip_assertion(self):
-            sector = Sector('# Core', '# 0, 0')
-            star1 = Star.parse_line_into_star(
-                "0103 Irkigkhan            B9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
-                sector, 'fixed', 'fixed')
-            star1.importance = -1
+        sector = Sector('# Core', '# 0, 0')
+        star1 = Star.parse_line_into_star(
+            "0103 Irkigkhan            B9C4733-9 Fl                   { 0 }  (E69+0) [4726] B     - - 123 8  Im M2 V           ",
+            sector, 'fixed', 'fixed')
+        star1.importance = -1
 
-            galaxy = Galaxy(min_btn=13)
-            tradecalc = TradeCalculation(galaxy)
+        galaxy = Galaxy(min_btn=13)
+        tradecalc = TradeCalculation(galaxy)
 
-            self.assertEqual(2, tradecalc.route_weight(star1, star1))
+        self.assertEqual(2, tradecalc.route_weight(star1, star1))
 
     def test_single_link_route_weight(self):
         sector = Sector('# Core', '# 0, 0')

--- a/Tests/testTradeCalculationPassengerBtn.py
+++ b/Tests/testTradeCalculationPassengerBtn.py
@@ -63,5 +63,6 @@ class testTradeCalculationPassengerBtn(unittest.TestCase):
                 actual = TradeCalculation.get_passenger_btn(0, astar, bstar)
                 self.assertEqual(expected, actual)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/testTradeCode.py
+++ b/Tests/testTradeCode.py
@@ -1,6 +1,5 @@
 import unittest
 import sys
-import re
 import logging
 
 sys.path.append('../PyRoute')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-lint.select = ["E", "F", "TID252", "E231", "NPY201"]
+lint.select = ["E", "F", "TID252", "E231", "NPY201", "W291", "W293"]
 lint.ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
As it says on the tin, extend the CI config to run ruff over the `Tests` dir as well as the `PyRoute` dir, and fix warnings found