### PR TITLE
Promote allegiance-reduction pass to on-by-default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,15 @@ PyRoute/Pathfinding/*.html
 b*/
 c*/
 d*/
+D*/
+f*/
+k*/
+n*/
+p*/
+s*/
 t*/
 .coverage
 *.log
+*.wiki
+*.png
+*.lprof

--- a/PyRoute/DeltaDebug/DeltaDebug.py
+++ b/PyRoute/DeltaDebug/DeltaDebug.py
@@ -110,8 +110,8 @@ def process() -> None:
                        help="Try all pairs of star lines to see if any can be removed.")
     delta.add_argument('--within-line', dest="run_within", default=False, action='store_true',
                        help="Try to remove irrelevant components (eg base codes) from _within_ individual lines")
-    delta.add_argument('--allegiance', dest="run_allegiance", default=False, action='store_true',
-                       help="Try to remove irrelevant allegiances")
+    delta.add_argument('--no-allegiance', dest="run_allegiance", default=True, action='store_false',
+                       help="Skip removing irrelevant allegiances")
     delta.add_argument('--assume-interesting', dest="run_init", default=True, action='store_false',
                        help="Assume initial input is interesting.")
 

--- a/PyRoute/DeltaDebug/actual_example.md
+++ b/PyRoute/DeltaDebug/actual_example.md
@@ -6,7 +6,7 @@ While setting up the worked example in the delta debugging readme, I discovered 
 The set up is the same as the worked example, but the command line is different (I didn't specify any interesting-related restrictions):
 
 ```
-python ./PyRoute/DeltaDebug/DeltaDebug.py --min-btn 15 --max-jump 2 --routes trade --borders erode --pop-code scaled --min-dir ./reduced/ --output ./prof-maps/ --sectors ./deltalist.txt --input ./deltasectors/
+python ./PyRoute/DeltaDebug/DeltaDebug.py --min-btn 15 --max-jump 2 --routes trade --borders erode --pop-code scaled --min-dir ./reduced/ --output ./prof-maps/ --sectors ./deltalist.txt --input ./deltasectors/ --no-allegiance
 ```
 
 The result wasn't what I was expecting:


### PR DESCRIPTION
As it says on the tin, promote the allegiance-reduction pass from off-by-default to on-by-default, and update delta debugging docs to match.