### PR TITLE
Reduce delta debug memory use

### DIFF
--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -165,6 +165,7 @@ class DeltaReduce:
                 galaxy.process_eti()
                 spectrade = SpeculativeTrade(args.speculative_version, galaxy.stars)
                 spectrade.process_tradegoods()
+                del spectrade
 
             if args.routes:
                 galaxy.write_routes(args.routes)
@@ -186,7 +187,24 @@ class DeltaReduce:
                 if args.subsectors:
                     graphMap = SubsectorMap(galaxy, args.routes, galaxy.output_path)
                     graphMap.write_maps()
+
+            galaxy.trade = None
+            galaxy.ranges = None
+            galaxy.stars = None
+            galaxy.star_mapping = None
+            galaxy.sectors = None
+            galaxy = None
+            del galaxy
+
+            del stats
         except Exception as e:
+            galaxy.trade = None
+            galaxy.ranges = None
+            galaxy.stars = None
+            galaxy.star_mapping = None
+            galaxy.sectors = None
+            del galaxy
+
             # special-case DeltaLogicError - that means something's gone sideways in the delta debugger itself
             if isinstance(e, DeltaLogicError):
                 raise e

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -198,13 +198,6 @@ class DeltaReduce:
 
             del stats
         except Exception as e:
-            galaxy.trade = None
-            galaxy.ranges = None
-            galaxy.stars = None
-            galaxy.star_mapping = None
-            galaxy.sectors = None
-            del galaxy
-
             # special-case DeltaLogicError - that means something's gone sideways in the delta debugger itself
             if isinstance(e, DeltaLogicError):
                 raise e

--- a/PyRoute/DeltaPasses/AllegianceReducer.py
+++ b/PyRoute/DeltaPasses/AllegianceReducer.py
@@ -73,4 +73,7 @@ class AllegianceReducer(object):
 
         # At least one allegiance was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
-            self.reducer.sectors.write_files(self.reducer.args.mindir)
+            self.write_files()
+
+    def write_files(self):
+        self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/AllegianceReducer.py
+++ b/PyRoute/DeltaPasses/AllegianceReducer.py
@@ -3,6 +3,7 @@ Created on Oct 07, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 
 
 class AllegianceReducer(object):
@@ -62,6 +63,7 @@ class AllegianceReducer(object):
 
             if 0 < len(remove):
                 num_chunks -= len(remove)
+                self.write_files(best_sectors)
 
             num_chunks *= 2
             segment = list(best_sectors.allegiance_list())
@@ -75,5 +77,8 @@ class AllegianceReducer(object):
         if old_length > len(segment):
             self.write_files()
 
-    def write_files(self):
-        self.reducer.sectors.write_files(self.reducer.args.mindir)
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SectorReducer.py
+++ b/PyRoute/DeltaPasses/SectorReducer.py
@@ -76,4 +76,7 @@ class SectorReducer(object):
 
         # At least one sector was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
-            self.reducer.sectors.write_files(self.reducer.args.mindir)
+            self.write_files()
+
+    def write_files(self):
+        self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SectorReducer.py
+++ b/PyRoute/DeltaPasses/SectorReducer.py
@@ -3,6 +3,7 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 
 
 class SectorReducer(object):
@@ -60,6 +61,7 @@ class SectorReducer(object):
 
             if 0 < len(remove):
                 num_chunks -= len(remove)
+                self.write_files(best_sectors)
 
             num_chunks *= 2
             # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
@@ -78,5 +80,8 @@ class SectorReducer(object):
         if old_length > len(segment):
             self.write_files()
 
-    def write_files(self):
-        self.reducer.sectors.write_files(self.reducer.args.mindir)
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SingleLineReducer.py
+++ b/PyRoute/DeltaPasses/SingleLineReducer.py
@@ -28,6 +28,7 @@ class SingleLineReducer(object):
         short_msg = None
         best_sectors = self.reducer.sectors
         singleton_run = singleton_only
+        old_length = len(segment)
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
@@ -111,3 +112,10 @@ class SingleLineReducer(object):
         self.reducer.sectors = best_sectors
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)
+
+        # At least one line was shown to be irrelevant, write out the intermediate result
+        if old_length > len(segment):
+            self.write_files()
+
+    def write_files(self):
+        self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SingleLineReducer.py
+++ b/PyRoute/DeltaPasses/SingleLineReducer.py
@@ -3,6 +3,7 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
 
 
@@ -99,6 +100,7 @@ class SingleLineReducer(object):
 
             if 0 < len(remove):
                 num_chunks -= len(remove)
+                self.write_files(best_sectors)
 
             num_chunks *= 2
 
@@ -117,5 +119,8 @@ class SingleLineReducer(object):
         if old_length > len(segment):
             self.write_files()
 
-    def write_files(self):
-        self.reducer.sectors.write_files(self.reducer.args.mindir)
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -102,4 +102,7 @@ class SubsectorReducer(object):
 
         # At least one subsector was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
-            self.reducer.sectors.write_files(self.reducer.args.mindir)
+            self.write_files()
+
+    def write_files(self):
+        self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -3,6 +3,7 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
 
 
@@ -91,6 +92,7 @@ class SubsectorReducer(object):
 
             if 0 < len(remove):
                 num_chunks -= len(remove)
+                self.write_files(best_sectors)
 
             num_chunks *= 2
             segment = best_sectors.subsector_list()
@@ -104,5 +106,8 @@ class SubsectorReducer(object):
         if old_length > len(segment):
             self.write_files()
 
-    def write_files(self):
-        self.reducer.sectors.write_files(self.reducer.args.mindir)
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/TwoLineReducer.py
+++ b/PyRoute/DeltaPasses/TwoLineReducer.py
@@ -3,6 +3,7 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 
 
 class TwoLineReducer(object):
@@ -24,6 +25,8 @@ class TwoLineReducer(object):
 
         best_sectors = self.reducer.sectors
         gap = 1
+        old_length = len(segment)
+
         while gap < len(segment):
             msg = "# of lines: " + str(len(best_sectors.lines)) + f", gap {gap}"
             self.reducer.logger.error(msg)
@@ -47,7 +50,21 @@ class TwoLineReducer(object):
                     i += 1
                 j = i + gap
 
+            if old_length > len(segment):
+                self.write_files(best_sectors)
+                old_length = len(segment)
+
             gap += 1
 
         # now that the pass is done, update self.sectors with best reduction found
         self.reducer.sectors = best_sectors
+
+        # At least one sector was shown to be irrelevant, write out the intermediate result
+        if old_length > len(segment):
+            self.write_files()
+
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -4,7 +4,6 @@ Created on Jun 13, 2023
 @author: CyberiaResurrection
 """
 from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
-from PyRoute.DeltaDebug.DeltaReduce import DeltaReduce
 
 
 class WithinLineReducer(object):
@@ -12,7 +11,7 @@ class WithinLineReducer(object):
     full_msg = None
     start_msg = None
 
-    def __init__(self, reducer: DeltaReduce):
+    def __init__(self, reducer):
         self.reducer = reducer
 
     def preflight(self):

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -3,6 +3,8 @@ Created on Jun 13, 2023
 
 @author: CyberiaResurrection
 """
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
+from PyRoute.DeltaDebug.DeltaReduce import DeltaReduce
 
 
 class WithinLineReducer(object):
@@ -10,7 +12,7 @@ class WithinLineReducer(object):
     full_msg = None
     start_msg = None
 
-    def __init__(self, reducer):
+    def __init__(self, reducer: DeltaReduce):
         self.reducer = reducer
 
     def preflight(self):
@@ -36,6 +38,7 @@ class WithinLineReducer(object):
         if interesting:
             self.reducer.sectors = best_sectors
             self.reducer.logger.error(self.full_msg)
+            self.write_files()
             return
         else:
             best_sectors = self.reducer.sectors
@@ -78,6 +81,7 @@ class WithinLineReducer(object):
 
             if 0 < len(remove):
                 num_chunks -= len(remove)
+                self.write_files(best_sectors)
 
             num_chunks *= 2
 
@@ -96,6 +100,7 @@ class WithinLineReducer(object):
                 num_chunks = len(segment)
 
         self.reducer.sectors = best_sectors
+        self.write_files()
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)
 
@@ -111,3 +116,9 @@ class WithinLineReducer(object):
             nu_list.append((line[0], line[1]))
 
         return nu_list
+
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/Nobles.py
+++ b/PyRoute/Nobles.py
@@ -6,6 +6,8 @@ Created on Nov 29, 2023
 
 
 class Nobles(object):
+    __slots__ = 'nobles', 'codes'
+
     def __init__(self):
         self.nobles = {'Knights': 0,
                        'Baronets': 0,

--- a/PyRoute/SpeculativeTrade.py
+++ b/PyRoute/SpeculativeTrade.py
@@ -8,6 +8,8 @@ import logging
 
 
 class SpeculativeTrade(object):
+    __slots__ = 'logger', 'trade_table', 'stars', 'trade_version'
+
     t5_trade_table = {
         "Ag": {"Ag": 1, "As": 1, "De": 1, "Hi": 1, "In": 1, "Ri": 1, "Va": 1},
         "As": {"As": 1, "In": 1, "Ri": 1, "Va": 1},

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -42,8 +42,14 @@ class UWPCodes(object):
 
 
 class Star(object):
-    __slots__ = '__dict__', '_hash', '_key', 'index', 'zone', 'tradeCode', 'wtn', 'alg_code', 'hex',\
-                'deep_space_station', 'is_redzone'
+    __slots__ = '__dict__', 'worlds', 'ggCount', 'belts', 'nobles', 'logger', '_hash', '_key', 'component', 'index',\
+                'gwp', 'population', 'perCapita', 'mspr', 'wtn', 'ru', 'ownedBy', 'name', 'sector', 'position', 'uwp',\
+                'popM', 'uwpCodes', 'tradeCode', 'economics', 'social', 'baseCode', 'zone', 'alg_code',\
+                'allegiance_base', 'ship_capacity', 'tcs_gwp', 'budget', 'importance', 'eti_cargo', 'eti_passenger',\
+                'raw_be', 'im_be', 'col_be', 'star_list_object', 'routes', 'stars', 'is_enqueued', 'is_target',\
+                'is_landmark', '_pax_btn_mod', 'suppress_soph_percent_warning', 'is_redzone', 'hex',\
+                'deep_space_station', '_oldskool', 'tradeIn', 'tradeOver', 'tradeCount', 'passIn', 'passOver',\
+                'starportSize', 'starportBudget', 'starportPop', 'index',
 
     def __init__(self):
         self.worlds = None

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -128,14 +128,19 @@ class Star(object):
 
     def __deepcopy__(self, memodict={}):
         state = self.__dict__.copy()
+        for item in Star.__slots__:
+            if item in state:
+                continue
+            if item.startswith('_'):
+                continue
+            state[item] = self[item]
 
         foo = Star()
         for key in state:
             item = state[key]
             setattr(foo, key, item)
-        foo.index = self.index
-        foo.calc_hash()
         foo.hex = copy.deepcopy(self.hex)
+        foo.calc_hash()
 
         return foo
 

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -9,6 +9,8 @@ import logging
 import bisect
 import random
 import math
+from typing import Tuple
+from typing_extensions import TypeAlias
 
 from PyRoute.Position.Hex import Hex
 
@@ -18,6 +20,8 @@ from PyRoute.SystemData.Utilities import Utilities
 from collections import OrderedDict
 
 from PyRoute.SystemData.StarList import StarList
+
+HexPos: TypeAlias = Tuple[int, int]
 
 
 class UWPCodes(object):
@@ -317,7 +321,7 @@ class Star(object):
         return self.uwp.oldskool is True
 
     @functools.cached_property
-    def hex_position(self):
+    def hex_position(self) -> HexPos:
         return self.hex.hex_position()
 
     def distance(self, star):

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -71,7 +71,8 @@ class TradeCodes(object):
     sophont = re.compile(r"[A-Za-z\'!]{1}[\w\'!]{2,4}(\d|W|\?)")
     dieback = re.compile(r"[Di]*\([^)]+\)\d?")
 
-    __slots__ = '__dict__', 'codeset', 'pcode', 'dcode', 'xcode'
+    __slots__ = '__dict__', 'codeset', 'pcode', 'dcode', 'xcode', 'logger', 'codes', 'owned', 'homeworld_list',\
+                'sophont_list', 'owner', 'colony', 'ownedBy'
 
     def __init__(self, initial_codes):
         """

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -80,15 +80,16 @@ class TradeCodes(object):
         """
         self.logger = logging.getLogger('PyRoute.TradeCodes')
         self.codes, initial_codes = self._preprocess_initial_codes(initial_codes.strip())
-        self.pcode = set(TradeCodes.pcodes) & set(self.codes)
-        self.dcode = set(TradeCodes.dcodes) & set(self.codes)
-        self.xcode = TradeCodes.ext_codes & set(self.codes)
+        code_set = set(self.codes)
+        self.pcode = set(TradeCodes.pcodes) & code_set
+        self.dcode = set(TradeCodes.dcodes) & code_set
+        self.xcode = TradeCodes.ext_codes & code_set
 
         self.owned = [code for code in self.codes if code.startswith('O:') or code.startswith('C:')]
 
         homeworlds_found = self._process_sophonts_and_homeworlds(initial_codes)
 
-        self.codeset = set(self.codes) - self.dcode - set(self.owned) - set(self.sophont_list)\
+        self.codeset = code_set - self.dcode - set(self.owned) - set(self.sophont_list)\
             - set(homeworlds_found) - self.xcode
         self.codeset = sorted(list(self.codeset))
 


### PR DESCRIPTION
I was working on some pathfinding tweaks when (surprise surprise) running over the imperial sector list blew up.

The first couple of times, delta debugging from the 32 sector imperial list wasn't _too_ annoying, but that changed with the third and later detonations.  Those somewhat quickly blew up with out-of-memory errors - on a box with 32 GB of physical RAM.

After some investigation between detonations, and liberal use of tracemalloc, turns out the Galaxy variable isn't getting cleaned up between iterations.  Tackling that, and some other things, reduced the largest memory allocation at the end of the SubsectorReduce pass by just under 3.8 fold, with similar reductions elsewhere.

Due to the delta debugging runs blowing up, I also changed all delta debugging passes to write out the current sector files at the end of any given sub-pass, with a given number of chunks, when that sub-pass makes any sort of progress in reduction.