### PR TITLE
Tighten raw trade route filtering

### DIFF
--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -127,15 +127,13 @@ class RouteCalculation(object):
         Calculate the BTN between two stars, which is the sum of the worlds
         WTNs plus a modifier for types, minus a modifier for distance.
         """
-        btn = star1.wtn + star2.wtn
+        btn = star1.wtn + star2.wtn + RouteCalculation._get_btn_allies(star1.alg_code, star2.alg_code)
         code1 = star1.tradeCode
         code2 = star2.tradeCode
-        if code1.ag_code_boost and (code1.agricultural or code2.agricultural):
+        if code1.ag_code_boost and code2.ag_code_boost and (code1.agricultural or code2.agricultural):
             btn += 1 if code1.match_ag_codes(code2) else 0
-        if code1.in_code_boost and (code1.industrial or code2.industrial):
+        if code1.in_code_boost and code2.in_code_boost and (code1.industrial or code2.industrial):
             btn += 1 if code1.match_in_codes(code2) else 0
-
-        btn += RouteCalculation._get_btn_allies(star1.alg_code, star2.alg_code)
 
         if not distance:
             distance = star1.distance(star2)

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -130,9 +130,9 @@ class RouteCalculation(object):
         btn = star1.wtn + star2.wtn
         code1 = star1.tradeCode
         code2 = star2.tradeCode
-        if code1.agricultural or code2.agricultural:
+        if code1.ag_code_boost and (code1.agricultural or code2.agricultural):
             btn += 1 if code1.match_ag_codes(code2) else 0
-        if code1.industrial or code2.industrial:
+        if code1.in_code_boost and (code1.industrial or code2.industrial):
             btn += 1 if code1.match_in_codes(code2) else 0
 
         btn += RouteCalculation._get_btn_allies(star1.alg_code, star2.alg_code)

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -169,7 +169,7 @@ class RouteCalculation(object):
         # Default assumes BTN is boosted by both agricultural and industrial matches
         # Offset of 1 assumes BTN is boosted by one match, agricultural xor industrial
         # Offset of 0 assumes no boost.
-        btn = star1.wtn + star2.wtn + offset
+        btn = star1.wtn + star2.wtn + offset + RouteCalculation._get_btn_allies(star1.alg_code, star2.alg_code)
 
         if not distance:
             distance = star1.distance(star2)

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -166,7 +166,9 @@ class RouteCalculation(object):
         max_range apart in pc, set the returned BTN upper bound to greater of upper-bounded BTN and
         supplied min_btn.
         """
-        # Assuming BTN, as per self.get_btn, is boosted by both agricultural and industrial matches
+        # Default assumes BTN is boosted by both agricultural and industrial matches
+        # Offset of 1 assumes BTN is boosted by one match, agricultural xor industrial
+        # Offset of 0 assumes no boost.
         btn = star1.wtn + star2.wtn + offset
 
         if not distance:

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -158,7 +158,7 @@ class RouteCalculation(object):
         return mod
 
     @staticmethod
-    def _get_btn_upper_bound(star1, star2, max_range, min_btn, distance=None):
+    def _get_btn_upper_bound(star1, star2, max_range, min_btn, distance=None, offset: int = 2):
         """
         Return an _upper bound_ on the BTN between star1 and star2.  If the upper bound on BTN
         doesn't meet/beat the minimum BTN, then the _actual_ BTN, which also doesn't meet/beat
@@ -167,7 +167,7 @@ class RouteCalculation(object):
         supplied min_btn.
         """
         # Assuming BTN, as per self.get_btn, is boosted by both agricultural and industrial matches
-        btn = star1.wtn + star2.wtn + 2
+        btn = star1.wtn + star2.wtn + offset
 
         if not distance:
             distance = star1.distance(star2)

--- a/PyRoute/Calculation/RouteCalculation.py
+++ b/PyRoute/Calculation/RouteCalculation.py
@@ -135,11 +135,7 @@ class RouteCalculation(object):
         if code1.industrial or code2.industrial:
             btn += 1 if code1.match_in_codes(code2) else 0
 
-        if not AllyGen.are_allies(star1.alg_code, star2.alg_code):
-            btn -= 1
-
-            if star1.alg_code == 'Wild' or star2.alg_code == 'Wild':
-                btn -= 1
+        btn += RouteCalculation._get_btn_allies(star1.alg_code, star2.alg_code)
 
         if not distance:
             distance = star1.distance(star2)
@@ -147,6 +143,19 @@ class RouteCalculation(object):
         btn += RouteCalculation.get_btn_offset(distance)
 
         return min(btn, RouteCalculation.get_max_btn(star1.wtn, star2.wtn))
+
+    @staticmethod
+    @functools.cache
+    def _get_btn_allies(code1: Optional[str], code2: Optional[str]) -> int:
+        if isinstance(code1, str) and isinstance(code2, str) and code1 > code2:
+            return RouteCalculation._get_btn_allies(code2, code1)
+        mod = 0
+        if not AllyGen.are_allies(code1, code2):
+            mod -= 1
+
+            if code1 == 'Wild' or code2 == 'Wild':
+                mod -= 1
+        return mod
 
     @staticmethod
     def _get_btn_upper_bound(star1, star2, max_range, min_btn, distance=None):

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -148,9 +148,21 @@ class TradeCalculation(RouteCalculation):
         hiball = [item for item in self.galaxy.ranges if item.wtn >= min_wtn and not item.is_redzone]
         loball = [item for item in self.galaxy.ranges if item.wtn < min_wtn and not item.is_redzone]
 
+        def two_boost(x):
+            return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
+                    and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) and \
+                   (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost
+                    and (x[0].tradeCode.industrial or x[1].tradeCode.industrial))
+
+        def one_boost(x):
+            return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
+                    and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) ^ \
+                   (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost
+                    and (x[0].tradeCode.industrial or x[1].tradeCode.industrial))
+
         def foo_boost(x):
             return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
-                    and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) or\
+                    and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) or \
                    (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost
                     and (x[0].tradeCode.industrial or x[1].tradeCode.industrial))
 
@@ -158,19 +170,23 @@ class TradeCalculation(RouteCalculation):
                   if (dist := star.distance(neighbour)) <= self._max_dist(star.wtn, neighbour.wtn, True)
                   and self._get_btn_upper_bound(star, neighbour, max_range, min_btn, distance=dist) >= min_btn
                   ]
-        hi_hi_ranges = [(star, neighbour) for (star, neighbour) in filter(foo_boost, ranges)]
-        hi_hi_ranges1 = [(star, neighbour) for (star, neighbour) in itertools.filterfalse(foo_boost, ranges)
-                  if self._get_btn_upper_bound(star, neighbour, max_range, min_btn, offset=0) >= min_btn
-                  ]
+        hi_hi_ranges = [(star, neighbour) for (star, neighbour) in filter(two_boost, ranges)]
+        hi_hi_ranges1 = [(star, neighbour) for (star, neighbour) in filter(one_boost, ranges)
+                         if self._get_btn_upper_bound(star, neighbour, max_range, min_btn, offset=1) >= min_btn
+                         ]
+        hi_hi_ranges2 = [(star, neighbour) for (star, neighbour) in itertools.filterfalse(foo_boost, ranges)
+                         if self._get_btn_upper_bound(star, neighbour, max_range, min_btn, offset=0) >= min_btn
+                         ]
         lo_lo_ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(loball, 2)
-                     if (star.distance(neighbour)) <= max_range
-                     ]
+                        if (star.distance(neighbour)) <= max_range
+                        ]
         hi_lo_ranges = [(star, neighbour) for (star, neighbour) in itertools.product(hiball, loball)
-                      if (star.distance(neighbour)) <= max_range
-                      ]
+                        if (star.distance(neighbour)) <= max_range
+                        ]
         hi_hi_ranges.extend(lo_lo_ranges)
         hi_hi_ranges.extend(hi_lo_ranges)
         hi_hi_ranges.extend(hi_hi_ranges1)
+        hi_hi_ranges.extend(hi_hi_ranges2)
         self.logger.info("Routes with endpoints more than " + str(max_route_dist) + " pc apart, trimmed")
 
         return hi_hi_ranges

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -149,8 +149,10 @@ class TradeCalculation(RouteCalculation):
         loball = [item for item in self.galaxy.ranges if item.wtn < min_wtn and not item.is_redzone]
 
         def foo_boost(x):
-            return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost) or\
-                   (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost)
+            return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
+                    and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) or\
+                   (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost
+                    and (x[0].tradeCode.industrial or x[1].tradeCode.industrial))
 
         ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(hiball, 2)
                   if (dist := star.distance(neighbour)) <= self._max_dist(star.wtn, neighbour.wtn, True)

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -148,9 +148,17 @@ class TradeCalculation(RouteCalculation):
         hiball = [item for item in self.galaxy.ranges if item.wtn >= min_wtn and not item.is_redzone]
         loball = [item for item in self.galaxy.ranges if item.wtn < min_wtn and not item.is_redzone]
 
-        hi_hi_ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(hiball, 2)
+        def foo_boost(x):
+            return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost) or\
+                   (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost)
+
+        ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(hiball, 2)
                   if (dist := star.distance(neighbour)) <= self._max_dist(star.wtn, neighbour.wtn, True)
                   and self._get_btn_upper_bound(star, neighbour, max_range, min_btn, distance=dist) >= min_btn
+                  ]
+        hi_hi_ranges = [(star, neighbour) for (star, neighbour) in filter(foo_boost, ranges)]
+        hi_hi_ranges1 = [(star, neighbour) for (star, neighbour) in itertools.filterfalse(foo_boost, ranges)
+                  if self._get_btn_upper_bound(star, neighbour, max_range, min_btn, offset=0) >= min_btn
                   ]
         lo_lo_ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(loball, 2)
                      if (star.distance(neighbour)) <= max_range
@@ -160,6 +168,7 @@ class TradeCalculation(RouteCalculation):
                       ]
         hi_hi_ranges.extend(lo_lo_ranges)
         hi_hi_ranges.extend(hi_lo_ranges)
+        hi_hi_ranges.extend(hi_hi_ranges1)
         self.logger.info("Routes with endpoints more than " + str(max_route_dist) + " pc apart, trimmed")
 
         return hi_hi_ranges

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -148,19 +148,19 @@ class TradeCalculation(RouteCalculation):
         hiball = [item for item in self.galaxy.ranges if item.wtn >= min_wtn and not item.is_redzone]
         loball = [item for item in self.galaxy.ranges if item.wtn < min_wtn and not item.is_redzone]
 
-        def two_boost(x):
+        def two_boost(x: tuple[Star, Star]) -> bool:
             return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
                     and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) and \
                    (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost
                     and (x[0].tradeCode.industrial or x[1].tradeCode.industrial))
 
-        def one_boost(x):
+        def one_boost(x: tuple[Star, Star]) -> bool:
             return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
                     and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) ^ \
                    (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost
                     and (x[0].tradeCode.industrial or x[1].tradeCode.industrial))
 
-        def foo_boost(x):
+        def foo_boost(x: tuple[Star, Star]) -> bool:
             return (x[0].tradeCode.ag_code_boost and x[1].tradeCode.ag_code_boost
                     and (x[0].tradeCode.agricultural or x[1].tradeCode.agricultural)) or \
                    (x[0].tradeCode.in_code_boost and x[1].tradeCode.in_code_boost

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -148,21 +148,21 @@ class TradeCalculation(RouteCalculation):
         hiball = [item for item in self.galaxy.ranges if item.wtn >= min_wtn and not item.is_redzone]
         loball = [item for item in self.galaxy.ranges if item.wtn < min_wtn and not item.is_redzone]
 
-        ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(hiball, 2)
+        hi_hi_ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(hiball, 2)
                   if (dist := star.distance(neighbour)) <= self._max_dist(star.wtn, neighbour.wtn, True)
                   and self._get_btn_upper_bound(star, neighbour, max_range, min_btn, distance=dist) >= min_btn
                   ]
-        lo_ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(loball, 2)
+        lo_lo_ranges = [(star, neighbour) for (star, neighbour) in itertools.combinations(loball, 2)
                      if (star.distance(neighbour)) <= max_range
                      ]
-        mid_ranges = [(star, neighbour) for (star, neighbour) in itertools.product(hiball, loball)
+        hi_lo_ranges = [(star, neighbour) for (star, neighbour) in itertools.product(hiball, loball)
                       if (star.distance(neighbour)) <= max_range
                       ]
-        ranges.extend(lo_ranges)
-        ranges.extend(mid_ranges)
+        hi_hi_ranges.extend(lo_lo_ranges)
+        hi_hi_ranges.extend(hi_lo_ranges)
         self.logger.info("Routes with endpoints more than " + str(max_route_dist) + " pc apart, trimmed")
 
-        return ranges
+        return hi_hi_ranges
 
     def generate_routes(self) -> None:
         """

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -643,6 +643,14 @@ class TradeCodes(object):
     def low_per_capita_gwp(self) -> bool:
         return self.extreme or self.poor or self.nonindustrial or self.low
 
+    @functools.cached_property
+    def ag_code_boost(self) -> bool:
+        return self.agricultural or self.needs_agricultural
+
+    @functools.cached_property
+    def in_code_boost(self) -> bool:
+        return self.industrial or self.nonindustrial
+
     def match_ag_codes(self, code) -> bool:
         return (self.agricultural and code.needs_agricultural) or (self.needs_agricultural and code.agricultural)
 

--- a/Tests/StatCalculation/testStatCalculation.py
+++ b/Tests/StatCalculation/testStatCalculation.py
@@ -424,10 +424,10 @@ class testStatCalculation(baseTest):
             self.assertEqual(exp_logs, output)
 
         exp_port_size = NoNoneDefaultDict(int)
-        exp_port_size[0] = 8
+        exp_port_size[0] = 7
         exp_port_size[2] = 4
         exp_port_size[3] = 10
-        exp_port_size[4] = 9
+        exp_port_size[4] = 10
         exp_port_size[5] = 6
         exp_port_size['A'] = 6
         exp_port_size['B'] = 22
@@ -478,11 +478,11 @@ class testStatCalculation(baseTest):
         self.assertEqual(100376, galstat.economy)
         self.assertEqual(37, galstat.number)
         self.assertEqual(38046, galstat.sum_ru)
-        self.assertEqual(223150000000, galstat.tradeVol)
+        self.assertEqual(224150000000, galstat.tradeVol)
         self.assertEqual(3178.4, galstat.col_be)
         self.assertAlmostEqual(1135.98, galstat.im_be, 3)
         self.assertEqual(14796000, galstat.passengers)
-        self.assertEqual(44450, galstat.spa_people)
+        self.assertEqual(44750, galstat.spa_people)
         self.assertEqual(exp_port_size, galstat.port_size)
         self.assertEqual(exp_code_count, galstat.code_counts)
         self.assertEqual(35, galstat.gg_count)
@@ -500,13 +500,13 @@ class testStatCalculation(baseTest):
         self.assertEqual(galstat.__dict__, galaxy.sectors['Zarushagar'].subsectors['A'].stats.__dict__)
         self.assertEqual([high_pop_star], galaxy.sectors['Zarushagar'].subsectors['A'].stats.high_pop_worlds)
         expected_starport_budgets = {0: 35.0, 1: 0, 2: 92.0, 3: 102.0, 4: 14.0, 5: 118.0, 6: 20.0, 7: 6.0, 8: 209.0,
-                                     9: 280.0, 10: 0, 11: 219.0, 12: 0, 13: 1.0, 14: 4.0, 15: 53.0, 16: 0, 17: 1403.0,
-                                     18: 1435.0, 19: 0, 20: 26.0, 21: 0, 22: 93.0, 23: 20.0, 24: 787.0, 25: 0,
+                                     9: 280.0, 10: 0, 11: 219.0, 12: 0, 13: 1.0, 14: 4.0, 15: 53.0, 16: 0, 17: 1409.0,
+                                     18: 1435.0, 19: 0, 20: 26.0, 21: 0, 22: 93.0, 23: 20.0, 24: 181.0, 25: 0,
                                      26: 1854.0, 27: 8.0, 28: 0, 29: 0, 30: 0, 31: 1.0, 32: 11.0, 33: 17.0, 34: 1309.0,
-                                     35: 773.0, 36: 0}
+                                     35: 773.0, 36: 660}
         expected_starport_sizes = {0: 4, 1: 2, 2: 4, 3: 4, 4: 3, 5: 4, 6: 3, 7: 3, 8: 4, 9: 4, 10: 0, 11: 4, 12: 2,
-                                   13: 3, 14: 3, 15: 4, 16: 0, 17: 5, 18: 5, 19: 0, 20: 3, 21: 0, 22: 4, 23: 3, 24: 5,
-                                   25: 0, 26: 5, 27: 3, 28: 2, 29: 0, 30: 0, 31: 2, 32: 3, 33: 3, 34: 5, 35: 5, 36: 0}
+                                   13: 3, 14: 3, 15: 4, 16: 0, 17: 5, 18: 5, 19: 0, 20: 3, 21: 0, 22: 4, 23: 3, 24: 4,
+                                   25: 0, 26: 5, 27: 3, 28: 2, 29: 0, 30: 0, 31: 2, 32: 3, 33: 3, 34: 5, 35: 5, 36: 5}
         for starnum in expected_starport_budgets:
             budget_star = galaxy.stars.nodes[starnum]['star']
             self.assertEqual(expected_starport_budgets[starnum], budget_star.starportBudget,


### PR DESCRIPTION
As it says on the tin, tighten up the filtering in `TradeCalculation._raw_routes` to try to minimise the number of `RouteCalculation.get_btn` calls.

As at status quo, full-orchestra, min BTN 15, J-4, gives:
`26,746 hiball stars`
`22,087 loball stars`

`7,665,255 ranges` after filtering

As at "Tighten code-boost filtering in get_btn", the star counts are the same, but
`2,692,896 ranges` after filtering

That's a 64.8% reduction in post-filtering ranges.

Total routes actually pathfinded, in both cases, are `2,232,309`.
Penumbral routes:
master: `985,900`
"Tighten code-boost...": `979,462`

Pathfinding times:
master: `4855`s
"Tighten code-boost...": `4589`s

As a result of the savings in route filtering, that's a 5.4% saving in pathfinding time.

