### PR TITLE
Tighten up sector reads in both Galaxy and SectorDictionary

### DIFF
--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -123,23 +123,7 @@ class Galaxy(AreaItem):
             for line in starlines:
                 star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
                 if star:
-                    assert star not in sec.worlds, "Star " + str(star) + " duplicated in sector " + str(sec)
-                    star.index = star_counter
-                    star_counter += 1
-                    self.star_mapping[star.index] = star
-
-                    sec.worlds.append(star)
-                    sec.subsectors[star.subsector()].worlds.append(star)
-                    star.alg_base_code = AllyGen.same_align(star.alg_code)
-
-                    self.set_area_alg(star, self, self.alg)
-                    self.set_area_alg(star, sec, self.alg)
-                    self.set_area_alg(star, sec.subsectors[star.subsector()], self.alg)
-
-                    star.tradeCode.sophont_list.append("{}A".format(self.alg[star.alg_code].population))
-                    star.is_redzone = self.trade.unilateral_filter(star)
-                    star.allegiance_base = self.alg[star.alg_base_code]
-                    star.is_well_formed()
+                    star_counter = self.add_star_to_galaxy(star, star_counter, sec)
 
             self.sectors[sec.name] = sec
             self.logger.info("Sector {} loaded {} worlds".format(sec, len(sec.worlds)))

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -113,26 +113,31 @@ class Galaxy(AreaItem):
 
             headers, starlines = ParseSectorInput.partition_lines(lines)
 
-            for line in headers:
-                if line.startswith('Hex'):
-                    break
-                if line.startswith('# Subsector'):
-                    data = line[11:].split(':', 1)
-                    pos = data[0].strip()
-                    name = data[1].strip()
-                    sec.subsectors[pos] = Subsector(name, pos, sec)
-                if line.startswith('# Alleg:'):
-                    alg_code = line[8:].split(':', 1)[0].strip()
-                    alg_name = line[8:].split(':', 1)[1].strip().strip('"')
+            # dig out allegiances
+            allegiances = [line for line in headers if line.startswith('# Alleg:')]
 
-                    # A work around for the base Na codes which may be empire dependent.
-                    alg_race = AllyGen.population_align(alg_code, alg_name)
+            for line in allegiances:
+                alg_code = line[8:].split(':', 1)[0].strip()
+                alg_name = line[8:].split(':', 1)[1].strip().strip('"')
 
-                    base = AllyGen.same_align(alg_code)
-                    if base not in self.alg:
-                        self.alg[base] = Allegiance(base, AllyGen.same_align_name(base, alg_name), base=True, population=alg_race)
-                    if alg_code not in self.alg:
-                        self.alg[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
+                # A work around for the base Na codes which may be empire dependent.
+                alg_race = AllyGen.population_align(alg_code, alg_name)
+
+                base = AllyGen.same_align(alg_code)
+                if base not in self.alg:
+                    self.alg[base] = Allegiance(base, AllyGen.same_align_name(base, alg_name), base=True,
+                                                population=alg_race)
+                if alg_code not in self.alg:
+                    self.alg[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
+
+            # dig out subsector names, and use them to seed the dict entries
+            sublines = [line for line in headers if line.startswith('# Subsector ')]
+
+            for line in sublines:
+                data = line[11:].split(':', 1)
+                pos = data[0].strip()
+                name = data[1].strip()
+                sec.subsectors[pos] = Subsector(name, pos, sec)
 
             for line in starlines:
                 star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -86,22 +86,20 @@ class Galaxy(AreaItem):
         ParseStarInput.deep_space = {} if (options.deep_space is None or not isinstance(options.deep_space, dict)) else options.deep_space
         logger = self.logger
         for sector in sectors:
-            lines = ParseSectorInput.read_sector_file(sector, logger)
+            headers, starlines = ParseSectorInput.read_sector_file(sector, logger)
 
-            if 0 == len(lines):
+            if 0 == len(headers):
                 continue
 
             self.logger.debug('reading %s ' % sector)
 
-            sec = Sector(lines[3], lines[4])
+            sec = Sector(headers[3], headers[4])
             sec.filename = os.path.basename(sector)
             if str(sec) not in loaded_sectors:
                 loaded_sectors.add(str(sec))
             else:
                 self.logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
                 continue
-
-            headers, starlines = ParseSectorInput.partition_lines(lines)
 
             # dig out allegiances
             ParseSectorInput.parse_allegiance(headers, self.alg)

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -106,20 +106,10 @@ class Galaxy(AreaItem):
 
             # dig out allegiances
             allegiances = [line for line in headers if line.startswith('# Alleg:')]
+            alg_object = self.alg
 
             for line in allegiances:
-                alg_code = line[8:].split(':', 1)[0].strip()
-                alg_name = line[8:].split(':', 1)[1].strip().strip('"')
-
-                # A work around for the base Na codes which may be empire dependent.
-                alg_race = AllyGen.population_align(alg_code, alg_name)
-
-                base = AllyGen.same_align(alg_code)
-                if base not in self.alg:
-                    self.alg[base] = Allegiance(base, AllyGen.same_align_name(base, alg_name), base=True,
-                                                population=alg_race)
-                if alg_code not in self.alg:
-                    self.alg[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
+                ParseSectorInput.parse_allegiance(line, alg_object)
 
             # dig out subsector names, and use them to seed the dict entries
             sublines = [line for line in headers if line.startswith('# Subsector ')]

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -10,6 +10,7 @@ import os
 import ast
 import itertools
 import math
+
 import networkx as nx
 import numpy as np
 
@@ -84,6 +85,7 @@ class Galaxy(AreaItem):
         from PyRoute.Inputs.ParseStarInput import ParseStarInput
         ParseStarInput.deep_space = {} if (options.deep_space is None or not isinstance(options.deep_space, dict)) else options.deep_space
         for sector in sectors:
+            lines = []
             try:
                 with codecs.open(sector, 'r', 'utf-8') as infile:
                     try:
@@ -94,6 +96,10 @@ class Galaxy(AreaItem):
             except FileNotFoundError:
                 self.logger.error("sector file %s not found" % sector)
                 continue
+
+            if 0 == len(lines):
+                continue
+
             self.logger.debug('reading %s ' % sector)
 
             sec = Sector(lines[3], lines[4])

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -87,17 +87,7 @@ class Galaxy(AreaItem):
         ParseStarInput.deep_space = {} if (options.deep_space is None or not isinstance(options.deep_space, dict)) else options.deep_space
         logger = self.logger
         for sector in sectors:
-            lines = []
-            try:
-                with codecs.open(sector, 'r', 'utf-8') as infile:
-                    try:
-                        lines = [line for line in infile]
-                    except (OSError, IOError):
-                        logger.error("sector file %s can not be read", sector, exc_info=True)
-                        continue
-            except FileNotFoundError:
-                logger.error("sector file %s not found" % sector)
-                continue
+            lines = ParseSectorInput.read_sector_file(sector, logger)
 
             if 0 == len(lines):
                 continue

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -85,6 +85,7 @@ class Galaxy(AreaItem):
         loaded_sectors = set()
         from PyRoute.Inputs.ParseStarInput import ParseStarInput
         ParseStarInput.deep_space = {} if (options.deep_space is None or not isinstance(options.deep_space, dict)) else options.deep_space
+        logger = self.logger
         for sector in sectors:
             lines = []
             try:
@@ -92,10 +93,10 @@ class Galaxy(AreaItem):
                     try:
                         lines = [line for line in infile]
                     except (OSError, IOError):
-                        self.logger.error("sector file %s can not be read", sector, exc_info=True)
+                        logger.error("sector file %s can not be read", sector, exc_info=True)
                         continue
             except FileNotFoundError:
-                self.logger.error("sector file %s not found" % sector)
+                logger.error("sector file %s not found" % sector)
                 continue
 
             if 0 == len(lines):

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -20,6 +20,7 @@ from PyRoute.AreaItems.AreaItem import AreaItem
 from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.AreaItems.Subsector import Subsector
 from PyRoute.AreaItems.Sector import Sector
+from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
 from PyRoute.Star import Star
 from PyRoute.Calculation.TradeCalculation import TradeCalculation
 from PyRoute.Calculation.TradeMPCalculation import TradeMPCalculation
@@ -109,6 +110,8 @@ class Galaxy(AreaItem):
             else:
                 self.logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
                 continue
+
+            headers, starlines = ParseSectorInput.partition_lines(lines)
 
             for lineno, line in enumerate(lines):
                 if line.startswith('Hex'):

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -91,14 +91,14 @@ class Galaxy(AreaItem):
             if 0 == len(headers):
                 continue
 
-            self.logger.debug('reading %s ' % sector)
+            logger.debug('reading %s ' % sector)
 
             sec = Sector(headers[3], headers[4])
             sec.filename = os.path.basename(sector)
             if str(sec) not in loaded_sectors:
                 loaded_sectors.add(str(sec))
             else:
-                self.logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
+                logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
                 continue
 
             # dig out allegiances

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -113,7 +113,7 @@ class Galaxy(AreaItem):
 
             headers, starlines = ParseSectorInput.partition_lines(lines)
 
-            for lineno, line in enumerate(lines):
+            for line in headers:
                 if line.startswith('Hex'):
                     break
                 if line.startswith('# Subsector'):
@@ -134,9 +134,7 @@ class Galaxy(AreaItem):
                     if alg_code not in self.alg:
                         self.alg[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
 
-            for line in lines[lineno + 2:]:
-                if line.startswith('#') or len(line) < 20:
-                    continue
+            for line in starlines:
                 star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
                 if star:
                     assert star not in sec.worlds, "Star " + str(star) + " duplicated in sector " + str(sec)

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -18,7 +18,6 @@ from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.Allies.Borders import Borders
 from PyRoute.AreaItems.AreaItem import AreaItem
 from PyRoute.AreaItems.Allegiance import Allegiance
-from PyRoute.AreaItems.Subsector import Subsector
 from PyRoute.AreaItems.Sector import Sector
 from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
 from PyRoute.Star import Star

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -105,11 +105,7 @@ class Galaxy(AreaItem):
             headers, starlines = ParseSectorInput.partition_lines(lines)
 
             # dig out allegiances
-            allegiances = [line for line in headers if line.startswith('# Alleg:')]
-            alg_object = self.alg
-
-            for line in allegiances:
-                ParseSectorInput._parse_allegiance_core(line, alg_object)
+            ParseSectorInput.parse_allegiance(headers, self.alg)
 
             # dig out subsector names, and use them to seed the dict entries
             sublines = [line for line in headers if line.startswith('# Subsector ')]

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -91,9 +91,9 @@ class Galaxy(AreaItem):
             if 0 == len(headers):
                 continue
 
-            sec, raw_counter = self.read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors, logger,
-                                                                        pop_code, ru_calc, sector, star_counter,
-                                                                        starlines, self)
+            sec, raw_counter = ParseSectorInput.read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors,
+                                                                                    logger, pop_code, ru_calc, sector,
+                                                                                    star_counter, starlines, self)
             if sec is None:
                 continue
             star_counter = raw_counter
@@ -104,32 +104,6 @@ class Galaxy(AreaItem):
         self.set_bounding_subsectors()
         self.set_positions()
         self.logger.debug("Allegiances: {}".format(self.alg))
-
-    @staticmethod
-    def read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors, logger, pop_code, ru_calc, sector,
-                                            star_counter, starlines, galaxy):
-        logger.debug('reading %s ' % sector)
-
-        sec = Sector(headers[3], headers[4])
-        sec.filename = os.path.basename(sector)
-        if str(sec) not in loaded_sectors:
-            loaded_sectors.add(str(sec))
-        else:
-            logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
-            return None, None
-
-        # dig out allegiances
-        ParseSectorInput.parse_allegiance(headers, galaxy.alg)
-
-        # dig out subsector names, and use them to seed the dict entries
-        ParseSectorInput.parse_subsectors(headers, sec.name, sec)
-
-        for line in starlines:
-            star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
-            if star:
-                star_counter = galaxy.add_star_to_galaxy(star, star_counter, sec)
-
-        return sec, star_counter
 
     def add_star_to_galaxy(self, star: Star, star_counter: int, sec: Sector):
         assert star not in sec.worlds, "Star " + str(star) + " duplicated in sector " + str(sec)

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -105,7 +105,7 @@ class Galaxy(AreaItem):
             ParseSectorInput.parse_allegiance(headers, self.alg)
 
             # dig out subsector names, and use them to seed the dict entries
-            ParseSectorInput.parse_subsectors(headers, sec)
+            ParseSectorInput.parse_subsectors(headers, sec.name, sec)
 
             for line in starlines:
                 star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -91,27 +91,12 @@ class Galaxy(AreaItem):
             if 0 == len(headers):
                 continue
 
-            logger.debug('reading %s ' % sector)
-
-            sec = Sector(headers[3], headers[4])
-            sec.filename = os.path.basename(sector)
-            if str(sec) not in loaded_sectors:
-                loaded_sectors.add(str(sec))
-            else:
-                logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
+            sec, raw_counter = self.read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors, logger,
+                                                                        pop_code, ru_calc, sector, star_counter,
+                                                                        starlines, self)
+            if sec is None:
                 continue
-
-            # dig out allegiances
-            ParseSectorInput.parse_allegiance(headers, self.alg)
-
-            # dig out subsector names, and use them to seed the dict entries
-            ParseSectorInput.parse_subsectors(headers, sec.name, sec)
-
-            for line in starlines:
-                star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
-                if star:
-                    star_counter = self.add_star_to_galaxy(star, star_counter, sec)
-
+            star_counter = raw_counter
             self.sectors[sec.name] = sec
             self.logger.info("Sector {} loaded {} worlds".format(sec, len(sec.worlds)))
 
@@ -119,6 +104,32 @@ class Galaxy(AreaItem):
         self.set_bounding_subsectors()
         self.set_positions()
         self.logger.debug("Allegiances: {}".format(self.alg))
+
+    @staticmethod
+    def read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors, logger, pop_code, ru_calc, sector,
+                                            star_counter, starlines, galaxy):
+        logger.debug('reading %s ' % sector)
+
+        sec = Sector(headers[3], headers[4])
+        sec.filename = os.path.basename(sector)
+        if str(sec) not in loaded_sectors:
+            loaded_sectors.add(str(sec))
+        else:
+            logger.error("sector file %s loads duplicate sector %s" % (sector, str(sec)))
+            return None, None
+
+        # dig out allegiances
+        ParseSectorInput.parse_allegiance(headers, galaxy.alg)
+
+        # dig out subsector names, and use them to seed the dict entries
+        ParseSectorInput.parse_subsectors(headers, sec.name, sec)
+
+        for line in starlines:
+            star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
+            if star:
+                star_counter = galaxy.add_star_to_galaxy(star, star_counter, sec)
+
+        return sec, star_counter
 
     def add_star_to_galaxy(self, star: Star, star_counter: int, sec: Sector):
         assert star not in sec.worlds, "Star " + str(star) + " duplicated in sector " + str(sec)

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -109,7 +109,7 @@ class Galaxy(AreaItem):
             alg_object = self.alg
 
             for line in allegiances:
-                ParseSectorInput.parse_allegiance(line, alg_object)
+                ParseSectorInput._parse_allegiance_core(line, alg_object)
 
             # dig out subsector names, and use them to seed the dict entries
             sublines = [line for line in headers if line.startswith('# Subsector ')]

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -108,13 +108,7 @@ class Galaxy(AreaItem):
             ParseSectorInput.parse_allegiance(headers, self.alg)
 
             # dig out subsector names, and use them to seed the dict entries
-            sublines = [line for line in headers if line.startswith('# Subsector ')]
-
-            for line in sublines:
-                data = line[11:].split(':', 1)
-                pos = data[0].strip()
-                name = data[1].strip()
-                sec.subsectors[pos] = Subsector(name, pos, sec)
+            ParseSectorInput.parse_subsectors(headers, sec)
 
             for line in starlines:
                 star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -10,7 +10,6 @@ import os
 
 from PyRoute.DeltaDebug.DeltaLogicError import DeltaLogicError
 from PyRoute.AreaItems.Sector import Sector
-from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
 from PyRoute.Star import Star
 
 
@@ -333,6 +332,7 @@ class SectorDictionary(dict):
 
     @staticmethod
     def load_traveller_map_file(filename):
+        from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
         basename = os.path.basename(filename)
         logger = logging.getLogger('PyRoute.DeltaDictionary')
         lines = ParseSectorInput.read_sector_file(filename, logger)
@@ -353,18 +353,7 @@ class SectorDictionary(dict):
         ParseSectorInput.parse_allegiance(headers, sector.allegiances)
 
         # dig out subsector names, and use them to seed the dict entries
-        sublines = [line for line in headers if '# Subsector ' in line]
-        subsector_names = dict()
-
-        for line in sublines:
-            bitz = line.split(':')
-            alpha = bitz[0][-1]
-            subname = bitz[1].strip()
-            if '' == subname:
-                subname = name.strip() + ' ' + bitz[0][2:]
-            subsector_names[alpha] = subname
-            subsec = SubsectorDictionary(subname, alpha)
-            sector[subname] = subsec
+        subsector_names = ParseSectorInput.parse_subsectors_delta(headers, name, sector)
 
         # now subsectors are seeded, run thru the elements of starlines and deal them out to their respective subsector
         # dicts

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -370,24 +370,6 @@ class SectorDictionary(dict):
 
         return sector
 
-    @staticmethod
-    def _partition_file(lines):
-        """
-            Break lines out into headers section, which is retained, and starlines, which gets minimised later on
-            - this assumes downloaded-from-TravellerMap sector file
-        """
-        headers = []
-        starlines = []
-        isheader = True
-        for line in lines:
-            if isheader:
-                headers.append(line)
-                if line.startswith('----'):
-                    isheader = False
-            else:
-                starlines.append(line.rstrip('\n'))
-        return headers, starlines
-
 
 class SubsectorDictionary(dict):
 

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -335,17 +335,16 @@ class SectorDictionary(dict):
         from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
         basename = os.path.basename(filename)
         logger = logging.getLogger('PyRoute.DeltaDictionary')
-        lines = ParseSectorInput.read_sector_file(filename, logger)
+        headers, starlines = ParseSectorInput.read_sector_file(filename, logger)
 
-        if 0 == len(lines):
+        if 0 == len(headers):
             return None
 
-        nameline = lines[3]  # assuming the definitive name line is the 4th line in what got read in
+        nameline = headers[3]  # assuming the definitive name line is the 4th line in what got read in
         name = nameline.strip('#')
-        position = lines[4]
+        position = headers[4]
 
         sector = SectorDictionary(name.strip(), basename)
-        headers, starlines = ParseSectorInput.partition_lines(lines)
         sector.headers = headers
         sector.position = position.strip()
 

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -352,7 +352,7 @@ class SectorDictionary(dict):
         ParseSectorInput.parse_allegiance(headers, sector.allegiances)
 
         # dig out subsector names, and use them to seed the dict entries
-        subsector_names = ParseSectorInput.parse_subsectors_delta(headers, name, sector)
+        subsector_names = ParseSectorInput.parse_subsectors(headers, name, sector)
 
         # now subsectors are seeded, run thru the elements of starlines and deal them out to their respective subsector
         # dicts

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -337,17 +337,9 @@ class SectorDictionary(dict):
     def load_traveller_map_file(filename):
         basename = os.path.basename(filename)
         logger = logging.getLogger('PyRoute.DeltaDictionary')
-        lines = None
+        lines = ParseSectorInput.read_sector_file(filename, logger)
 
-        # read travellermap file in, line by line
-        try:
-            with codecs.open(filename, 'r', 'utf-8') as infile:
-                try:
-                    lines = [line for line in infile]
-                except (OSError, IOError):
-                    logger.error("sector file %s can not be read", filename, exc_info=True)
-                    return None
-        except FileNotFoundError:
+        if 0 == len(lines):
             return None
 
         nameline = lines[3]  # assuming the definitive name line is the 4th line in what got read in

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -9,8 +9,6 @@ import logging
 import os
 
 from PyRoute.DeltaDebug.DeltaLogicError import DeltaLogicError
-from PyRoute.Allies.AllyGen import AllyGen
-from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.AreaItems.Sector import Sector
 from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
 from PyRoute.Star import Star

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -353,7 +353,7 @@ class SectorDictionary(dict):
         allegiances = [line for line in headers if '# Alleg:' in line]
         alg_object = sector.allegiances
         for line in allegiances:
-            ParseSectorInput.parse_allegiance(line, alg_object)
+            ParseSectorInput._parse_allegiance_core(line, alg_object)
 
         # dig out subsector names, and use them to seed the dict entries
         sublines = [line for line in headers if '# Subsector ' in line]

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -350,10 +350,7 @@ class SectorDictionary(dict):
         sector.position = position.strip()
 
         # dig out allegiances
-        allegiances = [line for line in headers if '# Alleg:' in line]
-        alg_object = sector.allegiances
-        for line in allegiances:
-            ParseSectorInput._parse_allegiance_core(line, alg_object)
+        ParseSectorInput.parse_allegiance(headers, sector.allegiances)
 
         # dig out subsector names, and use them to seed the dict entries
         sublines = [line for line in headers if '# Subsector ' in line]

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -353,16 +353,9 @@ class SectorDictionary(dict):
 
         # dig out allegiances
         allegiances = [line for line in headers if '# Alleg:' in line]
+        alg_object = sector.allegiances
         for line in allegiances:
-            alg_code = line[8:].split(':', 1)[0].strip()
-            alg_name = line[8:].split(':', 1)[1].strip().strip('"')
-            alg_race = AllyGen.population_align(alg_code, alg_name)
-            base = AllyGen.same_align(alg_code)
-            if base not in sector.allegiances:
-                sector.allegiances[base] = Allegiance(base, AllyGen.same_align_name(base, alg_name), base=True,
-                                                      population=alg_race)
-            if alg_code not in sector.allegiances:
-                sector.allegiances[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
+            ParseSectorInput.parse_allegiance(line, alg_object)
 
         # dig out subsector names, and use them to seed the dict entries
         sublines = [line for line in headers if '# Subsector ' in line]

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -336,6 +336,7 @@ class SectorDictionary(dict):
     @staticmethod
     def load_traveller_map_file(filename):
         basename = os.path.basename(filename)
+        logger = logging.getLogger('PyRoute.DeltaDictionary')
         lines = None
 
         # read travellermap file in, line by line
@@ -344,7 +345,6 @@ class SectorDictionary(dict):
                 try:
                     lines = [line for line in infile]
                 except (OSError, IOError):
-                    logger = logging.getLogger('PyRoute.DeltaDictionary')
                     logger.error("sector file %s can not be read", filename, exc_info=True)
                     return None
         except FileNotFoundError:

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -12,6 +12,7 @@ from PyRoute.DeltaDebug.DeltaLogicError import DeltaLogicError
 from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.AreaItems.Sector import Sector
+from PyRoute.Inputs.ParseSectorInput import ParseSectorInput
 from PyRoute.Star import Star
 
 
@@ -354,7 +355,7 @@ class SectorDictionary(dict):
         position = lines[4]
 
         sector = SectorDictionary(name.strip(), basename)
-        headers, starlines = SectorDictionary._partition_file(lines)
+        headers, starlines = ParseSectorInput.partition_lines(lines)
         sector.headers = headers
         sector.position = position.strip()
 

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -9,8 +9,6 @@ import logging
 import os
 
 from PyRoute.DeltaDebug.DeltaLogicError import DeltaLogicError
-from PyRoute.AreaItems.Sector import Sector
-from PyRoute.Star import Star
 
 
 class DeltaDictionary(dict):
@@ -340,33 +338,7 @@ class SectorDictionary(dict):
         if 0 == len(headers):
             return None
 
-        nameline = headers[3]  # assuming the definitive name line is the 4th line in what got read in
-        name = nameline.strip('#')
-        position = headers[4]
-
-        sector = SectorDictionary(name.strip(), basename)
-        sector.headers = headers
-        sector.position = position.strip()
-
-        # dig out allegiances
-        ParseSectorInput.parse_allegiance(headers, sector.allegiances)
-
-        # dig out subsector names, and use them to seed the dict entries
-        subsector_names = ParseSectorInput.parse_subsectors(headers, name, sector)
-
-        # now subsectors are seeded, run thru the elements of starlines and deal them out to their respective subsector
-        # dicts
-        dummy = Sector('# dummy', '# 0,0')
-        logging.disable(logging.WARNING)
-
-        for line in starlines:
-            # Re-use the existing, battle-tested, validation logic rather than scraping something new and buggy together
-            star = Star.parse_line_into_star(line, dummy, 'scaled', 'scaled')
-            if not star:
-                continue
-            subsec = star.subsector()
-            subname = subsector_names[subsec]
-            sector[subname].items.append(line)
+        sector = ParseSectorInput.read_parsed_sector_to_sector_dict(basename, headers, starlines)
 
         return sector
 

--- a/PyRoute/DeltaDebug/DeltaGalaxy.py
+++ b/PyRoute/DeltaDebug/DeltaGalaxy.py
@@ -47,23 +47,7 @@ class DeltaGalaxy(Galaxy):
                     continue
                 star = Star.parse_line_into_star(line, sec, pop_code, ru_calc)
                 if star:
-                    assert star not in sec.worlds, "Star " + str(star) + " duplicated in sector " + str(sec)
-                    star.index = star_counter
-                    star_counter += 1
-                    self.star_mapping[star.index] = star
-
-                    sec.worlds.append(star)
-                    sec.subsectors[star.subsector()].worlds.append(star)
-                    star.alg_base_code = AllyGen.same_align(star.alg_code)
-
-                    self.set_area_alg(star, self, self.alg)
-                    self.set_area_alg(star, sec, self.alg)
-                    self.set_area_alg(star, sec.subsectors[star.subsector()], self.alg)
-
-                    star.tradeCode.sophont_list.append("{}A".format(self.alg[star.alg_code].population))
-                    star.is_redzone = self.trade.unilateral_filter(star)
-                    star.allegiance_base = self.alg[star.alg_base_code]
-                    star.is_well_formed()
+                    star_counter = self.add_star_to_galaxy(star, star_counter, sec)
 
             self.sectors[sec.name] = sec
             self.logger.info("Sector {} loaded {} worlds".format(sec, len(sec.worlds)))

--- a/PyRoute/DeltaDebug/DeltaGalaxy.py
+++ b/PyRoute/DeltaDebug/DeltaGalaxy.py
@@ -5,7 +5,6 @@ Created on May 21, 2023
 """
 import copy
 
-from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.AreaItems.Galaxy import Galaxy
 from PyRoute.AreaItems.Subsector import Subsector

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -17,17 +17,14 @@ class ParseSectorInput:
 
         headers = []
         starlines = []
-        isheader = True
         for line in lines:
             if not isinstance(line, str):
                 continue
 
-            if isheader:
-                headers.append(line)
-                if line.startswith('----'):
-                    isheader = False
-            else:
-                if line.startswith('#') or len(line) < 20:
-                    continue
+            if line[0].isdigit():
                 starlines.append(line)
+            else:
+                headers.append(line)
+            continue
+
         return headers, starlines

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -8,6 +8,7 @@ from logging import Logger
 
 from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.AreaItems.Allegiance import Allegiance
+from PyRoute.AreaItems.Subsector import Subsector
 
 
 class ParseSectorInput:
@@ -71,3 +72,12 @@ class ParseSectorInput:
                                           population=alg_race)
         if alg_code not in alg_object:
             alg_object[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
+
+    @staticmethod
+    def parse_subsectors(headers, sec):
+        sublines = [line for line in headers if line.startswith('# Subsector ')]
+        for line in sublines:
+            data = line[11:].split(':', 1)
+            pos = data[0].strip()
+            name = data[1].strip()
+            sec.subsectors[pos] = Subsector(name, pos, sec)

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -8,8 +8,9 @@ from logging import Logger
 
 from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.AreaItems.Allegiance import Allegiance
+from PyRoute.AreaItems.Sector import Sector
 from PyRoute.AreaItems.Subsector import Subsector
-from PyRoute.DeltaDebug.DeltaDictionary import SubsectorDictionary
+from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, SubsectorDictionary
 
 
 class ParseSectorInput:
@@ -75,7 +76,7 @@ class ParseSectorInput:
             alg_object[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
 
     @staticmethod
-    def parse_subsectors(headers, sec):
+    def parse_subsectors(headers: list[str], sec: Sector) -> None:
         sublines = [line for line in headers if line.startswith('# Subsector ')]
         for line in sublines:
             data = line[11:].split(':', 1)
@@ -84,7 +85,7 @@ class ParseSectorInput:
             sec.subsectors[pos] = Subsector(name, pos, sec)
 
     @staticmethod
-    def parse_subsectors_delta(headers, name, sector) -> dict[str, SubsectorDictionary]:
+    def parse_subsectors_delta(headers: list[str], name: str, sector: SectorDictionary) -> dict[str, str]:
         sublines = [line for line in headers if '# Subsector ' in line]
         subsector_names = dict()
         for line in sublines:

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -78,26 +78,22 @@ class ParseSectorInput:
             alg_object[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
 
     @staticmethod
-    def parse_subsectors(headers: list[str], name: str, sec: Sector) -> None:
+    def parse_subsectors(headers: list[str], name: str, sector: [Sector, SectorDictionary]) -> dict[str, str]:
+        if not (isinstance(sector, Sector) or isinstance(sector, SectorDictionary)):
+            raise ValueError("Supplied sector must be instance of Sector or SectorDictionary")
+        is_dict = isinstance(sector, SectorDictionary)
+
         sublines = [line for line in headers if line.startswith('# Subsector ')]
+        subsector_names = dict()
         for line in sublines:
             data = line[11:].split(':', 1)
             pos = data[0].strip()
             subname = data[1].strip()
             if '' == subname:
                 subname = name.strip() + ' ' + pos
-            sec.subsectors[pos] = Subsector(subname, pos, sec)
-
-    @staticmethod
-    def parse_subsectors_delta(headers: list[str], name: str, sector: SectorDictionary) -> dict[str, str]:
-        sublines = [line for line in headers if line.startswith('# Subsector ')]
-        subsector_names = dict()
-        for line in sublines:
-            bitz = line.split(':')
-            pos = bitz[0][-1]
-            subname = bitz[1].strip()
-            if '' == subname:
-                subname = name.strip() + ' ' + bitz[0][2:]
             subsector_names[pos] = subname
-            sector[subname] = SubsectorDictionary(subname, pos)
+            if is_dict:
+                sector[subname] = SubsectorDictionary(subname, pos)
+            else:
+                sector.subsectors[pos] = Subsector(subname, pos, sector)
         return subsector_names

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -1,0 +1,33 @@
+"""
+Created on 12 Jan, 2025
+
+@author: CyberiaResurrection
+"""
+
+
+class ParseSectorInput:
+
+    @staticmethod
+    def partition_lines(lines: list[str]):
+        """
+            Break lines out into headers section, which is retained, and starlines, which gets either retained, or
+            minimised later on - this assumes downloaded-from-TravellerMap sector file
+        """
+        assert isinstance(lines, list)
+
+        headers = []
+        starlines = []
+        isheader = True
+        for line in lines:
+            if not isinstance(line, str):
+                continue
+
+            if isheader:
+                headers.append(line)
+                if line.startswith('----'):
+                    isheader = False
+            else:
+                if line.startswith('#') or len(line) < 20:
+                    continue
+                starlines.append(line)
+        return headers, starlines

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -3,6 +3,8 @@ Created on 12 Jan, 2025
 
 @author: CyberiaResurrection
 """
+import codecs
+from logging import Logger
 
 
 class ParseSectorInput:
@@ -28,3 +30,19 @@ class ParseSectorInput:
             continue
 
         return headers, starlines
+
+    @staticmethod
+    def read_sector_file(filename: str, logger: Logger) -> list[str]:
+        lines = []
+
+        # read travellermap file in, line by line
+        try:
+            with codecs.open(filename, 'r', 'utf-8') as infile:
+                try:
+                    lines = [line for line in infile]
+                except (OSError, IOError):
+                    logger.error("sector file %s can not be read", filename, exc_info=True)
+        except FileNotFoundError:
+            logger.error("sector file %s not found" % filename)
+
+        return lines

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -38,7 +38,8 @@ class ParseSectorInput:
         return headers, starlines
 
     @staticmethod
-    def read_sector_file(filename: str, logger: Logger) -> list[str]:
+    def read_sector_file(filename: str, logger: Logger) -> (list[str], list[str]):
+        headers = []
         lines = []
 
         # read travellermap file in, line by line
@@ -46,12 +47,13 @@ class ParseSectorInput:
             with codecs.open(filename, 'r', 'utf-8') as infile:
                 try:
                     lines = [line for line in infile]
+                    headers, lines = ParseSectorInput.partition_lines(lines)
                 except (OSError, IOError):
                     logger.error("sector file %s can not be read", filename, exc_info=True)
         except FileNotFoundError:
             logger.error("sector file %s not found" % filename)
 
-        return lines
+        return headers, lines
 
     @staticmethod
     def parse_allegiance(headers: list[str], alg_object) -> None:

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -51,7 +51,7 @@ class ParseSectorInput:
         return lines
 
     @staticmethod
-    def parse_allegiance(line: str, alg_object: dict[str, Allegiance]) -> None:
+    def _parse_allegiance_core(line: str, alg_object: dict[str, Allegiance]) -> None:
         alg_code = line[8:].split(':', 1)[0].strip()
         alg_name = line[8:].split(':', 1)[1].strip().strip('"')
 

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -51,6 +51,13 @@ class ParseSectorInput:
         return lines
 
     @staticmethod
+    def parse_allegiance(headers: list[str], alg_object) -> None:
+        allegiances = [line for line in headers if line.startswith('# Alleg:')]
+
+        for line in allegiances:
+            ParseSectorInput._parse_allegiance_core(line, alg_object)
+
+    @staticmethod
     def _parse_allegiance_core(line: str, alg_object: dict[str, Allegiance]) -> None:
         alg_code = line[8:].split(':', 1)[0].strip()
         alg_name = line[8:].split(':', 1)[1].strip().strip('"')

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -78,25 +78,26 @@ class ParseSectorInput:
             alg_object[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)
 
     @staticmethod
-    def parse_subsectors(headers: list[str], sec: Sector) -> None:
+    def parse_subsectors(headers: list[str], name: str, sec: Sector) -> None:
         sublines = [line for line in headers if line.startswith('# Subsector ')]
         for line in sublines:
             data = line[11:].split(':', 1)
             pos = data[0].strip()
-            name = data[1].strip()
-            sec.subsectors[pos] = Subsector(name, pos, sec)
+            subname = data[1].strip()
+            if '' == subname:
+                subname = name.strip() + ' ' + pos
+            sec.subsectors[pos] = Subsector(subname, pos, sec)
 
     @staticmethod
     def parse_subsectors_delta(headers: list[str], name: str, sector: SectorDictionary) -> dict[str, str]:
-        sublines = [line for line in headers if '# Subsector ' in line]
+        sublines = [line for line in headers if line.startswith('# Subsector ')]
         subsector_names = dict()
         for line in sublines:
             bitz = line.split(':')
-            alpha = bitz[0][-1]
+            pos = bitz[0][-1]
             subname = bitz[1].strip()
             if '' == subname:
                 subname = name.strip() + ' ' + bitz[0][2:]
-            subsector_names[alpha] = subname
-            subsec = SubsectorDictionary(subname, alpha)
-            sector[subname] = subsec
+            subsector_names[pos] = subname
+            sector[subname] = SubsectorDictionary(subname, pos)
         return subsector_names

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -6,6 +6,9 @@ Created on 12 Jan, 2025
 import codecs
 from logging import Logger
 
+from PyRoute.Allies.AllyGen import AllyGen
+from PyRoute.AreaItems.Allegiance import Allegiance
+
 
 class ParseSectorInput:
 
@@ -46,3 +49,18 @@ class ParseSectorInput:
             logger.error("sector file %s not found" % filename)
 
         return lines
+
+    @staticmethod
+    def parse_allegiance(line: str, alg_object: dict[str, Allegiance]) -> None:
+        alg_code = line[8:].split(':', 1)[0].strip()
+        alg_name = line[8:].split(':', 1)[1].strip().strip('"')
+
+        # A work around for the base Na codes which may be empire dependent.
+        alg_race = AllyGen.population_align(alg_code, alg_name)
+
+        base = AllyGen.same_align(alg_code)
+        if base not in alg_object:
+            alg_object[base] = Allegiance(base, AllyGen.same_align_name(base, alg_name), base=True,
+                                          population=alg_race)
+        if alg_code not in alg_object:
+            alg_object[alg_code] = Allegiance(alg_code, alg_name, base=False, population=alg_race)

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -9,6 +9,7 @@ from logging import Logger
 from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.AreaItems.Subsector import Subsector
+from PyRoute.DeltaDebug.DeltaDictionary import SubsectorDictionary
 
 
 class ParseSectorInput:
@@ -81,3 +82,18 @@ class ParseSectorInput:
             pos = data[0].strip()
             name = data[1].strip()
             sec.subsectors[pos] = Subsector(name, pos, sec)
+
+    @staticmethod
+    def parse_subsectors_delta(headers, name, sector) -> dict[str, SubsectorDictionary]:
+        sublines = [line for line in headers if '# Subsector ' in line]
+        subsector_names = dict()
+        for line in sublines:
+            bitz = line.split(':')
+            alpha = bitz[0][-1]
+            subname = bitz[1].strip()
+            if '' == subname:
+                subname = name.strip() + ' ' + bitz[0][2:]
+            subsector_names[alpha] = subname
+            subsec = SubsectorDictionary(subname, alpha)
+            sector[subname] = subsec
+        return subsector_names

--- a/Tests/AreaItems/testAllegiance.py
+++ b/Tests/AreaItems/testAllegiance.py
@@ -8,7 +8,8 @@ import copy
 from PyRoute.AreaItems.Allegiance import Allegiance
 from PyRoute.AreaItems.Galaxy import Galaxy
 from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
-from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary
+from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary, DeltaDictionary
+from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from Tests.baseTest import baseTest
 
 
@@ -47,12 +48,22 @@ class testAllegiance(baseTest):
         galaxy = Galaxy(min_btn=11, max_jump=4)
         galaxy.read_sectors(readparms)
 
-        expected_allegiances = ['As', 'AsMw', 'AsSc', 'AsT0', 'AsT1', 'AsT2', 'AsT3', 'AsT4', 'AsT5', 'AsT6', 'AsT7',
-                                'AsT8', 'AsT9', 'AsTv', 'AsVc', 'AsWc', 'AsXX', 'BlSo', 'CsIm', 'CsZh', 'FlLe', 'GlEm',
-                                'Im', 'ImDd', 'NaDr', 'NaHu', 'NaXX', 'SeFo', 'StCl']
+        expected_allegiances = {'As': 7, 'AsMw': 1, 'AsSc': 0, 'AsT0': 1, 'AsT1': 0, 'AsT2': 0, 'AsT3': 0, 'AsT4': 0,
+                                'AsT5': 0, 'AsT6': 0, 'AsT7': 0, 'AsT8': 0, 'AsT9': 1, 'AsTv': 2, 'AsVc': 1, 'AsWc': 1,
+                                'AsXX': 0, 'BlSo': 0, 'CsIm': 1, 'CsZh': 0, 'FlLe': 0, 'GlEm': 0, 'Im': 3, 'ImDd': 3,
+                                'NaDr': 0, 'NaHu': 5, 'NaXX': 0, 'SeFo': 0, 'StCl': 0}
         actual_allegiances = list(galaxy.alg.keys())
 
-        self.assertEqual(expected_allegiances, actual_allegiances, "Allegiance name list unexpected")
+        self.assertEqual(list(expected_allegiances.keys()), actual_allegiances, "Allegiance name list unexpected")
+        for alg_name in expected_allegiances:
+            expected_count = expected_allegiances[alg_name]
+            actual_count = len(galaxy.alg[alg_name].worlds)
+            self.assertEqual(expected_count, actual_count, "Unexpected world count for " + alg_name + " allegiance")
+            if 0 != expected_count:
+                actual_count = len(galaxy.sectors['Trojan Reach'].alg[alg_name].worlds)
+                self.assertEqual(expected_count, actual_count, "Unexpected world count for " + alg_name + " allegiance")
+            else:
+                self.assertNotIn(alg_name, galaxy.sectors['Trojan Reach'].alg, "Unexpected allegiance " + alg_name)
 
     def test_allegiance_list_on_sector_dictionary_read(self):
         sourcefile = self.unpack_filename('DeltaFiles/duplicate_node_blowup/Trojan Reach.sec')
@@ -65,3 +76,33 @@ class testAllegiance(baseTest):
         actual_allegiances = list(sector.allegiances.keys())
 
         self.assertEqual(expected_allegiances, actual_allegiances, "Allegiance name list unexpected")
+
+    def test_allegiance_list_on_delta_galaxy_read(self):
+        sourcefile = self.unpack_filename('DeltaFiles/duplicate_node_blowup/Trojan Reach.sec')
+
+        args = self._make_args()
+        args.route_btn = 15
+
+        sector = SectorDictionary.load_traveller_map_file(sourcefile)
+        delta = DeltaDictionary()
+        delta['Trojan Reach'] = sector
+
+        galaxy = DeltaGalaxy(min_btn=11, max_jump=4)
+        galaxy.read_sectors(delta, args.pop_code, args.ru_calc, args.route_reuse, args.routes, args.route_btn,
+                            1, False)
+
+        expected_allegiances = {'As': 7, 'AsMw': 1, 'AsSc': 0, 'AsT0': 1, 'AsT1': 0, 'AsT2': 0, 'AsT3': 0, 'AsT4': 0,
+                                'AsT5': 0, 'AsT6': 0, 'AsT7': 0, 'AsT8': 0, 'AsT9': 1, 'AsTv': 2, 'AsVc': 1, 'AsWc': 1,
+                                'AsXX': 0, 'BlSo': 0, 'CsIm': 1, 'CsZh': 0, 'FlLe': 0, 'GlEm': 0, 'Im': 3, 'ImDd': 3,
+                                'NaDr': 0, 'NaHu': 5, 'NaXX': 0, 'SeFo': 0, 'StCl': 0}
+        actual_allegiances = list(galaxy.alg.keys())
+        self.assertEqual(list(expected_allegiances.keys()), actual_allegiances, "Allegiance name list unexpected")
+        for alg_name in expected_allegiances:
+            expected_count = expected_allegiances[alg_name]
+            actual_count = len(galaxy.alg[alg_name].worlds)
+            self.assertEqual(expected_count, actual_count, "Unexpected world count for " + alg_name + " allegiance")
+            if 0 != expected_count:
+                actual_count = len(galaxy.sectors['Trojan Reach'].alg[alg_name].worlds)
+                self.assertEqual(expected_count, actual_count, "Unexpected world count for " + alg_name + " allegiance")
+            else:
+                self.assertNotIn(alg_name, galaxy.sectors['Trojan Reach'].alg, "Unexpected allegiance " + alg_name)

--- a/Tests/AreaItems/testAllegiance.py
+++ b/Tests/AreaItems/testAllegiance.py
@@ -1,10 +1,18 @@
+"""
+Created on Apr 17, 2025
+
+@author: CyberiaResurrection
+"""
 import copy
-import unittest
 
 from PyRoute.AreaItems.Allegiance import Allegiance
+from PyRoute.AreaItems.Galaxy import Galaxy
+from PyRoute.DataClasses.ReadSectorOptions import ReadSectorOptions
+from PyRoute.DeltaDebug.DeltaDictionary import SectorDictionary
+from Tests.baseTest import baseTest
 
 
-class testAllegiance(unittest.TestCase):
+class testAllegiance(baseTest):
 
     def testAslanAllegianceNotBeginningWithAs(self):
         code = "A8"
@@ -25,3 +33,35 @@ class testAllegiance(unittest.TestCase):
 
         foo = copy.deepcopy(alleg)
         self.assertTrue(isinstance(foo, Allegiance))
+
+    def test_allegiance_list_on_galaxy_read(self):
+        sourcefile = self.unpack_filename('DeltaFiles/duplicate_node_blowup/Trojan Reach.sec')
+
+        args = self._make_args()
+        args.route_btn = 15
+        readparms = ReadSectorOptions(sectors=[sourcefile], pop_code=args.pop_code, ru_calc=args.ru_calc,
+                                      route_reuse=args.route_reuse, trade_choice=args.routes, route_btn=args.route_btn,
+                                      mp_threads=args.mp_threads, debug_flag=args.debug_flag, fix_pop=False,
+                                      deep_space={}, map_type=args.map_type)
+
+        galaxy = Galaxy(min_btn=11, max_jump=4)
+        galaxy.read_sectors(readparms)
+
+        expected_allegiances = ['As', 'AsMw', 'AsSc', 'AsT0', 'AsT1', 'AsT2', 'AsT3', 'AsT4', 'AsT5', 'AsT6', 'AsT7',
+                                'AsT8', 'AsT9', 'AsTv', 'AsVc', 'AsWc', 'AsXX', 'BlSo', 'CsIm', 'CsZh', 'FlLe', 'GlEm',
+                                'Im', 'ImDd', 'NaDr', 'NaHu', 'NaXX', 'SeFo', 'StCl']
+        actual_allegiances = list(galaxy.alg.keys())
+
+        self.assertEqual(expected_allegiances, actual_allegiances, "Allegiance name list unexpected")
+
+    def test_allegiance_list_on_sector_dictionary_read(self):
+        sourcefile = self.unpack_filename('DeltaFiles/duplicate_node_blowup/Trojan Reach.sec')
+
+        sector = SectorDictionary.load_traveller_map_file(sourcefile)
+
+        expected_allegiances = ['As', 'AsMw', 'AsSc', 'AsT0', 'AsT1', 'AsT2', 'AsT3', 'AsT4', 'AsT5', 'AsT6', 'AsT7',
+                                'AsT8', 'AsT9', 'AsTv', 'AsVc', 'AsWc', 'AsXX', 'BlSo', 'CsIm', 'CsZh', 'FlLe', 'GlEm',
+                                'Im', 'ImDd', 'NaDr', 'NaHu', 'NaXX', 'SeFo', 'StCl']
+        actual_allegiances = list(sector.allegiances.keys())
+
+        self.assertEqual(expected_allegiances, actual_allegiances, "Allegiance name list unexpected")

--- a/Tests/Pathfinding/testTradeCalculation.py
+++ b/Tests/Pathfinding/testTradeCalculation.py
@@ -23,6 +23,12 @@ class testTradeCalculation(baseTest):
         galaxy.read_sectors(readparms)
         galaxy.output_path = args.output
 
+        self.assertEqual(1, len(galaxy.sectors))
+        sector = galaxy.sectors['Trojan Reach']
+        self.assertEqual(16, len(sector.subsectors))
+        self.assertEqual(11, len(sector.alg))
+        self.assertEqual(16, len(sector.worlds))
+
         galaxy.generate_routes()
         galaxy.trade.calculate_components()
 
@@ -41,6 +47,12 @@ class testTradeCalculation(baseTest):
         galaxy = Galaxy(min_btn=15, max_jump=4)
         galaxy.read_sectors(readparms)
         galaxy.output_path = args.output
+
+        self.assertEqual(1, len(galaxy.sectors))
+        sector = galaxy.sectors['Verge']
+        self.assertEqual(16, len(sector.subsectors))
+        self.assertEqual(2, len(sector.alg))
+        self.assertEqual(13, len(sector.worlds))
 
         galaxy.generate_routes()
         galaxy.trade.calculate_components()

--- a/Tests/testDeltaReduce.py
+++ b/Tests/testDeltaReduce.py
@@ -36,7 +36,7 @@ class testDeltaReduce(baseTest):
             expected = 0
             affix = " not empty after subsector reduction"
             if subsector_name == 'Pact':
-                expected = 39
+                expected = 37
                 affix = " empty after subsector reduction"
             actual = 0 if reducer.sectors['Dagudashaag'][subsector_name].items is None else len(reducer.sectors['Dagudashaag'][subsector_name].items)
             self.assertEqual(expected, actual, subsector_name + affix)


### PR DESCRIPTION
Unify, as far as possible, sector-file read in both Galaxy and SectorDictionary.
Specifically, hoist out sector-file partitioning (into headers and lines) into a common ParseSectorInput method.
Similarly, hoist out allegiance and subsector parsing into dedicated ParseSectorInput methods.