### PR TITLE
Reduce delta debug mem use

### DIFF
--- a/PyRoute/DeltaDebug/DeltaDebug.py
+++ b/PyRoute/DeltaDebug/DeltaDebug.py
@@ -184,14 +184,14 @@ def process():
         reducer.reduce_line_pass()
         reducer.is_initial_state_interesting()
 
+    if args.run_within:
+        logger.error("Reducing within lines")
+        reducer.reduce_within_line()
+
     # enforce 2-minimality
     if args.two_min:
         logger.error("Reducing by two-line")
         reducer.reduce_line_two_minimal()
-
-    if args.run_within:
-        logger.error("Reducing within lines")
-        reducer.reduce_within_line()
 
     # check final input is _still_ interesting
     reducer.is_initial_state_interesting()

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -332,7 +332,7 @@ class SectorDictionary(dict):
             handle.write(line)
 
         for line in self.lines:
-            line = line.strip() + '\n'
+            line = line + '\n'
             handle.write(line)
 
         handle.close()
@@ -421,7 +421,7 @@ class SectorDictionary(dict):
                 if line.startswith('----'):
                     isheader = False
             else:
-                starlines.append(line.strip())
+                starlines.append(line.rstrip('\n'))
         return headers, starlines
 
 

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -134,10 +134,11 @@ class DeltaReduce:
         return short_msg
 
     @staticmethod
-    def _check_interesting(args, sectors):
+    def _check_interesting(args, raw_sectors):
         interesting = False
         msg = None
         q = None
+        sectors = copy.deepcopy(raw_sectors)
 
         try:
             galaxy = DeltaGalaxy(args.btn, args.max_jump)
@@ -217,6 +218,7 @@ class DeltaReduce:
                     interesting = True
                 else:
                     interesting = False
+        del sectors
 
         return interesting, msg, q
 

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -223,4 +223,6 @@ class DeltaReduce:
     @staticmethod
     def chunk_lines(lines, num_chunks):
         n = math.ceil(len(lines) / num_chunks)
-        return [lines[i:i + n] for i in range(0, len(lines), n)]
+        chunks = [lines[i:i + n] for i in range(0, len(lines), n)]
+        chunks = [item for item in chunks if 0 < len(item)]
+        return chunks

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -87,7 +87,8 @@ class DeltaReduce:
         self.single_line_reducer.run(singleton_only)
 
     def reduce_line_two_minimal(self):
-        self.two_line_reducer.run(False)
+        self.two_line_reducer.run(False, first_segment=True)
+        self.two_line_reducer.run(False, first_segment=False)
 
     def reduce_within_line(self):
         # we're going to be deliberately mangling lines in the process of reducing them, so shut up loggers,

--- a/PyRoute/DeltaPasses/AllegianceReducer.py
+++ b/PyRoute/DeltaPasses/AllegianceReducer.py
@@ -30,6 +30,7 @@ class AllegianceReducer(object):
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
+            num_chunks = len(chunks)
             remove = []
             msg = "# of lines: " + str(len(best_sectors.lines)) + ", # of chunks: " + str(num_chunks) + ", # of allegiances: " + str(len(segment))
             self.reducer.logger.error(msg)

--- a/PyRoute/DeltaPasses/AllegianceReducer.py
+++ b/PyRoute/DeltaPasses/AllegianceReducer.py
@@ -26,6 +26,7 @@ class AllegianceReducer(object):
         num_chunks = len(segment) if singleton_only else 2
         short_msg = None
         best_sectors = self.reducer.sectors
+        singleton_run = singleton_only
         old_length = len(segment)
 
         while num_chunks <= len(segment):
@@ -67,6 +68,10 @@ class AllegianceReducer(object):
                 self.write_files(best_sectors)
 
             num_chunks *= 2
+            # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
+            if num_chunks > len(segment) and not singleton_run:
+                singleton_run = True
+                num_chunks = len(segment)
             segment = list(best_sectors.allegiance_list())
 
         # now that the pass is done, update self.sectors with best reduction found

--- a/PyRoute/DeltaPasses/AuxiliaryLineReduce.py
+++ b/PyRoute/DeltaPasses/AuxiliaryLineReduce.py
@@ -17,11 +17,11 @@ class AuxiliaryLineReduce(WithinLineReducer):
         segment = []
         num_lines = len(self.reducer.sectors.lines)
         for line in self.reducer.sectors.lines:
-            canon = DeltaStar.reduce_auxiliary(line.strip())
+            canon = DeltaStar.reduce_auxiliary(line)
             assert isinstance(canon,
                               str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
             # Skip already-reduced lines
-            if 2 < num_lines and line == canon:
+            if 2 < num_lines and line.startswith(canon):
                 continue
             subs_list.append((line, canon))
             segment.append(line)

--- a/PyRoute/DeltaPasses/CapitalLineReduce.py
+++ b/PyRoute/DeltaPasses/CapitalLineReduce.py
@@ -21,7 +21,7 @@ class CapitalLineReduce(WithinLineReducer):
             assert isinstance(canon,
                               str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
             # Skip already-reduced lines
-            if 2 < num_lines and line == canon:
+            if 2 < num_lines and line.startswith(canon):
                 continue
             subs_list.append((line, canon))
             segment.append(line)

--- a/PyRoute/DeltaPasses/FullLineReduce.py
+++ b/PyRoute/DeltaPasses/FullLineReduce.py
@@ -16,11 +16,11 @@ class FullLineReduce(WithinLineReducer):
         subs_list = []
         segment = []
         for line in self.reducer.sectors.lines:
-            canon = DeltaStar.reduce_all(line.strip())
+            canon = DeltaStar.reduce_all(line)
             assert isinstance(canon,
                               str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
             # Skip already-reduced lines
-            if line == canon:
+            if line.startswith(canon):
                 continue
             subs_list.append((line, canon))
             segment.append(line)

--- a/PyRoute/DeltaPasses/ImportanceLineReduce.py
+++ b/PyRoute/DeltaPasses/ImportanceLineReduce.py
@@ -16,11 +16,11 @@ class ImportanceLineReduce(WithinLineReducer):
         subs_list = []
         segment = []
         for line in self.reducer.sectors.lines:
-            canon = DeltaStar.reduce_importance(line.strip())
+            canon = DeltaStar.reduce_importance(line)
             assert isinstance(canon,
                               str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
             # Skip already-reduced lines
-            if line == canon:
+            if line.startswith(canon):
                 continue
             subs_list.append((line, canon))
             segment.append(line)

--- a/PyRoute/DeltaPasses/SectorReducer.py
+++ b/PyRoute/DeltaPasses/SectorReducer.py
@@ -31,6 +31,7 @@ class SectorReducer(object):
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
+            num_chunks = len(chunks)
             remove = []
             msg = "# of lines: " + str(len(best_sectors.lines)) + ", # of chunks: " + str(num_chunks) + ", # of sectors: " + str(len(segment))
             self.reducer.logger.error(msg)

--- a/PyRoute/DeltaPasses/SingleLineReducer.py
+++ b/PyRoute/DeltaPasses/SingleLineReducer.py
@@ -33,6 +33,7 @@ class SingleLineReducer(object):
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
+            num_chunks = len(chunks)
             remove = []
             msg = "# of lines: " + str(len(best_sectors.lines)) + ", # of chunks: " + str(num_chunks)
             self.reducer.logger.error(msg)

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -32,6 +32,7 @@ class SubsectorReducer(object):
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
+            num_chunks = len(chunks)
             remove = []
             msg = "# of lines: " + str(len(best_sectors.lines)) + ", # of chunks: " + str(
                 num_chunks) + ", # of subsectors: " + str(len(segment))

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -28,6 +28,7 @@ class SubsectorReducer(object):
         num_chunks = len(segment) if singleton_only else 2
         short_msg = None
         best_sectors = self.reducer.sectors
+        singleton_run = singleton_only
         old_length = len(segment)
 
         while num_chunks <= len(segment):
@@ -96,6 +97,10 @@ class SubsectorReducer(object):
                 self.write_files(best_sectors)
 
             num_chunks *= 2
+            # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
+            if num_chunks > len(segment) and not singleton_run:
+                singleton_run = True
+                num_chunks = len(segment)
             segment = best_sectors.subsector_list()
 
         # now that the pass is done, update self.sectors with best reduction found

--- a/PyRoute/DeltaPasses/TwoLineReducer.py
+++ b/PyRoute/DeltaPasses/TwoLineReducer.py
@@ -32,6 +32,8 @@ class TwoLineReducer(object):
         while gap < min(maxgap, len(segment)):
             msg = "# of lines: " + str(len(best_sectors.lines)) + f", gap {gap}"
             self.reducer.logger.error(msg)
+            interim_write = max(10, int((len(segment) - gap) ** 0.5))
+            interim_counter = 0
 
             i = 0
             j = i + gap
@@ -48,6 +50,10 @@ class TwoLineReducer(object):
                     segment = best_sectors.lines
                     msg = "Reduction found: new input has " + str(len(best_sectors.lines)) + " lines"
                     self.reducer.logger.error(msg)
+                    interim_counter += 1
+                    if interim_write == interim_counter:
+                        interim_counter = 0
+                        self.write_files(best_sectors)
                 else:
                     i += 1
                 j = i + gap

--- a/PyRoute/DeltaPasses/TwoLineReducer.py
+++ b/PyRoute/DeltaPasses/TwoLineReducer.py
@@ -16,7 +16,7 @@ class TwoLineReducer(object):
             return True
         return False
 
-    def run(self, singleton_only=False):
+    def run(self, singleton_only=False, first_segment=True):
         segment = self.reducer.sectors.lines
 
         # An interesting less-than-4-element list is 2-minimal by definition
@@ -24,10 +24,12 @@ class TwoLineReducer(object):
             return
 
         best_sectors = self.reducer.sectors
-        gap = 1
         old_length = len(segment)
+        sqrt = max(2, round(old_length ** 0.5))
+        gap = 1 if first_segment else sqrt
+        maxgap = sqrt + 1 if first_segment else len(segment)
 
-        while gap < len(segment):
+        while gap < min(maxgap, len(segment)):
             msg = "# of lines: " + str(len(best_sectors.lines)) + f", gap {gap}"
             self.reducer.logger.error(msg)
 

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -80,6 +80,16 @@ class WithinLineReducer(object):
 
             if 0 < len(remove):
                 num_chunks -= len(remove)
+                new_hex = 'Hex  Name                 UWP       Remarks                               {Ix}   (Ex)    [Cx]   N    B  Z PBG W  A    Stellar         Routes                                   \n'
+                new_dash = '---- -------------------- --------- ------------------------------------- ------ ------- ------ ---- -- - --- -- ---- --------------- -----------------------------------------\n'
+                for sec_name in best_sectors:
+                    num_headers = len(best_sectors[sec_name].headers)
+                    for i in range(0, num_headers):
+                        raw_line = best_sectors[sec_name].headers[i]
+                        if raw_line.startswith('Hex  '):
+                            best_sectors[sec_name].headers[i] = new_hex
+                        elif raw_line.startswith('---- --'):
+                            best_sectors[sec_name].headers[i] = new_dash
                 self.write_files(best_sectors)
 
             num_chunks *= 2

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -78,6 +78,7 @@ class WithinLineReducer(object):
                     best_sectors = temp_sectors
                     msg = "Reduction found: new input has " + str(len(raw_lines)) + " unreduced lines"
                     self.reducer.logger.error(msg)
+                del temp_sectors
 
             if 0 < len(remove):
                 num_chunks -= len(remove)

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -49,6 +49,7 @@ class WithinLineReducer(object):
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)
+            num_chunks = len(chunks)
             remove = []
             msg = "# of unreduced lines: " + str(len(segment)) + ", # of chunks: " + str(num_chunks)
             self.reducer.logger.error(msg)

--- a/PyRoute/Nobles.py
+++ b/PyRoute/Nobles.py
@@ -6,7 +6,21 @@ Created on Nov 29, 2023
 
 
 class Nobles(object):
-    __slots__ = 'nobles', 'codes'
+    __slots__ = 'nobles'
+
+    codes = {'B': 'Knights',
+             'c': 'Baronets',
+             'C': 'Barons',
+             'D': 'Marquis',
+             'e': 'Viscounts',
+             'E': 'Counts',
+             'f': 'Dukes',
+             'F': 'Sector Dukes',
+             'G': 'Archdukes',
+             'H': 'Emperor'}
+
+    key_list = list(codes.keys())
+    value_list = list(codes.values())
 
     def __init__(self):
         self.nobles = {'Knights': 0,
@@ -19,28 +33,16 @@ class Nobles(object):
                        'Sector Dukes': 0,
                        'Archdukes': 0,
                        'Emperor': 0}
-        self.codes = {'B': 'Knights',
-                      'c': 'Baronets',
-                      'C': 'Barons',
-                      'D': 'Marquis',
-                      'e': 'Viscounts',
-                      'E': 'Counts',
-                      'f': 'Dukes',
-                      'F': 'Sector Dukes',
-                      'G': 'Archdukes',
-                      'H': 'Emperor'}
 
     def __str__(self):
         # If there's absolutely no nobles, return '-':
-        if 0 == max(self.nobles.values()):
+        if 0 == self.max_value:
             return '-'
 
         nobility = ""
-        key_list = list(self.codes.keys())
-        value_list = list(self.codes.values())
         for rank, count in self.nobles.items():
             if count > 0:
-                nobility += key_list[value_list.index(rank)]
+                nobility += Nobles.key_list[Nobles.value_list.index(rank)]
         return ''.join(sorted(nobility, key=lambda v: (v.lower(), v[0].isupper())))
 
     def __getstate__(self):
@@ -49,7 +51,7 @@ class Nobles(object):
         return state
 
     def count(self, nobility):
-        for code, rank in self.codes.items():
+        for code, rank in Nobles.codes.items():
             if code in nobility:
                 self.nobles[rank] += 1
 

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -53,7 +53,7 @@ class Star(object):
                 'raw_be', 'im_be', 'col_be', 'star_list_object', 'routes', 'stars', 'is_enqueued', 'is_target',\
                 'is_landmark', '_pax_btn_mod', 'suppress_soph_percent_warning', 'is_redzone', 'hex',\
                 'deep_space_station', '_oldskool', 'tradeIn', 'tradeOver', 'tradeCount', 'passIn', 'passOver',\
-                'starportSize', 'starportBudget', 'starportPop', 'index',
+                'starportSize', 'starportBudget', 'starportPop', 'index', 'trade_cost', 'trade_id'
 
     def __init__(self):
         self.worlds = None
@@ -111,6 +111,8 @@ class Star(object):
         self.tradeIn = None
         self.tradeOver = None
         self.tradeCount = None
+        self.trade_cost = 0.0
+        self.trade_id = ""
         self.passIn = None
         self.passOver = None
         self.starportSize = None

--- a/PyRoute/StatCalculation.py
+++ b/PyRoute/StatCalculation.py
@@ -3,6 +3,7 @@ Created on Mar 17, 2014
 
 @author: tjoneslo
 """
+import copy
 import logging
 import math
 from PyRoute.wikistats import WikiStats
@@ -41,6 +42,13 @@ class Populations(object):
 
 
 class ObjectStatistics(object):
+
+    __slots__ = 'population', 'populations', 'economy', 'trade', 'tradeExt', 'tradeVol', 'tradeDton', 'tradeDtonExt',\
+                'percapita', 'number', 'milBudget', 'maxTL', 'maxPort', 'maxPop', 'sum_ru', 'shipyards', 'col_be',\
+                'im_be', 'passengers', 'spa_people', 'port_size', 'code_counts', 'bases', 'eti_worlds', 'eti_cargo',\
+                'eti_pass', 'homeworlds', 'high_pop_worlds', 'high_tech_worlds', 'TLmean', 'TLstddev', 'subsectorCp',\
+                'sectorCp', 'otherCp', 'gg_count', 'worlds', 'stars', 'star_count', 'primary_count', '__dict__'
+
     base_mapping = {'C': 'Corsair base', 'D': 'Naval depot', 'E': 'Embassy', 'K': 'Naval base', 'M': 'Military base',
                     'N': 'Naval base', 'O': 'Naval outpost',
                     'R': 'Clan base', 'S': 'Scout base', 'T': 'Tlaukhu base', 'V': 'Scout base', 'W': 'Way station',
@@ -95,6 +103,9 @@ class ObjectStatistics(object):
     # For the JSONPickel work
     def __getstate__(self):
         state = self.__dict__.copy()
+        for key in ObjectStatistics.__slots__:
+            if key not in state:
+                state[key] = self[key]
         del state['high_pop_worlds']
         del state['high_tech_worlds']
         del state['subsectorCp']
@@ -107,6 +118,9 @@ class ObjectStatistics(object):
         state = self.__dict__.copy()
         foo = ObjectStatistics()
         foo.__dict__.update(state)
+        for key in ObjectStatistics.__slots__:
+            if key not in foo:
+                foo[key] = copy.deepcopy(self[key])
 
         return foo
 

--- a/PyRoute/StatCalculation.py
+++ b/PyRoute/StatCalculation.py
@@ -28,6 +28,17 @@ class Populations(object):
     def __lt__(self, other):
         return self.population < other.population
 
+    def __eq__(self, other):
+        if self.code != other.code:
+            return False
+        if self.count != other.count:
+            return False
+        if self.population != other.population:
+            return False
+        if self.homeworlds != other.homeworlds:
+            return False
+        return True
+
 
 class ObjectStatistics(object):
     base_mapping = {'C': 'Corsair base', 'D': 'Naval depot', 'E': 'Embassy', 'K': 'Naval base', 'M': 'Military base',

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -519,7 +519,7 @@ class TradeCodes(object):
     def homeworld(self):
         return sorted(self.homeworld_list)
 
-    @functools.cached_property
+    @property
     def sophonts(self):
         return sorted(self.sophont_list)
 

--- a/Tests/Pathfinding/testStatCalcRegression.py
+++ b/Tests/Pathfinding/testStatCalcRegression.py
@@ -72,7 +72,8 @@ class testStatCalcRegression(baseTest):
                     'population': 80481, 'populations': NoNoneDefaultDict(Populations), 'port_size': NoNoneDefaultDict(int),
                     'primary_count': NoNoneDefaultDict(int), 'shipyards': 81, 'spa_people': 23705,
                     'star_count': NoNoneDefaultDict(int), 'stars': 172, 'sum_ru': 121636, 'trade': 143514760000,
-                    'tradeDton': 3273603, 'tradeDtonExt': 0, 'tradeExt': 0, 'tradeVol': 144540860000, 'worlds': 1272}
+                    'tradeDton': 3273603, 'tradeDtonExt': 0, 'tradeExt': 0, 'tradeVol': 144540860000, 'worlds': 1272,
+                    '__dict__': {}}
         expected['bases']['Military base'] = 18
         expected['bases']['Naval base'] = 23
         expected['bases']['Scout base'] = 9

--- a/Tests/Pathfinding/testStatCalcRegression.py
+++ b/Tests/Pathfinding/testStatCalcRegression.py
@@ -3,10 +3,13 @@ Created on Oct 19, 2023
 
 @author: CyberiaResurrection
 """
+import copy
+
 from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
-from PyRoute.StatCalculation import StatCalculation
+from PyRoute.StatCalculation import StatCalculation, Populations
 from Tests.baseTest import baseTest
+from PyRoute.Utilities.NoNoneDefaultDict import NoNoneDefaultDict
 
 
 class testStatCalcRegression(baseTest):
@@ -35,3 +38,82 @@ class testStatCalcRegression(baseTest):
         stats = StatCalculation(galaxy)
         stats.calculate_statistics(args.ally_match)
         stats.write_statistics(args.ally_count, args.ally_match, args.json_data)
+
+    def testStatsCalcReftSector(self):
+        sourcefile = self.unpack_filename('DeltaFiles/reft-allegiance-pax-balance/Reft Sector.sec')
+
+        sector = SectorDictionary.load_traveller_map_file(sourcefile)
+        delta = DeltaDictionary()
+        delta[sector.name] = sector
+
+        args = self._make_args()
+        args.max_jump = 2
+        args.min_btn = 15
+
+        galaxy = DeltaGalaxy(args.btn, args.max_jump)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc,
+                            args.route_reuse, args.routes, args.route_btn, args.mp_threads, args.debug_flag)
+        galaxy.output_path = args.output
+
+        galaxy.generate_routes()
+        galaxy.trade.calculate_components()
+
+        galaxy.trade.calculate_routes()
+
+        stats = StatCalculation(galaxy)
+        stats.calculate_statistics(args.ally_match)
+        stats.write_statistics(args.ally_count, args.ally_match, args.json_data)
+
+        gal_stats = galaxy.stats
+        expected = {'TLmean': 0, 'TLstddev': 0, 'bases': NoNoneDefaultDict(int), 'code_counts': NoNoneDefaultDict(int),
+                    'col_be': 6797.200000000001, 'economy': 381621, 'eti_cargo': 0,
+                    'eti_pass': 0, 'eti_worlds': 0, 'gg_count': 93, 'im_be': 6196.989999999999, 'maxPop': 0,
+                    'maxPort': 'X', 'maxTL': 0, 'milBudget': 0, 'number': 122, 'passengers': 7817295, 'percapita': 4741,
+                    'population': 80481, 'populations': NoNoneDefaultDict(Populations), 'port_size': NoNoneDefaultDict(int),
+                    'primary_count': NoNoneDefaultDict(int), 'shipyards': 81, 'spa_people': 23705,
+                    'star_count': NoNoneDefaultDict(int), 'stars': 172, 'sum_ru': 121636, 'trade': 143514760000,
+                    'tradeDton': 3273603, 'tradeDtonExt': 0, 'tradeExt': 0, 'tradeVol': 144540860000, 'worlds': 1272}
+        expected['bases']['Military base'] = 18
+        expected['bases']['Naval base'] = 23
+        expected['bases']['Scout base'] = 9
+        expected['code_counts'].update({'(Orpheides)': 1, '(Tapazmal)': 1, 'Ag': 20, 'An': 1, 'As': 3, 'Chir2': 1,
+                                        'Chir4': 1, 'ChirW': 1, 'Cp': 2, 'Da': 7, 'De': 11, 'Di(Droyne)': 1,
+                                        'Di(Salika)': 1, 'Droy4': 1, 'Droy6': 1, 'Fl': 2, 'Fo': 2, 'Ga': 7, 'He': 8,
+                                        'Hi': 13, 'Ic': 6, 'In': 7, 'Lo': 28, 'Mr': 1, 'Na': 11, 'Ni': 63, 'O:0707': 1,
+                                        'O:0926': 2, 'O:1323': 1, 'O:1327': 1, 'O:1628': 1, 'O:1822': 1, 'O:2322': 1,
+                                        'O:2325': 1, 'O:2738': 2, 'O:2837': 1, 'O:2838': 1, 'O:Gush-0130': 1,
+                                        'O:Troj-3215': 1, 'Oc': 2, 'Pa': 10, 'Ph': 6, 'Pi': 9, 'Po': 20, 'Pr': 6,
+                                        'Pz': 9, 'Ri': 9, 'RsA': 1, 'RsB': 1, 'Tapa2': 1, 'Tapa3': 1, 'Tapa4': 1,
+                                        'Tapa6': 1, 'Tapa8': 1, 'Va': 15, 'Wa': 3})
+        expected['port_size'].update({0: 23, 1: 27, 2: 41, 3: 24, 4: 4, 5: 3, 'A': 22, 'B': 61, 'C': 18, 'D': 11,
+                                      'E': 8, 'X': 2})
+        expected['primary_count'].update({'A': 3, 'F': 23, 'G': 43, 'K': 31, 'M': 22})
+        expected['star_count'][1] = 74
+        expected['star_count'][2] = 46
+        expected['star_count'][3] = 2
+        expected['populations']['Chir'] = Populations()
+        expected['populations']['Chir'].count = 3
+        expected['populations']['Chir'].population = 6
+        expected['populations']['Droy'] = Populations()
+        expected['populations']['Droy'].count = 3
+        expected['populations']['Droy'].population = 2
+        expected['populations']['Huma'] = Populations()
+        expected['populations']['Huma'].count = 122
+        expected['populations']['Huma'].population = 80467
+        expected['populations']['Orph'] = Populations()
+        expected['populations']['Orph'].count = 1
+        expected['populations']['Orph'].population = 1
+        expected['populations']['Orph'].homeworlds.append(galaxy.star_mapping[53])
+        expected['populations']['Sali'] = Populations()
+        expected['populations']['Sali'].count = 1
+        expected['populations']['Tapa'] = Populations()
+        expected['populations']['Tapa'].count = 6
+        expected['populations']['Tapa'].population = 2
+        expected['populations']['Tapa'].homeworlds.append(galaxy.star_mapping[116])
+        actual = gal_stats.__getstate__()
+        act_pops = actual['populations']
+        self.assertEqual(expected['populations'], act_pops)
+        self.assertEqual(expected, actual)
+
+        remix = copy.deepcopy(actual)
+        self.assertEqual(expected, remix, "Deep-copy not equal to original")

--- a/Tests/testDeltaDictionary.py
+++ b/Tests/testDeltaDictionary.py
@@ -220,8 +220,6 @@ class testDeltaDictionary(baseTest):
 
         remix = foo.sector_subset(['Spinward Marches', 'Deneb', 'Trojan Reach'])
         self.assertEqual(1, len(remix))
-        remix_stats = remix['Spinward Marches'].allegiances['CsIm'].stats
-        self.assertTrue('high_pop_worlds' in remix_stats.__dict__, "Missing high_pop_worlds attribute not restored")
         self.assertListEqual([], remix['Spinward Marches'].allegiances['CsIm'].stats.high_pop_worlds, "Missing high_pop_worlds list not restored")
 
     def test_allegiance_list(self):


### PR DESCRIPTION
Following up #143 , here's some more tweaks to further reduce memory use, clean up internals of delta debugging, and spit out intermediate results (ie, sector files) more frequently.

Unlike #143 , this isn't one major focused chunk, but a collection of smaller chunks.