### PR TITLE
Delta debugging fixes

### DIFF
--- a/PyRoute/DeltaDebug/DeltaDebug.py
+++ b/PyRoute/DeltaDebug/DeltaDebug.py
@@ -42,8 +42,8 @@ def process():
                        help='Allegiance matching for borders, default [collapse]')
 
     route = parser.add_argument_group('Routes', 'Route generation options')
-    route.add_argument('--routes', dest='routes', choices=['trade', 'comm', 'xroute', 'owned', 'none'], default='trade',
-                       help='Route type to be generated, default [trade]')
+    route.add_argument('--routes', dest='routes', choices=['trade', 'comm', 'xroute', 'owned', 'none', 'trade-mp'],
+                       default='trade', help='Route type to be generated, default [trade]')
     route.add_argument('--min-btn', dest='btn', default=13, type=int,
                        help='Minimum BTN used for route calculation, default [13]')
     route.add_argument('--min-route-btn', dest='route_btn', default=8, type=int,

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -338,6 +338,10 @@ class SectorDictionary(dict):
                 self[sub_name].items = None
 
     def write_file(self, output_dir):
+        result, msg = self.is_well_formed()
+        if not result:
+            raise DeltaLogicError(msg)
+
         exists = os.path.exists(output_dir)
         if not exists:
             os.makedirs(output_dir)

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -124,6 +124,8 @@ class DeltaDictionary(dict):
             raise DeltaLogicError(msg)
 
         for sector_name in self:
+            if 0 == len(self[sector_name].lines):
+                continue
             self[sector_name].write_file(output_dir)
 
     def skip_void_subsectors(self):

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -338,10 +338,6 @@ class SectorDictionary(dict):
                 self[sub_name].items = None
 
     def write_file(self, output_dir):
-        result, msg = self.is_well_formed()
-        if not result:
-            raise DeltaLogicError(msg)
-
         exists = os.path.exists(output_dir)
         if not exists:
             os.makedirs(output_dir)

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -30,7 +30,10 @@ class DeltaDictionary(dict):
 
         new_dict = DeltaDictionary()
         for sector_name in overlap:
-            new_dict[sector_name] = copy.deepcopy(self[sector_name])
+            subset_sector = copy.deepcopy(self[sector_name])
+            if 0 == len(subset_sector.lines):
+                continue
+            new_dict[sector_name] = subset_sector
             pass
 
         return new_dict
@@ -50,7 +53,10 @@ class DeltaDictionary(dict):
 
         new_dict = DeltaDictionary()
         for sector_name in overlap:
-            new_dict[sector_name] = self[sector_name].subsector_subset(overlap[sector_name])
+            subset_sector = self[sector_name].subsector_subset(overlap[sector_name])
+            if 0 == len(subset_sector.lines):
+                continue
+            new_dict[sector_name] = subset_sector
 
         return new_dict
 
@@ -59,6 +65,8 @@ class DeltaDictionary(dict):
         for sector_name in self:
             subset_sector = self[sector_name].allegiance_subset(allegiances)
             if 0 == len(subset_sector.allegiances):
+                continue
+            if 0 == len(subset_sector.lines):
                 continue
             new_dict[sector_name] = subset_sector
 

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -349,7 +349,7 @@ class SectorDictionary(dict):
             handle.write(line)
 
         for line in self.lines:
-            line = line + '\n'
+            line = line.strip('\n') + '\n'
             handle.write(line)
 
         handle.close()

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -273,7 +273,7 @@ class SectorDictionary(dict):
     def subsector_list(self):
         result = list()
         for subsector_name in self:
-            if not self[subsector_name].skipped:
+            if 0 < self[subsector_name].num_lines:
                 result.append(subsector_name)
 
         return result

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -206,7 +206,8 @@ class SectorDictionary(dict):
         missed = list()
         for subsector_name in subsectors:
             if subsector_name in self:
-                overlap.append(subsector_name)
+                if not 0 == self[subsector_name].num_lines:
+                    overlap.append(subsector_name)
 
         for subsector_name in self:
             if subsector_name not in overlap:

--- a/PyRoute/DeltaDebug/DeltaDictionary.py
+++ b/PyRoute/DeltaDebug/DeltaDictionary.py
@@ -464,7 +464,7 @@ class SubsectorDictionary(dict):
             return foo
 
         for item in self.items:
-            foo.items.append(copy.deepcopy(item))
+            foo.items.append(copy.deepcopy(item.strip('\n')))
         return foo
 
     def drop_lines(self, lines_to_drop):

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -49,7 +49,9 @@ class DeltaReduce:
         self.interesting_type = interesting_type
         self.logger = logging.getLogger('PyRoute.Star')
         logging.disable(logging.WARNING)
-        self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self), TradeCodeLineReduce(self), NBZLineReduce(self)]
+        self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
+                           ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
+                           TradeCodeLineReduce(self), NBZLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -23,6 +23,7 @@ from PyRoute.DeltaPasses.NBZLineReduce import NBZLineReduce
 from PyRoute.DeltaPasses.SectorReducer import SectorReducer
 from PyRoute.DeltaPasses.SingleLineReducer import SingleLineReducer
 from PyRoute.DeltaPasses.SubsectorReducer import SubsectorReducer
+from PyRoute.DeltaPasses.TradeCodeLineReduce import TradeCodeLineReduce
 from PyRoute.DeltaPasses.TwoLineReducer import TwoLineReducer
 from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
 from PyRoute.Outputs.ClassicModePDFSectorMap import ClassicModePDFSectorMap
@@ -47,7 +48,7 @@ class DeltaReduce:
         self.interesting_type = interesting_type
         self.logger = logging.getLogger('PyRoute.Star')
         logging.disable(logging.WARNING)
-        self.withinline = [Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self), NBZLineReduce(self)]
+        self.withinline = [Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self), TradeCodeLineReduce(self), NBZLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -21,6 +21,7 @@ from PyRoute.DeltaPasses.FullLineReduce import FullLineReduce
 from PyRoute.DeltaPasses.IdentityLineReduce import IdentityLineReduce
 from PyRoute.DeltaPasses.ImportanceLineReduce import ImportanceLineReduce
 from PyRoute.DeltaPasses.NBZLineReduce import NBZLineReduce
+from PyRoute.DeltaPasses.NoblesTrimLineReduce import NoblesTrimLineReduce
 from PyRoute.DeltaPasses.SectorReducer import SectorReducer
 from PyRoute.DeltaPasses.SingleLineReducer import SingleLineReducer
 from PyRoute.DeltaPasses.SubsectorReducer import SubsectorReducer
@@ -51,7 +52,7 @@ class DeltaReduce:
         logging.disable(logging.WARNING)
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
-                           TradeCodeLineReduce(self), NBZLineReduce(self)]
+                           TradeCodeLineReduce(self), NBZLineReduce(self), NoblesTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -18,6 +18,7 @@ from PyRoute.DeltaPasses.AuxiliaryLineReduce import AuxiliaryLineReduce
 from PyRoute.DeltaPasses.Canonicalisation import Canonicalisation
 from PyRoute.DeltaPasses.CapitalLineReduce import CapitalLineReduce
 from PyRoute.DeltaPasses.FullLineReduce import FullLineReduce
+from PyRoute.DeltaPasses.IdentityLineReduce import IdentityLineReduce
 from PyRoute.DeltaPasses.ImportanceLineReduce import ImportanceLineReduce
 from PyRoute.DeltaPasses.NBZLineReduce import NBZLineReduce
 from PyRoute.DeltaPasses.SectorReducer import SectorReducer
@@ -48,7 +49,7 @@ class DeltaReduce:
         self.interesting_type = interesting_type
         self.logger = logging.getLogger('PyRoute.Star')
         logging.disable(logging.WARNING)
-        self.withinline = [Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self), TradeCodeLineReduce(self), NBZLineReduce(self)]
+        self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self), ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self), TradeCodeLineReduce(self), NBZLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -15,6 +15,7 @@ from PyRoute.DeltaDebug.DeltaDictionary import DeltaDictionary
 from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from PyRoute.DeltaPasses.AllegianceReducer import AllegianceReducer
 from PyRoute.DeltaPasses.AuxiliaryLineReduce import AuxiliaryLineReduce
+from PyRoute.DeltaPasses.BaseLineReduce import BaseLineReduce
 from PyRoute.DeltaPasses.Canonicalisation import Canonicalisation
 from PyRoute.DeltaPasses.CapitalLineReduce import CapitalLineReduce
 from PyRoute.DeltaPasses.FullLineReduce import FullLineReduce
@@ -54,7 +55,7 @@ class DeltaReduce:
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
                            TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self), NBZLineReduce(self),
-                           NoblesTrimLineReduce(self)]
+                           BaseLineReduce(self), NoblesTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -16,6 +16,7 @@ from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from PyRoute.DeltaPasses.AllegianceReducer import AllegianceReducer
 from PyRoute.DeltaPasses.AuxiliaryLineReduce import AuxiliaryLineReduce
 from PyRoute.DeltaPasses.BaseLineReduce import BaseLineReduce
+from PyRoute.DeltaPasses.BaseTrimLineReduce import BaseTrimLineReduce
 from PyRoute.DeltaPasses.Canonicalisation import Canonicalisation
 from PyRoute.DeltaPasses.CapitalLineReduce import CapitalLineReduce
 from PyRoute.DeltaPasses.FullLineReduce import FullLineReduce
@@ -56,7 +57,8 @@ class DeltaReduce:
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
                            TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self), NBZLineReduce(self),
-                           BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self)]
+                           BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self),
+                           BaseTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -58,7 +58,7 @@ class DeltaReduce:
         logging.disable(logging.WARNING)
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
-                           PortAndTlLineReduce(self),  TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self),
+                           PortAndTlLineReduce(self), TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self),
                            NBZLineReduce(self), BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self),
                            BaseTrimLineReduce(self), ZoneTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -30,6 +30,7 @@ from PyRoute.DeltaPasses.TradeCodeLineReduce import TradeCodeLineReduce
 from PyRoute.DeltaPasses.TradeCodeTrimLineReduce import TradeCodeTrimLineReduce
 from PyRoute.DeltaPasses.TwoLineReducer import TwoLineReducer
 from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
+from PyRoute.DeltaPasses.ZoneLineReduce import ZoneLineReduce
 from PyRoute.Outputs.ClassicModePDFSectorMap import ClassicModePDFSectorMap
 from PyRoute.Outputs.DarkModePDFSectorMap import DarkModePDFSectorMap
 from PyRoute.Outputs.LightModePDFSectorMap import LightModePDFSectorMap
@@ -55,7 +56,7 @@ class DeltaReduce:
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
                            TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self), NBZLineReduce(self),
-                           BaseLineReduce(self), NoblesTrimLineReduce(self)]
+                           BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -32,6 +32,7 @@ from PyRoute.DeltaPasses.TradeCodeTrimLineReduce import TradeCodeTrimLineReduce
 from PyRoute.DeltaPasses.TwoLineReducer import TwoLineReducer
 from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
 from PyRoute.DeltaPasses.ZoneLineReduce import ZoneLineReduce
+from PyRoute.DeltaPasses.ZoneTrimLineReduce import ZoneTrimLineReduce
 from PyRoute.Outputs.ClassicModePDFSectorMap import ClassicModePDFSectorMap
 from PyRoute.Outputs.DarkModePDFSectorMap import DarkModePDFSectorMap
 from PyRoute.Outputs.LightModePDFSectorMap import LightModePDFSectorMap
@@ -58,7 +59,7 @@ class DeltaReduce:
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
                            TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self), NBZLineReduce(self),
                            BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self),
-                           BaseTrimLineReduce(self)]
+                           BaseTrimLineReduce(self), ZoneTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -24,6 +24,7 @@ from PyRoute.DeltaPasses.IdentityLineReduce import IdentityLineReduce
 from PyRoute.DeltaPasses.ImportanceLineReduce import ImportanceLineReduce
 from PyRoute.DeltaPasses.NBZLineReduce import NBZLineReduce
 from PyRoute.DeltaPasses.NoblesTrimLineReduce import NoblesTrimLineReduce
+from PyRoute.DeltaPasses.PortAndTlLineReduce import PortAndTlLineReduce
 from PyRoute.DeltaPasses.SectorReducer import SectorReducer
 from PyRoute.DeltaPasses.SingleLineReducer import SingleLineReducer
 from PyRoute.DeltaPasses.SubsectorReducer import SubsectorReducer
@@ -57,8 +58,8 @@ class DeltaReduce:
         logging.disable(logging.WARNING)
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
-                           TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self), NBZLineReduce(self),
-                           BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self),
+                           PortAndTlLineReduce(self),  TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self),
+                           NBZLineReduce(self), BaseLineReduce(self), ZoneLineReduce(self), NoblesTrimLineReduce(self),
                            BaseTrimLineReduce(self), ZoneTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)

--- a/PyRoute/DeltaDebug/DeltaReduce.py
+++ b/PyRoute/DeltaDebug/DeltaReduce.py
@@ -26,6 +26,7 @@ from PyRoute.DeltaPasses.SectorReducer import SectorReducer
 from PyRoute.DeltaPasses.SingleLineReducer import SingleLineReducer
 from PyRoute.DeltaPasses.SubsectorReducer import SubsectorReducer
 from PyRoute.DeltaPasses.TradeCodeLineReduce import TradeCodeLineReduce
+from PyRoute.DeltaPasses.TradeCodeTrimLineReduce import TradeCodeTrimLineReduce
 from PyRoute.DeltaPasses.TwoLineReducer import TwoLineReducer
 from PyRoute.DeltaPasses.WidenHoleReducer import WidenHoleReducer
 from PyRoute.Outputs.ClassicModePDFSectorMap import ClassicModePDFSectorMap
@@ -52,7 +53,8 @@ class DeltaReduce:
         logging.disable(logging.WARNING)
         self.withinline = [IdentityLineReduce(self), Canonicalisation(self), FullLineReduce(self),
                            ImportanceLineReduce(self), CapitalLineReduce(self), AuxiliaryLineReduce(self),
-                           TradeCodeLineReduce(self), NBZLineReduce(self), NoblesTrimLineReduce(self)]
+                           TradeCodeLineReduce(self), TradeCodeTrimLineReduce(self), NBZLineReduce(self),
+                           NoblesTrimLineReduce(self)]
         self.sector_reducer = SectorReducer(self)
         self.allegiance_reducer = AllegianceReducer(self)
         self.subsector_reducer = SubsectorReducer(self)

--- a/PyRoute/DeltaPasses/AllegianceReducer.py
+++ b/PyRoute/DeltaPasses/AllegianceReducer.py
@@ -70,7 +70,7 @@ class AllegianceReducer(object):
 
             num_chunks *= 2
             # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
-            if num_chunks > len(segment) and not singleton_run:
+            if num_chunks >= len(segment) and not singleton_run:
                 singleton_run = True
                 num_chunks = len(segment)
             segment = list(best_sectors.allegiance_list())

--- a/PyRoute/DeltaPasses/BaseLineReduce.py
+++ b/PyRoute/DeltaPasses/BaseLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 06, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class BaseLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with base reduction"
+        self.start_msg = "Commencing base within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, drop_base_codes=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/BaseTrimLineReduce.py
+++ b/PyRoute/DeltaPasses/BaseTrimLineReduce.py
@@ -1,5 +1,5 @@
 """
-Created on May 06, 2025
+Created on May 08, 2025
 
 @author: CyberiaResurrection
 """
@@ -7,18 +7,18 @@ from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
 from PyRoute.DeltaStar import DeltaStar
 
 
-class BaseLineReduce(WithinLineReducer):
+class BaseTrimLineReduce(WithinLineReducer):
 
     def _build_subs_list(self):
-        self.full_msg = "Reduction found with base reduction"
-        self.start_msg = "Commencing base within-line reduction"
+        self.full_msg = "Reduction found with base trim reduction"
+        self.start_msg = "Commencing base trim within-line reduction"
 
         # build substitution list - reduce _everything_
         subs_list = []
         segment = []
         num_lines = len(self.reducer.sectors.lines)
         for line in self.reducer.sectors.lines:
-            canon = DeltaStar.reduce(line, drop_base_codes=True)
+            canon = DeltaStar.reduce(line, trim_base_codes=True)
             assert isinstance(canon,
                               str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
             # Skip already-reduced lines

--- a/PyRoute/DeltaPasses/BaseTrimLineReduce.py
+++ b/PyRoute/DeltaPasses/BaseTrimLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 06, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class BaseLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with base reduction"
+        self.start_msg = "Commencing base within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, drop_base_codes=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/IdentityLineReduce.py
+++ b/PyRoute/DeltaPasses/IdentityLineReduce.py
@@ -1,0 +1,28 @@
+"""
+Created on May 04, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class IdentityLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with identity reduction"
+        self.start_msg = "Commencing identity within-line reduction"
+
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/NoblesTrimLineReduce.py
+++ b/PyRoute/DeltaPasses/NoblesTrimLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 05, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class NoblesTrimLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with nobles trim"
+        self.start_msg = "Commencing nobles trim within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, trim_noble_codes=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/PortAndTlLineReduce.py
+++ b/PyRoute/DeltaPasses/PortAndTlLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 07, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class PortAndTlLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with port and TL reduction"
+        self.start_msg = "Commencing port and TL within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, reset_port=True, reset_tl=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/SectorReducer.py
+++ b/PyRoute/DeltaPasses/SectorReducer.py
@@ -59,7 +59,7 @@ class SectorReducer(BeyondLineReducer):
 
             num_chunks *= 2
             # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
-            if num_chunks > len(segment) and not singleton_run:
+            if num_chunks >= len(segment) and not singleton_run:
                 singleton_run = True
                 num_chunks = len(segment)
 

--- a/PyRoute/DeltaPasses/SingleLineReducer.py
+++ b/PyRoute/DeltaPasses/SingleLineReducer.py
@@ -98,7 +98,7 @@ class SingleLineReducer(BeyondLineReducer):
 
             segment = best_sectors.lines
             # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
-            if num_chunks > len(segment) and not singleton_run:
+            if num_chunks >= len(segment) and not singleton_run:
                 singleton_run = True
                 num_chunks = len(segment)
 

--- a/PyRoute/DeltaPasses/SubsectorReducer.py
+++ b/PyRoute/DeltaPasses/SubsectorReducer.py
@@ -89,7 +89,7 @@ class SubsectorReducer(BeyondLineReducer):
 
             num_chunks *= 2
             # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
-            if num_chunks > len(segment) and not singleton_run:
+            if num_chunks >= len(segment) and not singleton_run:
                 singleton_run = True
                 num_chunks = len(segment)
             segment = best_sectors.subsector_list()

--- a/PyRoute/DeltaPasses/TradeCodeLineReduce.py
+++ b/PyRoute/DeltaPasses/TradeCodeLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 04, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class TradeCodeLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with trade-code reduction"
+        self.start_msg = "Commencing trade-code within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, drop_trade_codes=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/TradeCodeTrimLineReduce.py
+++ b/PyRoute/DeltaPasses/TradeCodeTrimLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 05, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class TradeCodeTrimLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with trade codes trim"
+        self.start_msg = "Commencing trade codes trim within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, trim_trade_codes=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -84,7 +84,7 @@ class WithinLineReducer(object):
                     chunks[i] = []
                     remove.append(i)
                     best_sectors = temp_sectors
-                    step = '(' + str(i+1) + "/" + str(num_chunks) + ')'
+                    step = '(' + str(i + 1) + "/" + str(num_chunks) + ')'
                     msg = "Reduction found " + step + ": new input has " + str(len(raw_lines)) + " unreduced lines"
                     self.reducer.logger.error(msg)
                 del temp_sectors

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -127,6 +127,7 @@ class WithinLineReducer(object):
         if not interesting:
             raise DeltaLogicError("Final output not interesting")
 
+        self.reducer.sectors.trim_empty_allegiances()
         self.write_files()
         if short_msg is not None:
             self.reducer.logger.error("Shortest error message: " + short_msg)

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -81,7 +81,8 @@ class WithinLineReducer(object):
                     chunks[i] = []
                     remove.append(i)
                     best_sectors = temp_sectors
-                    msg = "Reduction found: new input has " + str(len(raw_lines)) + " unreduced lines"
+                    step = '(' + str(i+1) + "/" + str(num_chunks) + ')'
+                    msg = "Reduction found " + step + ": new input has " + str(len(raw_lines)) + " unreduced lines"
                     self.reducer.logger.error(msg)
                 del temp_sectors
 

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -43,9 +43,12 @@ class WithinLineReducer(object):
             self.reducer.sectors.trim_empty_allegiances()
             self.write_files()
             return
+        # By the time we've gotten here, if segment is 1 element long, switching it in _can't_ be interesting,
+        # otherwise it would have tripped the original if statement, so bail out early
+        elif 1 == len(segment):
+            return
         else:
             best_sectors = self.reducer.sectors
-
 
         # trying everything didn't work, now we need to minimise the number of un-reduced lines
         num_chunks = 2

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -121,9 +121,6 @@ class WithinLineReducer(object):
             raise DeltaLogicError("Intermediate output not interesting")
 
         self.reducer.sectors = best_sectors
-        _, subs_list = self._build_fill_list()
-        if 0 != len(subs_list):
-            self.reducer.sectors = self.reducer.sectors.switch_lines(subs_list)
 
         self.reducer.sectors.trim_empty_allegiances()
         interesting, msg, _ = self.reducer._check_interesting(self.reducer.args, self.reducer.sectors)

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -50,7 +50,7 @@ class WithinLineReducer(object):
         # trying everything didn't work, now we need to minimise the number of un-reduced lines
         num_chunks = 2
         short_msg = None
-        singleton_run = True
+        singleton_run = False
 
         while num_chunks <= len(segment):
             chunks = self.reducer.chunk_lines(segment, num_chunks)

--- a/PyRoute/DeltaPasses/WithinLineReducer.py
+++ b/PyRoute/DeltaPasses/WithinLineReducer.py
@@ -109,7 +109,7 @@ class WithinLineReducer(object):
                 break
 
             # if we're about to bust our loop condition, make sure we verify 1-minimality as our last hurrah
-            if num_chunks > len(segment) and not singleton_run:
+            if num_chunks >= len(segment) and not singleton_run:
                 singleton_run = True
                 num_chunks = len(segment)
 

--- a/PyRoute/DeltaPasses/ZoneLineReduce.py
+++ b/PyRoute/DeltaPasses/ZoneLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 07, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class ZoneLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with zone reduction"
+        self.start_msg = "Commencing zone within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, drop_trade_zone=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaPasses/ZoneTrimLineReduce.py
+++ b/PyRoute/DeltaPasses/ZoneTrimLineReduce.py
@@ -1,0 +1,29 @@
+"""
+Created on May 07, 2025
+
+@author: CyberiaResurrection
+"""
+from PyRoute.DeltaPasses.WithinLineReducer import WithinLineReducer
+from PyRoute.DeltaStar import DeltaStar
+
+
+class ZoneTrimLineReduce(WithinLineReducer):
+
+    def _build_subs_list(self):
+        self.full_msg = "Reduction found with zone trim reduction"
+        self.start_msg = "Commencing zone trim within-line reduction"
+
+        # build substitution list - reduce _everything_
+        subs_list = []
+        segment = []
+        num_lines = len(self.reducer.sectors.lines)
+        for line in self.reducer.sectors.lines:
+            canon = DeltaStar.reduce(line, trim_trade_zone=True)
+            assert isinstance(canon,
+                              str), "Candidate line " + line + " was not reduced to a string.  Got " + canon + " instead."
+            # Skip already-reduced lines
+            if 2 < num_lines and line.startswith(canon):
+                continue
+            subs_list.append((line, canon))
+            segment.append(line)
+        return segment, subs_list

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -86,9 +86,10 @@ class DeltaStar(Star):
         self.tradeCode = TradeCodes('')
 
     def trim_trade_codes(self):
-        matches = {"In", "Ni", "Ag", "Na", "Ex", "Hi", "Ri", "Cp", "Cs", "Cx"}
         if '' == str(self.tradeCode):
             return
+
+        matches = {"In", "Ni", "Ag", "Na", "Ex", "Hi", "Ri", "Cp", "Cs", "Cx"}.union(TradeCodes.ex_codes)
         trade_string = ""
         for codes in self.tradeCode.codes:
             if codes in matches:

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -13,7 +13,9 @@ from PyRoute.TradeCodes import TradeCodes
 class DeltaStar(Star):
 
     @staticmethod
-    def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False, drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False, reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False):
+    def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False,
+               drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False,
+               reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False, trim_noble_codes=False):
         sector = Sector("# dummy", "# 0, 0")
         star = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
         if not isinstance(star, DeltaStar):
@@ -27,6 +29,8 @@ class DeltaStar(Star):
             star.reduce_trade_codes()
         if drop_noble_codes:
             star.reduce_noble_codes()
+        elif trim_noble_codes:
+            star.trim_noble_codes()
         if drop_base_codes:
             star.reduce_base_codes()
         if drop_trade_zone:
@@ -78,6 +82,14 @@ class DeltaStar(Star):
 
     def reduce_noble_codes(self):
         self.nobles = Nobles()
+
+    def trim_noble_codes(self):
+        noble_code = str(self.nobles)
+        if 2 > len(noble_code):
+            return
+
+        self.nobles = Nobles()
+        self.nobles.count(noble_code[0])
 
     def reduce_base_codes(self):
         self.baseCode = '-'

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -16,7 +16,7 @@ class DeltaStar(Star):
     def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False,
                drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False,
                reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False, trim_noble_codes=False,
-               trim_trade_codes=False, trim_base_codes=False):
+               trim_trade_codes=False, trim_base_codes=False, trim_trade_zone=False):
         sector = Sector("# dummy", "# 0, 0")
         star = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
         if not isinstance(star, DeltaStar):
@@ -40,6 +40,8 @@ class DeltaStar(Star):
             star.trim_base_codes()
         if drop_trade_zone:
             star.reduce_trade_zone()
+        elif trim_trade_zone:
+            star.trim_trade_zone()
         if drop_extra_stars:
             star.reduce_extra_stars()
         if reset_pbg:
@@ -120,6 +122,16 @@ class DeltaStar(Star):
 
     def reduce_trade_zone(self):
         self.zone = '-'
+
+    def trim_trade_zone(self):
+        if '-' == self.zone:
+            return
+        if 'R' == self.zone.upper():
+            self.zone = 'A'
+        elif 'F' == self.zone.upper():
+            self.zone = 'U'
+        else:
+            self.zone = '-'
 
     def reduce_extra_stars(self):
         if 0 < len(self.star_list):

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -15,7 +15,8 @@ class DeltaStar(Star):
     @staticmethod
     def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False,
                drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False,
-               reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False, trim_noble_codes=False):
+               reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False, trim_noble_codes=False,
+               trim_trade_codes=False):
         sector = Sector("# dummy", "# 0, 0")
         star = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
         if not isinstance(star, DeltaStar):
@@ -27,6 +28,8 @@ class DeltaStar(Star):
             star.reduce_routes()
         if drop_trade_codes:
             star.reduce_trade_codes()
+        elif trim_trade_codes:
+            star.trim_trade_codes()
         if drop_noble_codes:
             star.reduce_noble_codes()
         elif trim_noble_codes:
@@ -79,6 +82,17 @@ class DeltaStar(Star):
 
     def reduce_trade_codes(self):
         self.tradeCode = TradeCodes('')
+
+    def trim_trade_codes(self):
+        matches = {"In", "Ni", "Ag", "Na", "Ex", "Hi", "Ri", "Cp", "Cs", "Cx"}
+        if '' == str(self.tradeCode):
+            return
+        trade_string = ""
+        for codes in self.tradeCode.codes:
+            if codes in matches:
+                trade_string += " " + str(codes)
+
+        self.tradeCode = TradeCodes(trade_string)
 
     def reduce_noble_codes(self):
         self.nobles = Nobles()

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -16,7 +16,7 @@ class DeltaStar(Star):
     def reduce(starline, drop_routes=False, drop_trade_codes=False, drop_noble_codes=False, drop_base_codes=False,
                drop_trade_zone=False, drop_extra_stars=False, reset_pbg=False, reset_worlds=False, reset_port=False,
                reset_tl=False, reset_sophont=False, reset_capitals=False, canonicalise=False, trim_noble_codes=False,
-               trim_trade_codes=False):
+               trim_trade_codes=False, trim_base_codes=False):
         sector = Sector("# dummy", "# 0, 0")
         star = DeltaStar.parse_line_into_star(starline, sector, 'fixed', 'fixed')
         if not isinstance(star, DeltaStar):
@@ -36,6 +36,8 @@ class DeltaStar(Star):
             star.trim_noble_codes()
         if drop_base_codes:
             star.reduce_base_codes()
+        elif trim_base_codes:
+            star.trim_base_codes()
         if drop_trade_zone:
             star.reduce_trade_zone()
         if drop_extra_stars:
@@ -107,6 +109,13 @@ class DeltaStar(Star):
 
     def reduce_base_codes(self):
         self.baseCode = '-'
+
+    def trim_base_codes(self):
+        base_code = str(self.baseCode)
+        if 2 > len(base_code):
+            return
+
+        self.baseCode = base_code[0]
 
     def reduce_trade_zone(self):
         self.zone = '-'

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -129,7 +129,7 @@ class ParseSectorInput:
                 continue
             subsec = star.subsector()
             subname = subsector_names[subsec]
-            sector[subname].items.append(line)
+            sector[subname].items.append(line.strip('\n'))
 
         return sector
 

--- a/Tests/testDeltaDictionary.py
+++ b/Tests/testDeltaDictionary.py
@@ -118,7 +118,7 @@ class testDeltaDictionary(baseTest):
 
         remix = foo.subsector_subset(subsectorlist)
         self.assertTrue(isinstance(remix, DeltaDictionary))
-        self.assertEqual(2, len(remix), 'Subsetted delta dict should have two element')
+        self.assertEqual(1, len(remix), 'Subsetted delta dict should have one element')
         self.assertEqual('Gushemege', remix['Gushemege'].name)
         self.assertEqual('# -2,0', remix['Gushemege'].position)
         self.assertEqual('filename', remix['Gushemege'].filename)
@@ -127,18 +127,6 @@ class testDeltaDictionary(baseTest):
         self.assertEqual('Khiira', remix['Gushemege']['Khiira'].name)
         self.assertEqual('Riften', remix['Gushemege']['Riften'].name)
         self.assertEqual(None, remix['Gushemege']['Riften'].items, 'Skipped subsector should have None for items')
-        self.assertEqual('Dagudashaag', remix['Dagudashaag'].name)
-        self.assertEqual('# -1,0', remix['Dagudashaag'].position)
-        self.assertEqual(1, len(remix['Dagudashaag']),
-                         'Subsetted delta dict should have one subsector in Dagudashaag')
-        self.assertEqual('Mimu', remix['Dagudashaag']['Mimu'].name)
-        self.assertEqual('A', remix['Dagudashaag']['Mimu'].position)
-        # check allegiances got cleared
-        self.assertEqual(1, len(remix['Dagudashaag'].allegiances), "Unexpected allegiance count for Dagudashaag")
-        nu_alg = remix['Dagudashaag'].allegiances['fo']
-        self.assertEqual(0, nu_alg.stats.passengers, "Allegiance pax not cleared during subsector_list")
-        self.assertEqual(0, nu_alg.stats.trade, "Allegiance trade not cleared during subsector_list")
-        self.assertEqual(0, nu_alg.stats.tradeExt, "Allegiance tradeExt not cleared during subsector_list")
 
     def test_sector_list(self):
         foo = DeltaDictionary()
@@ -181,8 +169,6 @@ class testDeltaDictionary(baseTest):
         foo[gus.name] = gus
 
         expected = list()
-        expected.append('Khiira')
-        expected.append('Mimu')
         expected.append('Riften')
         actual = foo.subsector_list()
 
@@ -191,7 +177,6 @@ class testDeltaDictionary(baseTest):
         gusB.items = None
 
         expected = list()
-        expected.append('Mimu')
         expected.append('Riften')
         actual = foo.subsector_list()
 
@@ -206,7 +191,7 @@ class testDeltaDictionary(baseTest):
         foo[vland_sec.name] = vland_sec
 
         remix = foo.sector_subset(['Vland'])
-        self.assertEqual(1, len(remix))
+        self.assertEqual(0, len(remix))
 
     def test_sector_subset_blowup_on_spinward_marches(self):
         spinward = self.unpack_filename('DeltaFiles/high_pop_worlds_blowup/Spinward Marches.sec')
@@ -217,7 +202,7 @@ class testDeltaDictionary(baseTest):
         foo[spinward_sec.name] = spinward_sec
 
         remix = foo.sector_subset(['Spinward Marches', 'Deneb', 'Trojan Reach'])
-        self.assertEqual(1, len(remix))
+        self.assertEqual(0, len(remix))
 
     def test_allegiance_list(self):
         spinward = self.unpack_filename('DeltaFiles/high_pop_worlds_blowup/Spinward Marches.sec')

--- a/Tests/testDeltaReduce.py
+++ b/Tests/testDeltaReduce.py
@@ -36,7 +36,7 @@ class testDeltaReduce(baseTest):
             expected = 0
             affix = " not empty after subsector reduction"
             if subsector_name == 'Pact':
-                expected = 37
+                expected = 39
                 affix = " empty after subsector reduction"
             actual = 0 if reducer.sectors['Dagudashaag'][subsector_name].items is None else len(reducer.sectors['Dagudashaag'][subsector_name].items)
             self.assertEqual(expected, actual, subsector_name + affix)


### PR DESCRIPTION
This PR started with adding an is_well_formed() check to SectorDictionary, to verify that each allegiance line in a sector file has at least one starline with that allegiance present, and that each starline maps to one of the present allegiance lines.

Additional changes along the way:
- Add trade-mp to reduction options;
- Unconditionally skip empty (sub) sectors;
- Remove empty allegiances from sector files when writing them out;
- Add bunch of within-line reduction passes;
- Fix existing within-line reduction passes to preserve interestingness;
