### PR TITLE
Count penumbra routes

### DIFF
--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -89,6 +89,9 @@ class TradeCalculation(RouteCalculation):
         self.debug_flag = debug_flag
         self.pathfinding_data = None
 
+        # Count routes that get trimmed by as-found route length
+        self.penumbra_routes = 0
+
         self.shortest_path_tree = None
         # Track inter-sector passenger imbalances
         self.sector_passenger_balance = TradeBalance(stat_field="passengers", region=galaxy)
@@ -282,6 +285,7 @@ class TradeCalculation(RouteCalculation):
             processed += 1
         self.multilateral_balance_pass()
         self.logger.info('processed {} routes at BTN {}'.format(counter, base_btn))
+        self.logger.info('{} penumbra routes included out of {}'.format(self.penumbra_routes, processed))
         if self.debug_flag:
             num_stars = len(self.galaxy.stars)
             self.logger.info('Pathfinding diagnostic data for route reuse {}, {} stars, {} routes'.
@@ -362,6 +366,7 @@ class TradeCalculation(RouteCalculation):
         btn = self.get_btn(star, target, distance)
 
         if self.min_btn > btn:
+            self.penumbra_routes += 1
             return
 
         if self.debug_flag:

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -203,8 +203,10 @@ class TradeMPCalculation(TradeCalculation):
 
                 assert is_path(self.galaxy.stars, route_list), f"Route returned by mp process is not a correct path: {route}"
 
-                btn = self.get_btn(route)
+                distance = self.route_distance(route)
+                btn = self.get_btn(route[0], route[-1], distance)
                 if self.min_btn > btn:
+                    self.penumbra_routes += 1
                     continue
 
                 # Using the route found by the child process update the stars / routes graphs in the parent process
@@ -249,8 +251,10 @@ class TradeMPCalculation(TradeCalculation):
                 route = [self.galaxy.star_mapping[item] for item in route_list]
                 assert is_path(self.galaxy.stars, route_list), f"Route returned by mp process is not a correct path: {route}"
 
-                btn = self.get_btn(route)
+                distance = self.route_distance(route)
+                btn = self.get_btn(route[0], route[-1], distance)
                 if self.min_btn > btn:
+                    self.penumbra_routes += 1
                     continue
 
                 if total > 100 and processed % (total // 20) == 0:
@@ -324,8 +328,10 @@ class TradeMPCalculation(TradeCalculation):
         assert self.galaxy.route_no_revisit(route), \
             f"Route between {star}  and {target} revisits at least one star"
 
-        btn = self.get_btn(route)
+        distance = self.route_distance(route)
+        btn = self.get_btn(star, target, distance)
         if self.min_btn > btn:
+            self.penumbra_routes += 1
             return
 
         if self.debug_flag:

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -125,6 +125,7 @@ class TradeMPCalculation(TradeCalculation):
 
         self.btn = []
         self.mp_threads = mp_threads
+        self.total_processed = 0
 
     def calculate_routes(self):
         """
@@ -205,6 +206,7 @@ class TradeMPCalculation(TradeCalculation):
 
                 distance = self.route_distance(route)
                 btn = self.get_btn(route[0], route[-1], distance)
+                count += 1
                 if self.min_btn > btn:
                     self.penumbra_routes += 1
                     continue
@@ -214,8 +216,9 @@ class TradeMPCalculation(TradeCalculation):
                 target = route[-1]
                 tradeCr, tradePass, tradeDton = self.route_update_simple(route, True)
                 self.update_statistics(start, target, tradeCr, tradePass, tradeDton)
-                count += 1
+
         self.logger.info(f"Intra-sector route processing completed. Processed {count} routes")
+        self.total_processed += count
 
     def process_long_routes(self, btn):
 
@@ -253,6 +256,7 @@ class TradeMPCalculation(TradeCalculation):
 
                 distance = self.route_distance(route)
                 btn = self.get_btn(route[0], route[-1], distance)
+                processed += 1
                 if self.min_btn > btn:
                     self.penumbra_routes += 1
                     continue
@@ -265,8 +269,10 @@ class TradeMPCalculation(TradeCalculation):
                 target = route[-1]
                 tradeCr, tradePass, tradeDton = self.route_update_simple(route, False)
                 self.update_statistics(start, target, tradeCr, tradePass, tradeDton)
-                processed += 1
+
         self.logger.info(f"Long route processing completed. process {processed} routes")
+        self.total_processed += processed
+        self.logger.info('{} penumbra routes included out of {}'.format(self.penumbra_routes, self.total_processed))
 
     def process_routes(self, btn):
         """
@@ -298,6 +304,7 @@ class TradeMPCalculation(TradeCalculation):
             counter += 1
             processed += 1
         self.logger.info(f'processed {counter} routes at BTN {base_btn}')
+        self.total_processed += processed
 
     def get_trade_between(self, star, target):
         """

--- a/PyRoute/Calculation/TradeMPCalculation.py
+++ b/PyRoute/Calculation/TradeMPCalculation.py
@@ -203,6 +203,10 @@ class TradeMPCalculation(TradeCalculation):
 
                 assert is_path(self.galaxy.stars, route_list), f"Route returned by mp process is not a correct path: {route}"
 
+                btn = self.get_btn(route)
+                if self.min_btn > btn:
+                    continue
+
                 # Using the route found by the child process update the stars / routes graphs in the parent process
                 start = route[0]
                 target = route[-1]
@@ -244,6 +248,10 @@ class TradeMPCalculation(TradeCalculation):
                     break
                 route = [self.galaxy.star_mapping[item] for item in route_list]
                 assert is_path(self.galaxy.stars, route_list), f"Route returned by mp process is not a correct path: {route}"
+
+                btn = self.get_btn(route)
+                if self.min_btn > btn:
+                    continue
 
                 if total > 100 and processed % (total // 20) == 0:
                     self.logger.info(f'processed {processed} routes, at {processed // (total // 100)}%')
@@ -315,6 +323,10 @@ class TradeMPCalculation(TradeCalculation):
 
         assert self.galaxy.route_no_revisit(route), \
             f"Route between {star}  and {target} revisits at least one star"
+
+        btn = self.get_btn(route)
+        if self.min_btn > btn:
+            return
 
         if self.debug_flag:
             fwd_weight = self.route_cost(route)


### PR DESCRIPTION
Potential routes during a trade/trade-mp run can be grouped into three classes:

Umbra - route below min BTN with straight line distance.
Penumbra - route not below min BTN with straight line distance, route below min BTN with actual route distance.
Light - route not below min BTN with actual route distance.

Routes in the umbra are filtered out during initial route collection.
Previously, penumbra routes were filtered out in the uniprocess trade run, but not in the multiprocess trade-mp run.
Nor were they counted.
Routes in the light are counted as normal.

This PR filters penumbra routes in trade-mp (to line up with the uniprocess version), counts the penumbra routes, and prints out the total at the end of pathfinding.