### PR TITLE
Chase down landmark borkage in fallback

### DIFF
--- a/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
+++ b/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
@@ -24,7 +24,7 @@ def dijkstra_core(arcs, distance_labels, divisor, seeds, max_neighbour_labels, m
     diagnostics = {'nodes_processed': 0, 'nodes_queued': len(heap), 'nodes_exceeded': 0, 'nodes_min_exceeded': 0,
                    'nodes_tailed': 0}
 
-    parents = np.ones(len(arcs)) * -100  # Using -100 to track "not considered during processing"
+    parents = np.ones(len(arcs), dtype=int) * -100  # Using -100 to track "not considered during processing"
     parents[list(seeds)] = -1  # Using -1 to flag "root node of tree"
 
     while heap:

--- a/Tests/Pathfinding/Schemas/testLandmarkAvoidHelper.py
+++ b/Tests/Pathfinding/Schemas/testLandmarkAvoidHelper.py
@@ -10,7 +10,7 @@ from PyRoute.DeltaDebug.DeltaGalaxy import DeltaGalaxy
 from PyRoute.Pathfinding.DistanceGraph import DistanceGraph
 from PyRoute.Pathfinding.LandmarkSchemes.LandmarkAvoidHelper import LandmarkAvoidHelper
 from Tests.baseTest import baseTest
-from PyRoute.Pathfinding.single_source_dijkstra import explicit_shortest_path_dijkstra_distance_graph
+from PyRoute.Pathfinding.single_source_dijkstra_core_fallback import dijkstra_core
 
 
 class testLandmarkAvoidHelper(baseTest):
@@ -23,8 +23,10 @@ class testLandmarkAvoidHelper(baseTest):
 
         distance_labels = np.ones(len(graph)) * float('+inf')
         distance_labels[source] = 0
-        actual_distances, actual_parents, _, _ = explicit_shortest_path_dijkstra_distance_graph(distgraph, source,
-                                                                                                distance_labels)
+        max_labels = np.ones((num_stars), dtype=float) * float('+inf')
+        min_cost = distgraph.min_cost(0, True)
+
+        actual_distances, actual_parents, _, _ = dijkstra_core(distgraph._arcs, distance_labels, 1.0, [source], max_labels, min_cost)
         lobound = np.zeros(num_stars, dtype=float)
         expected_weights = actual_distances
         actual_weights = LandmarkAvoidHelper.calc_weights(actual_distances, lobound)

--- a/Tests/Pathfinding/testSingleSourceDijkstraCoreFallback.py
+++ b/Tests/Pathfinding/testSingleSourceDijkstraCoreFallback.py
@@ -41,6 +41,7 @@ class testSingleSourceDijkstraCoreFallback(baseTest):
 
         nu_labels, nu_parents, nu_max, nu_diagnostics = dijkstra_core(dist_graph._arcs, dist_labels, float(1.0 / 1.1),
                                                         [source], max_labels, min_cost)
+        self.assertEqual('int64', str(nu_parents.dtype))
         exp_labels = [0.0, 158.18181818181816, 199.99999999999997, 222.7272727272727, 241.81818181818178,
                       49.090909090909086, 114.54545454545453, 241.81818181818178, 67.27272727272727, 108.18181818181817,
                       132.72727272727272, 150.0, 216.36363636363637, 241.8181818181818, 90.9090909090909,


### PR DESCRIPTION
For unrelaed reasons, I was trying to run pathfinding against the non-cython versions of `astar_path_numpy` and `single_source_dijkstra_core`.  Landmark generation blew up with an IndexError, complaining that floats couldn't be used as indices into arrays.

A bit of investigation revealed the proximate culprit to be the creation of the parents array inside the non-cython version of `single_source_dijkstra_core` - NumPy arrays default to the `float64` dtype unless specified.  After that, a quick change to a test verified that the test suite now caught the issue, and verified that the root cause remains solved.