### PR TITLE
Speed up jump generation in trade routes

### DIFF
--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -163,9 +163,7 @@ class RouteCalculation(object):
 
         btn += RouteCalculation.get_btn_offset(distance)
         btn = min(btn, RouteCalculation.get_max_btn(star1.wtn, star2.wtn))
-        if min_btn > btn and distance <= max_range:
-            return min_btn
-        return btn
+        return min_btn if min_btn > btn and distance <= max_range else btn
 
     @staticmethod
     def get_passenger_btn(btn, star, neighbor):

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -89,7 +89,7 @@ class RouteCalculation(object):
 
             if dist <= self.galaxy.max_jump_range:
                 weight = self.route_weight(star, neighbor)
-                btn = self.get_btn(star, neighbor)
+                btn = self.get_btn(star, neighbor, dist)
                 excess = (weight / dist - 1)
                 exhaust = 1 + math.ceil(math.log(excess) * multiplier)
                 self.galaxy.stars.add_edge(star.index, neighbor.index, distance=dist,

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -119,9 +119,6 @@ class TradeCalculation(RouteCalculation):
         max_dist = self._max_dist(star.wtn, neighbor.wtn)
         # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
-        if dist > max_dist and dist > self.galaxy.max_jump_range:
-            return None
-
         if dist <= max_dist:
             # Only bother getting btn if the route is inside max length
             btn = self.get_btn(star, neighbor, dist)

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -116,10 +116,10 @@ class TradeCalculation(RouteCalculation):
 
     def base_range_routes(self, star, neighbor):
         dist = star.distance(neighbor)
-        max_dist = self._max_dist(star.wtn, neighbor.wtn)
+        # max_dist = self._max_dist(star.wtn, neighbor.wtn)
         # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
-        if dist <= max_dist:
+        if dist <= self._max_dist(star.wtn, neighbor.wtn):
             # Only bother getting btn if the route is inside max length
             btn = self.get_btn(star, neighbor, dist)
             if btn >= self.min_btn:

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -112,16 +112,6 @@ class TradeCalculation(RouteCalculation):
     def base_route_filter(self, star, neighbor):
         # by the time we've _reached_ here, we're assuming generate_base_routes() has handled the unilateral filtering
         # - in this case, red/forbidden zones and barren systems - so only bilateral filtering remains.
-        # TODO: Bilateral filtering
-        # This would ordinarily be a unilateral filter, but, for hysterical raisins, route and edge filtering are
-        # convolved.  Rather than untangle that, filter out routes with at least one endpoint too small to support the
-        # minimum WTN route here.
-        if self.min_route_wtn > star.wtn or self.min_route_wtn > neighbor.wtn:
-            # Don't filter if, despite the route being too small, it's within the max jump range.  Such stars can still
-            # have trade routes flowing _through_ them, just not _from_ or _to_ them.
-            if self.galaxy.max_jump_range < star.distance(neighbor):
-                return True
-            return False
         return False
 
     def base_range_routes(self, star, neighbor):

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -124,9 +124,7 @@ class TradeCalculation(RouteCalculation):
             btn = self.get_btn(star, neighbor, dist)
             if btn >= self.min_btn:
                 passBTN = self.get_passenger_btn(btn, star, neighbor)
-                self.galaxy.ranges.add_edge(star, neighbor, distance=dist,
-                                            btn=btn,
-                                            passenger_btn=passBTN)
+                self.galaxy.ranges.add_edge(star, neighbor, distance=dist, btn=btn, passenger_btn=passBTN)
 
         return None if dist > self.galaxy.max_jump_range else dist
 

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -128,9 +128,7 @@ class TradeCalculation(RouteCalculation):
                                             btn=btn,
                                             passenger_btn=passBTN)
 
-        if dist > self.galaxy.max_jump_range:
-            return None
-        return dist
+        return None if dist > self.galaxy.max_jump_range else dist
 
     @functools.cache
     def _max_dist(self, star_wtn, neighbour_wtn, maxjump=False):

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -116,15 +116,12 @@ class TradeCalculation(RouteCalculation):
 
     def base_range_routes(self, star, neighbor):
         dist = star.distance(neighbor)
-        # max_dist = self._max_dist(star.wtn, neighbor.wtn)
         # add all the stars in the BTN range, but skip this pair
         # if there there isn't enough trade to warrant a trade check
-        if dist <= self._max_dist(star.wtn, neighbor.wtn):
-            # Only bother getting btn if the route is inside max length
-            btn = self.get_btn(star, neighbor, dist)
-            if btn >= self.min_btn:
-                passBTN = self.get_passenger_btn(btn, star, neighbor)
-                self.galaxy.ranges.add_edge(star, neighbor, distance=dist, btn=btn, passenger_btn=passBTN)
+        btn = self.get_btn(star, neighbor, dist)
+        if btn >= self.min_btn:
+            passBTN = self.get_passenger_btn(btn, star, neighbor)
+            self.galaxy.ranges.add_edge(star, neighbor, distance=dist, btn=btn, passenger_btn=passBTN)
 
         return None if dist > self.galaxy.max_jump_range else dist
 


### PR DESCRIPTION
Spend a bit more effort wringing out route/jump generation in **TradeCalculation**.

Under profiling, after these changes, raw route generation over imperial sectors takes up over 85% of overall jump-gen time and **base_route_ranges()** takes up around 10%.

Over full-orchestra, jump generation at status quo takes 18 min 42 s (1122 s), while as at "Trim redundant max_dist check...", jump generation over full-orchestra takes 17 min 24 s (1044 s) - a 6.9% reduction.

I'm not sure what other gains are achievable in jump generation, given raw route generation and **base_route_ranges()** are both fairly well tuned for speed.