### PR TITLE
Check allegiance world counts in is_well_formed()

### DIFF
--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -392,6 +392,9 @@ class Galaxy(AreaItem):
             result, msg = allegiance.is_well_formed()
             assert result, msg
 
+        result, msg = self._check_allegiance_counts_well_formed()
+        assert result, msg
+
         for item in self.stars.nodes:
             assert isinstance(item, int), "Star nodes must be integers"
             assert 'star' in self.stars.nodes[item], "Star attribute not set for item " + str(item)
@@ -438,3 +441,24 @@ class Galaxy(AreaItem):
             visited.add(name)
 
         return True
+
+    def _check_allegiance_counts_well_formed(self):
+        galaxy_count = dict()
+        sector_count = dict()
+
+        for alg in self.alg:
+            galaxy_count[alg] = len(self.alg[alg].worlds)
+            sector_count[alg] = 0
+
+        for position in self.sectors:
+            for alg in self.sectors[position].alg:
+                if alg not in galaxy_count:
+                    return False, "Allegiance " + alg + " found in sector " + position + " but not galaxy"
+                sector_count[alg] += len(self.sectors[position].alg[alg].worlds)
+
+        for alg in galaxy_count:
+            if galaxy_count[alg] != sector_count[alg]:
+                return False, "Allegiance " + alg + " has " + str(galaxy_count[alg]) + " worlds at galaxy, and "\
+                       + str(sector_count[alg]) + " totalled across sectors"
+
+        return True, ""

--- a/PyRoute/AreaItems/Sector.py
+++ b/PyRoute/AreaItems/Sector.py
@@ -128,4 +128,29 @@ class Sector(AreaItem):
                 msg = "Trailing sector y co-ord mismatch for " + self.name
                 return False, msg
 
+        result, tempmsg = self._check_allegiance_counts_well_formed()
+        if not result:
+            return False, tempmsg
+
         return True, msg
+
+    def _check_allegiance_counts_well_formed(self):
+        sector_count = dict()
+        subsector_count = dict()
+
+        for alg in self.alg:
+            sector_count[alg] = len(self.alg[alg].worlds)
+            subsector_count[alg] = 0
+
+        for position in self.subsectors:
+            for alg in self.subsectors[position].alg:
+                if alg not in sector_count:
+                    return False, "Allegiance " + alg + " found in subsector " + position + " but not sector"
+                subsector_count[alg] += len(self.subsectors[position].alg[alg].worlds)
+
+        for alg in sector_count:
+            if sector_count[alg] != subsector_count[alg]:
+                return False, "Allegiance " + alg + " has " + str(sector_count[alg]) + " worlds at sector, and "\
+                       + str(subsector_count[alg]) + " totalled across subsectors"
+
+        return True, ""

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -216,7 +216,7 @@ class SectorDictionary(dict):
             raw_lines = [line for line in raw_lines if ' ' + alg + ' ' not in line]
 
         result = self.drop_lines(raw_lines)
-        result.allegiances = {key: alg for (key, alg) in self.allegiances.items() if key in allegiances}
+        result.allegiances = {key: copy.deepcopy(alg) for (key, alg) in self.allegiances.items() if key in allegiances}
 
         nu_headers = []
         processed = set()

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -263,8 +263,9 @@ class SectorDictionary(dict):
         new_dict = SectorDictionary(self.name, self.filename)
         new_dict.position = self.position
         new_dict.headers = self.headers
-        new_dict.allegiances = self.allegiances
-        for alg in new_dict.allegiances:
+        new_dict.allegiances = dict()
+        for alg in self.allegiances:
+            new_dict.allegiances[alg] = copy.deepcopy(self.allegiances[alg])
             new_dict.allegiances[alg].homeworlds = []
             stats = new_dict.allegiances[alg].stats
             stats.homeworlds = []

--- a/PyRoute/DeltaDebug/DeltaGalaxy.py
+++ b/PyRoute/DeltaDebug/DeltaGalaxy.py
@@ -3,6 +3,7 @@ Created on May 21, 2023
 
 @author: CyberiaResurrection
 """
+import copy
 
 from PyRoute.Allies.AllyGen import AllyGen
 from PyRoute.AreaItems.Allegiance import Allegiance
@@ -35,7 +36,7 @@ class DeltaGalaxy(Galaxy):
 
             # load up allegiances
             for allegiance_name in sector.allegiances:
-                allegiance: Allegiance = sector.allegiances[allegiance_name]
+                allegiance: Allegiance = copy.deepcopy(sector.allegiances[allegiance_name])
 
                 if allegiance_name not in self.alg:
                     self.alg[allegiance_name] = allegiance

--- a/PyRoute/StatCalculation.py
+++ b/PyRoute/StatCalculation.py
@@ -119,8 +119,11 @@ class ObjectStatistics(object):
         foo = ObjectStatistics()
         foo.__dict__.update(state)
         for key in ObjectStatistics.__slots__:
-            if key not in foo:
-                foo[key] = copy.deepcopy(self[key])
+            if '__dict__' != key:
+                try:
+                    foo[key] = copy.deepcopy(self[key])
+                except AttributeError:
+                    pass
 
         return foo
 

--- a/Tests/AreaItems/testAllegiance.py
+++ b/Tests/AreaItems/testAllegiance.py
@@ -24,3 +24,4 @@ class testAllegiance(unittest.TestCase):
         alleg = Allegiance(code, name, False, pop)
 
         foo = copy.deepcopy(alleg)
+        self.assertTrue(isinstance(foo, Allegiance))

--- a/Tests/AreaItems/testAllegiance.py
+++ b/Tests/AreaItems/testAllegiance.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 from PyRoute.AreaItems.Allegiance import Allegiance
@@ -14,3 +15,12 @@ class testAllegiance(unittest.TestCase):
 
         result, msg = alleg.is_well_formed()
         self.assertTrue(result, msg)
+
+    def test_deep_copy_of_new_allegiance(self):
+        code = "A8"
+        name = "Aslan Hierate, Tlaukhu control, Seieakh (9), Akatoiloh (18), We'okurir (29)"
+        pop = "Asla"
+
+        alleg = Allegiance(code, name, False, pop)
+
+        foo = copy.deepcopy(alleg)

--- a/Tests/testDeltaReduce.py
+++ b/Tests/testDeltaReduce.py
@@ -383,6 +383,28 @@ class testDeltaReduce(baseTest):
         reducer = DeltaReduce(delta, args, args.interestingline, args.interestingtype)
         reducer.is_initial_state_uninteresting(reraise=True)
 
+    def test_allegiance_reduction(self):
+        sourcefile = self.unpack_filename('DeltaFiles/Passes/Dagudashaag-subsector-full-reduce.sec')
+
+        args = self._make_args()
+
+        sector = SectorDictionary.load_traveller_map_file(sourcefile)
+        self.assertEqual('# -1,0', sector.position, "Unexpected position value for Dagudashaag")
+        delta = DeltaDictionary()
+        delta[sector.name] = sector
+
+        reducer = DeltaReduce(delta, args)
+
+        reducer.is_initial_state_interesting()
+
+        reducer.reduce_allegiance_pass()
+        self.assertEqual(1, len(reducer.sectors['Dagudashaag'].allegiances), "Unexpected allegiance count after reduction")
+        for alg_name in reducer.sectors['Dagudashaag'].allegiances:
+            expected = 0
+            self.assertEqual(expected, len(reducer.sectors['Dagudashaag'].allegiances[alg_name].worlds))
+
+        self.assertEqual(4, len(reducer.sectors.lines), "Unexpected line count after allegiance pass")
+
     def _make_args(self):
         args = argparse.ArgumentParser(description='PyRoute input minimiser.')
         args.btn = 8


### PR DESCRIPTION
Given stars, upon insertion, are added to their corresponding allegiance at galaxy, sector _and_ subsector levels, that suggests the following invariant:

World counts by allegiance at one level (galaxy, sector) should equal the _sum_ of the allegiance world counts of the areas at the next level down (sector, subsector).

Because integer equality is transitive (A == B and B == C implies A == C), don't need to compare galaxy level counts with sum of _subsector_ allegiance counts.