### PR TITLE
Add debug option to fix econ-based trade codes in flight

### DIFF
--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -79,6 +79,7 @@ class Galaxy(AreaItem):
         pop_code = options.pop_code
         ru_calc = options.ru_calc
         fix_pop = options.fix_pop
+        fix_econ = False
         self._set_trade_object(route_reuse, trade_choice, route_btn, mp_threads, debug_flag)
         star_counter = 0
         loaded_sectors: set[str] = set()
@@ -94,7 +95,7 @@ class Galaxy(AreaItem):
             sec, raw_counter = ParseSectorInput.read_parsed_sector_to_sector_object(headers, loaded_sectors, logger,
                                                                                     pop_code, ru_calc, sector,
                                                                                     star_counter, starlines, self,
-                                                                                    fix_pop)
+                                                                                    fix_pop, fix_econ)
             if sec is None:
                 continue
             star_counter = raw_counter

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -79,7 +79,7 @@ class Galaxy(AreaItem):
         pop_code = options.pop_code
         ru_calc = options.ru_calc
         fix_pop = options.fix_pop
-        fix_econ = False
+        fix_econ = options.fix_econ
         self._set_trade_object(route_reuse, trade_choice, route_btn, mp_threads, debug_flag)
         star_counter = 0
         loaded_sectors: set[str] = set()

--- a/PyRoute/AreaItems/Galaxy.py
+++ b/PyRoute/AreaItems/Galaxy.py
@@ -91,9 +91,10 @@ class Galaxy(AreaItem):
             if 0 == len(headers):
                 continue
 
-            sec, raw_counter = ParseSectorInput.read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors,
-                                                                                    logger, pop_code, ru_calc, sector,
-                                                                                    star_counter, starlines, self)
+            sec, raw_counter = ParseSectorInput.read_parsed_sector_to_sector_object(headers, loaded_sectors, logger,
+                                                                                    pop_code, ru_calc, sector,
+                                                                                    star_counter, starlines, self,
+                                                                                    fix_pop)
             if sec is None:
                 continue
             star_counter = raw_counter

--- a/PyRoute/DataClasses/ReadSectorOptions.py
+++ b/PyRoute/DataClasses/ReadSectorOptions.py
@@ -17,5 +17,6 @@ class ReadSectorOptions:
     mp_threads: int = 1
     debug_flag: bool = False
     fix_pop: bool = False
+    fix_econ: bool = False
     deep_space: dict = None
     map_type: str = 'classic'

--- a/PyRoute/DeltaStar.py
+++ b/PyRoute/DeltaStar.py
@@ -80,9 +80,9 @@ class DeltaStar(Star):
         return DeltaStar.reduce(original, drop_noble_codes=True, drop_base_codes=True, drop_trade_zone=True)
 
     @staticmethod
-    def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False):
+    def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False, fix_econ=False):
         star = DeltaStar()
-        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop)
+        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop, fix_econ=fix_econ)
 
     def reduce_routes(self) -> None:
         self.routes = []

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -136,7 +136,7 @@ class ParseSectorInput:
 
     @staticmethod
     def read_parsed_sector_to_sector_object(headers, loaded_sectors, logger, pop_code, ru_calc, sector, star_counter,
-                                            starlines, galaxy, fix_pop):
+                                            starlines, galaxy, fix_pop, fix_econ):
         logger.debug('reading %s ' % sector)
 
         sec = Sector(headers[3], headers[4])
@@ -154,7 +154,7 @@ class ParseSectorInput:
         ParseSectorInput.parse_subsectors(headers, sec.name, sec)
 
         for line in starlines:
-            star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop)
+            star = Star.parse_line_into_star(line, sec, pop_code, ru_calc, fix_pop=fix_pop, fix_econ=fix_econ)
             if star:
                 star_counter = galaxy.add_star_to_galaxy(star, star_counter, sec)
 

--- a/PyRoute/Inputs/ParseSectorInput.py
+++ b/PyRoute/Inputs/ParseSectorInput.py
@@ -135,8 +135,8 @@ class ParseSectorInput:
         return sector
 
     @staticmethod
-    def read_parsed_sector_to_sector_object(fix_pop, headers, loaded_sectors, logger, pop_code, ru_calc, sector,
-                                            star_counter, starlines, galaxy):
+    def read_parsed_sector_to_sector_object(headers, loaded_sectors, logger, pop_code, ru_calc, sector, star_counter,
+                                            starlines, galaxy, fix_pop):
         logger.debug('reading %s ' % sector)
 
         sec = Sector(headers[3], headers[4])

--- a/PyRoute/Inputs/ParseStarInput.py
+++ b/PyRoute/Inputs/ParseStarInput.py
@@ -57,7 +57,7 @@ class ParseStarInput:
     valid_nobles = 'BCcDEeFfGH-'
 
     @staticmethod
-    def parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=False):
+    def parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=False, fix_econ=False):
         star.sector = sector
         star.logger.debug(line)
         data, is_station = ParseStarInput._unpack_starline(star, line, sector)
@@ -131,7 +131,7 @@ class ParseStarInput:
         star.starportBudget = 0
         star.starportPop = 0
 
-        star.tradeCode.check_world_codes(star, fix_pop=fix_pop)
+        star.tradeCode.check_world_codes(star, fix_pop=fix_pop, fix_econ=fix_econ)
 
         if data[5] and data[5].startswith('{'):
             raw_imp = data[5][1:-1].strip()

--- a/PyRoute/Star.py
+++ b/PyRoute/Star.py
@@ -139,10 +139,10 @@ class Star(object):
         setattr(self, key, value)
 
     @staticmethod
-    def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False):
+    def parse_line_into_star(line, sector, pop_code, ru_calc, fix_pop=False, fix_econ=False):
         from PyRoute.Inputs.ParseStarInput import ParseStarInput
         star = Star()
-        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop)
+        return ParseStarInput.parse_line_into_star_core(star, line, sector, pop_code, ru_calc, fix_pop=fix_pop, fix_econ=fix_econ)
 
     def parse_to_line(self) -> str:
         result = str(self.position) + " "

--- a/PyRoute/TradeCodes.py
+++ b/PyRoute/TradeCodes.py
@@ -451,17 +451,21 @@ class TradeCodes(object):
             listmsg.append(msg)
         return False
 
-    def check_world_codes(self, star, msg=None, fix_pop=False) -> Union[bool, list]:
+    def check_world_codes(self, star, msg=None, fix_pop=False, fix_econ=False) -> Union[bool, list]:
         is_list = isinstance(msg, list)
         msg = msg if is_list else None
 
         check = True
         if fix_pop is True:
             self._fix_all_pop_codes(star)
+        if fix_econ is True:
+            self._fix_all_econ_codes(star)
 
         # Do the may-be-implied codes first, then everything else
-        check = self._check_econ_code(star, 'In', '012479ABC', None, '9ABCDEF', msg, "Hi") and check
         check = self._check_planet_code(star, 'As', '0', '0', '0', msg, 'Va') and check
+
+        if fix_econ is not True:
+            check = self._check_all_econ_codes(check, msg, star)
 
         check = self._check_planet_code(star, 'De', None, '23456789', '0', msg) and check
         check = self._check_planet_code(star, 'Fl', None, 'ABC', '123456789A', msg) and check
@@ -472,13 +476,6 @@ class TradeCodes(object):
         check = self._check_planet_code(star, 'Oc', 'ABCDEF', '3456789DEF', 'A', msg) and check
         check = self._check_planet_code(star, 'Va', None, '0', None, msg) and check
         check = self._check_planet_code(star, 'Wa', '3456789', '3456789DEF', 'A', msg) and check
-
-        check = self._check_econ_code(star, 'Pa', '456789', '45678', '48', msg) and check
-        check = self._check_econ_code(star, 'Ag', '456789', '45678', '567', msg) and check
-        check = self._check_econ_code(star, 'Na', '0123', '0123', '6789ABCDEF', msg) and check
-        check = self._check_econ_code(star, 'Pi', '012479', None, '78', msg) and check
-        check = self._check_econ_code(star, 'Pr', '68', None, '59', msg) and check
-        check = self._check_econ_code(star, 'Ri', '68', None, '678', msg) and check
 
         if fix_pop is not True:
             check = self._check_all_pop_codes(check, msg, star)
@@ -493,6 +490,17 @@ class TradeCodes(object):
         check = self._check_pop_code(star, 'Ni', '456', msg) and check
         check = self._check_pop_code(star, 'Ph', '8', msg) and check
         check = self._check_pop_code(star, 'Hi', '9ABCDEF', msg) and check
+        return check
+
+    def _check_all_econ_codes(self, check, msg, star):
+        check = self._check_econ_code(star, 'In', '012479ABC', None, '9ABCDEF', msg, "Hi") and check
+        check = self._check_econ_code(star, 'Pa', '456789', '45678', '48', msg) and check
+        check = self._check_econ_code(star, 'Ag', '456789', '45678', '567', msg) and check
+        check = self._check_econ_code(star, 'Na', '0123', '0123', '6789ABCDEF', msg) and check
+        check = self._check_econ_code(star, 'Pi', '012479', None, '78', msg) and check
+        check = self._check_econ_code(star, 'Pr', '68', None, '59', msg) and check
+        check = self._check_econ_code(star, 'Ri', '68', None, '678', msg) and check
+
         return check
 
     def owned_by(self, star) -> Union[str, None]:
@@ -778,13 +786,7 @@ class TradeCodes(object):
         self._fix_trade_code(star, 'Oc', 'ABCDEF', '3456789DEF', 'A')
         self._fix_trade_code(star, 'Va', None, '0', None)
 
-        self._fix_econ_code(star, 'Na', '0123', '0123', '6789ABCDEF')
-        self._fix_econ_code(star, 'Pi', '012479', None, '78')
-        self._fix_econ_code(star, 'Pa', '456789', '45678', '48')
-        self._fix_econ_code(star, 'Ag', '456789', '45678', '567')
-        self._fix_econ_code(star, 'Pr', '68', None, '59')
-        self._fix_econ_code(star, 'In', '012479ABC', None, '9ABCDEF')
-        self._fix_econ_code(star, 'Ri', '68', None, '678')
+        self._fix_all_econ_codes(star)
 
         self._fix_all_pop_codes(star)
         self._drop_invalid_trade_code('O:' + star.position)
@@ -849,6 +851,15 @@ class TradeCodes(object):
         self._fix_pop_code(star, 'Ni', '456')
         self._fix_pop_code(star, 'Ph', '8')
         self._fix_pop_code(star, 'Hi', '9ABCDEF')
+
+    def _fix_all_econ_codes(self, star):
+        self._fix_econ_code(star, 'In', '012479ABC', None, '9ABCDEF')
+        self._fix_econ_code(star, 'Na', '0123', '0123', '6789ABCDEF')
+        self._fix_econ_code(star, 'Pi', '012479', None, '78')
+        self._fix_econ_code(star, 'Pa', '456789', '45678', '48')
+        self._fix_econ_code(star, 'Ag', '456789', '45678', '567')
+        self._fix_econ_code(star, 'Pr', '68', None, '59')
+        self._fix_econ_code(star, 'Ri', '68', None, '678')
 
     def _drop_invalid_trade_code(self, targcode):
         self.codes = [code for code in self.codes if code != targcode]

--- a/PyRoute/route.py
+++ b/PyRoute/route.py
@@ -83,6 +83,8 @@ def process() -> None:
                            help="Turn on trade-route debugging")
     debugging.add_argument('--fix-pop', dest="fix_pop", default=False, action=argparse.BooleanOptionalAction,
                            help="Fix incorrect pop codes when loading stars")
+    debugging.add_argument('--fix-econ', dest="fix_econ", default=False, action=argparse.BooleanOptionalAction,
+                           help="Fix incorrect econ codes when loading stars")
 
     parser.add_argument('--version', action='version', version='%(prog)s 0.4')
     parser.add_argument('--log-level', default='INFO')
@@ -129,7 +131,7 @@ def process() -> None:
     readparms = ReadSectorOptions(sectors=sectors_list, pop_code=args.pop_code, ru_calc=args.ru_calc,
                                   route_reuse=args.route_reuse, trade_choice=args.routes, route_btn=args.route_btn,
                                   mp_threads=args.mp_threads, debug_flag=args.debug_flag, fix_pop=args.fix_pop,
-                                  deep_space=deep_space, map_type=args.map_type)
+                                  deep_space=deep_space, map_type=args.map_type, fix_econ=args.fix_econ)
     galaxy.read_sectors(readparms)
 
     # galaxy.read_sectors(sectors_list, args.pop_code, args.ru_calc,


### PR DESCRIPTION
Much like #107 , I again got tired of crap filling up the logs of full-orchestra runs.  

As at status-quo with `fix-pop` enabled, on the Dec 23, 2023 Traveller map data: 7,582 parsing complaints, 893 kilobytes
As at HEAD, with both `fix-pop` and `fix-econ` enabled on same data: 4,299 parsing complaints, 520 kilobytes

For @bobbyjim , et al:

As at status-quo:
|Code | Type | Invalid | Calculated | Total |
| ----- | -----: |  -----: |  -----: |  -----: |
| Ag | Econ | 260 | 118 | 378 |
| In | Econ |250 | 116 | 366 |
| Na | Econ | 93 | 76 | 169 |
| Pa | Econ | 0 | 656 | 656 |
| Pi | Econ | 0 | 812 | 812 |
| Pr | Econ | 6 | 477 | 483 |
| Ri | Econ | 57 | 362 | 417 |
| **Econ** | **Subtotal** | **666** | **2,617** | **3,283** |
| As | Planet | 2 | 6 | 8 |
| De | Planet | 227 | 41 | 268 |
| Fl | Planet | 189 | 44 | 233 |
| Ga | Planet | 6 | 906 | 912 |
| He | Planet | 1 | 1,179 | 1,180 |
| Ic | Planet | 2 | 39 | 41 |
| Oc | Planet | 1 | 99 | 100 |
| Po | Planet | 86 | 201 | 287 |
| Va | Planet | 3 | 62 | 65 |
| Wa | Planet | 179 | 30 | 209 |
| **Planet** | **Subtotal** | **696** | **2,607** | **3,303** |
| **GRAND** | **TOTAL** | **1,362** | **5,224** | **6,586** |

The remaining 996 parsing complaints break down as:
Disallowed residual trade code - 36
Importance mismatch - 26
Acceptance mismatch - 931
Symbols mismatch - 3

As at HEAD:
|Code | Type | Invalid | Calculated | Total |
| ----- | -----: |  -----: |  -----: |  -----: |
| Ag | Econ | 0 | 0 | 0 |
| In | Econ |0 | 0 | 0 |
| Na | Econ | 0 | 0 | 0 |
| Pa | Econ | 0 | 0 | 0 |
| Pi | Econ | 0 | 0 | 0 |
| Pr | Econ | 0 | 0 | 0 |
| Ri | Econ | 0 | 0 | 0 |
| **Econ** | **Subtotal** | **0** | **0** | **0** |
| As | Planet | 2 | 6 | 8 |
| De | Planet | 227 | 41 | 268 |
| Fl | Planet | 189 | 44 | 233 |
| Ga | Planet | 6 | 906 | 912 |
| He | Planet | 1 | 1,179 | 1,180 |
| Ic | Planet | 2 | 39 | 41 |
| Oc | Planet | 1 | 99 | 100 |
| Po | Planet | 86 | 201 | 287 |
| Va | Planet | 3 | 62 | 65 |
| Wa | Planet | 179 | 30 | 209 |
| **Planet** | **Subtotal** | **696** | **2,607** | **3,303** |
| **GRAND** | **TOTAL** | **696** | **2,607** | **3,303** |

The remaining 996 parsing complaints break down as:
Disallowed residual trade code - 36
Importance mismatch - 26
Acceptance mismatch - 931
Symbols mismatch - 3