### PR TITLE
Delta debug tweaks

### DIFF
--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -126,16 +126,10 @@ class DeltaDictionary(dict):
         for sector_name in self:
             self[sector_name].write_file(output_dir)
 
-    def skip_void_subsectors_if_half(self):
-        # if at least half of read-in subsectors are void, assume this is a follow-up on a previous reduction run
-        # and mark all void subsectors as skipped
-        void_subsec = 0
+    def skip_void_subsectors(self):
+        # skip void subsectors unconditionally - all they do is take up space in subsector reduction
         for secname in self:
-            void_subsec += self[secname].void_subsectors
-
-        if void_subsec * 2 >= 16 * len(self):
-            for secname in self:
-                self[secname].skip_void_subsectors()
+            self[secname].skip_void_subsectors()
 
 
 class SectorDictionary(dict):

--- a/PyRoute/DeltaDebug/DeltaGalaxy.py
+++ b/PyRoute/DeltaDebug/DeltaGalaxy.py
@@ -21,7 +21,7 @@ class DeltaGalaxy(Galaxy):
         star_counter = 0
         sector: SectorDictionary
 
-        sectors.skip_void_subsectors_if_half()
+        sectors.skip_void_subsectors()
         for sector_name in sectors:
             sector = sectors[sector_name]
             sec = Sector("# " + sector.name, sector.position)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -19,6 +19,7 @@ from PyRoute.DeltaPasses.Canonicalisation import Canonicalisation
 from PyRoute.DeltaPasses.CapitalLineReduce import CapitalLineReduce
 from PyRoute.DeltaPasses.FullLineReduce import FullLineReduce
 from PyRoute.DeltaPasses.ImportanceLineReduce import ImportanceLineReduce
+from PyRoute.DeltaPasses.NBZLineReduce import NBZLineReduce
 from PyRoute.DeltaPasses.SectorReducer import SectorReducer
 from PyRoute.DeltaPasses.SingleLineReducer import SingleLineReducer
 from PyRoute.DeltaPasses.SubsectorReducer import SubsectorReducer
@@ -46,7 +47,7 @@ class DeltaReduce:
         self.interesting_type = interesting_type
         self.logger = logging.getLogger('PyRoute.Star')
         logging.disable(logging.WARNING)
-        self.withinline = [Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self)]
+        self.withinline = [Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self), NBZLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaPasses/BeyondLineReducer.py
+++ b/PyRoute/DeltaPasses/BeyondLineReducer.py
@@ -1,0 +1,25 @@
+"""
+Created on Apr 05, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
+from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
+
+
+class BeyondLineReducer(object):
+
+    def __init__(self, reducer):
+        self.reducer = reducer
+        self.breacher = WidenHoleReducer(reducer)
+
+    def preflight(self):
+        if self.reducer is not None and self.reducer.sectors is not None and 0 < len(self.reducer.sectors.lines):
+            return True
+        return False
+
+    def write_files(self, sectors=None):
+        if isinstance(sectors, DeltaDictionary):
+            sectors.write_files(self.reducer.args.mindir)
+        else:
+            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/NBZLineReduce.py
+++ b/PyRoute/DeltaPasses/NBZLineReduce.py
@@ -1,0 +1,28 @@
+"""
+Created on Apr 03, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class NBZLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with nbz reduction"
+        self.start_msg = "Commencing nbz within-line reduction"
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce_nbz(line)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/SectorReducer.py
+++ b/PyRoute/DeltaPasses/SectorReducer.py
@@ -3,18 +3,10 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
-from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
+from PyRoute.DeltaPasses.BeyondLineReducer import BeyondLineReducer
 
 
-class SectorReducer(object):
-
-    def __init__(self, reducer):
-        self.reducer = reducer
-
-    def preflight(self):
-        if self.reducer is not None and self.reducer.sectors is not None and 0 < len(self.reducer.sectors.lines):
-            return True
-        return False
+class SectorReducer(BeyondLineReducer):
 
     def run(self, singleton_only=False):
         segment = self.reducer.sectors.sector_list()
@@ -80,9 +72,3 @@ class SectorReducer(object):
         # At least one sector was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
             self.write_files()
-
-    def write_files(self, sectors=None):
-        if isinstance(sectors, DeltaDictionary):
-            sectors.write_files(self.reducer.args.mindir)
-        else:
-            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SingleLineReducer.py
+++ b/PyRoute/DeltaPasses/SingleLineReducer.py
@@ -3,20 +3,10 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
-from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
-from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
+from PyRoute.DeltaPasses.BeyondLineReducer import BeyondLineReducer
 
 
-class SingleLineReducer(object):
-
-    def __init__(self, reducer):
-        self.reducer = reducer
-        self.breacher = WidenHoleReducer(reducer)
-
-    def preflight(self):
-        if self.reducer is not None and self.reducer.sectors is not None and 0 < len(self.reducer.sectors.lines):
-            return True
-        return False
+class SingleLineReducer(BeyondLineReducer):
 
     def run(self, singleton_only=False):
         segment = self.reducer.sectors.lines
@@ -119,9 +109,3 @@ class SingleLineReducer(object):
         # At least one line was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
             self.write_files()
-
-    def write_files(self, sectors=None):
-        if isinstance(sectors, DeltaDictionary):
-            sectors.write_files(self.reducer.args.mindir)
-        else:
-            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -3,20 +3,10 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
-from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
-from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
+from PyRoute.DeltaPasses.BeyondLineReducer import BeyondLineReducer
 
 
-class SubsectorReducer(object):
-
-    def __init__(self, reducer):
-        self.reducer = reducer
-        self.breacher = WidenHoleReducer(reducer)
-
-    def preflight(self):
-        if self.reducer is not None and self.reducer.sectors is not None and 0 < len(self.reducer.sectors.lines):
-            return True
-        return False
+class SubsectorReducer(BeyondLineReducer):
 
     def run(self, singleton_only=False):
         segment = self.reducer.sectors.subsector_list()
@@ -111,9 +101,3 @@ class SubsectorReducer(object):
         # At least one subsector was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
             self.write_files()
-
-    def write_files(self, sectors=None):
-        if isinstance(sectors, DeltaDictionary):
-            sectors.write_files(self.reducer.args.mindir)
-        else:
-            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/TwoLineReducer.py
+++ b/PyRoute/DeltaPasses/TwoLineReducer.py
@@ -3,18 +3,10 @@ Created on Oct 03, 2023
 
 @author: CyberiaResurrection
 """
-from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
+from PyRoute.DeltaPasses.BeyondLineReducer import BeyondLineReducer
 
 
-class TwoLineReducer(object):
-
-    def __init__(self, reducer):
-        self.reducer = reducer
-
-    def preflight(self):
-        if self.reducer is not None and self.reducer.sectors is not None and 0 < len(self.reducer.sectors.lines):
-            return True
-        return False
+class TwoLineReducer(BeyondLineReducer):
 
     def run(self, singleton_only=False, first_segment=True):
         segment = self.reducer.sectors.lines
@@ -70,9 +62,3 @@ class TwoLineReducer(object):
         # At least one sector was shown to be irrelevant, write out the intermediate result
         if old_length > len(segment):
             self.write_files()
-
-    def write_files(self, sectors=None):
-        if isinstance(sectors, DeltaDictionary):
-            sectors.write_files(self.reducer.args.mindir)
-        else:
-            self.reducer.sectors.write_files(self.reducer.args.mindir)

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -6,6 +6,7 @@ Created on Jun 13, 2023
 from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 from PyRoute.DeltaStar import DeltaStar
 
+
 class WithinLineReducer(object):
 
     full_msg = None

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -4,7 +4,7 @@ Created on Jun 13, 2023
 @author: CyberiaResurrection
 """
 from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
-
+from PyRoute.DeltaStar import DeltaStar
 
 class WithinLineReducer(object):
 
@@ -111,12 +111,29 @@ class WithinLineReducer(object):
                 num_chunks = len(segment)
 
         self.reducer.sectors = best_sectors
+        _, subs_list = self._build_fill_list()
+        if 0 != len(subs_list):
+            self.reducer.sectors = self.reducer.sectors.switch_lines(subs_list)
+
         self.write_files()
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)
 
     def _build_subs_list(self):
         raise NotImplementedError
+
+    def _build_fill_list(self):
+        subs_list = []
+        segment = []
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line)
+            if line.startswith(canon):
+                continue
+
+            subs_list.append((line, canon))
+            segment.append(line)
+
+        return segment, subs_list
 
     def _assemble_segment(self, unreduced_lines, subs_list):
         nu_list = []

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -62,6 +62,10 @@ class DeltaStar(Star):
         return DeltaStar.reduce(original, drop_trade_codes=True, drop_base_codes=True, reset_port=True, reset_tl=True)
 
     @staticmethod
+    def reduce_nbz(original):
+        return DeltaStar.reduce(original, drop_noble_codes=True, drop_base_codes=True, drop_trade_zone=True)
+
+    @staticmethod
     def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False):
         star = DeltaStar()
         return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop)


### PR DESCRIPTION
Four tweaks to delta debugging found while working on pathfinding:

1.  Write unreduced lines back out during within-line reduction.  This was mainly to ensure that the resulting sector files look ok, but doing this for full-line reduction sped up later within-line passes as well.
2. Unconditionally skip void subsectors during reduction, rather than only if half or more of all subsectors are void.
3. Add a noble-base-zone within-line reduction, to unstick a reduction that had gotten stuck.
4. Extract common bits of {sector,subsector,single-line,two-line} reducers into a common base class to square them up like the within-line passes already are.