### PR TITLE
Speed up fallback astar and dijkstra versions

### DIFF
--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -427,17 +427,13 @@ class TradeCalculation(RouteCalculation):
             common_len = len(common)
             if 0 < common_len:
                 midbound = hist_src[1][src] + hist_targ[1][trg]
-                mindex = np.argmin(midbound)
-                upbound = min(upbound, midbound[mindex])
+                upbound = min(upbound, np.min(midbound))
                 if reheat:
                     adj = self.galaxy.stars._adj
                     reheat_list = set()
-                    reheat_list.add((stardex, common[mindex]))
-                    reheat_list.add((targdex, common[mindex]))
-                    if 1 < common_len:
-                        maxdex = np.argmax(midbound)
-                        reheat_list.add((stardex, common[maxdex]))
-                        reheat_list.add((targdex, common[maxdex]))
+                    for k in range(common_len):
+                        reheat_list.add((stardex, common[k]))
+                        reheat_list.add((targdex, common[k]))
 
                     for pair in reheat_list:
                         edge = adj[pair[0]][pair[1]]

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -440,7 +440,7 @@ class TradeCalculation(RouteCalculation):
 
                         # The 0.5% bump is to _ensure_ the newcost remains an _upper_ bound
                         # on the historic-route cost
-                        newcost = self.galaxy.route_cost(edge['route']) * 1.005
+                        newcost = round(self.galaxy.route_cost(edge['route']) * 1.005, 3)
                         if edge['weight'] > newcost:
                             edge['weight'] = newcost
                             self.galaxy.historic_costs.lighten_edge(pair[0], pair[1], newcost)

--- a/PyRoute/Pathfinding/astar_numpy_fallback.py
+++ b/PyRoute/Pathfinding/astar_numpy_fallback.py
@@ -124,8 +124,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, upbound=float64max, diag
                 continue
 
             # Skip bad paths that were enqueued before finding a better one
-            qcost = distances[curnode]
-            if qcost <= dist:
+            if distances[curnode] <= dist:
                 queue = [item for item in queue if not (item[1] > distances[item[2]])]
                 heapify(queue)
                 continue

--- a/PyRoute/Pathfinding/astar_numpy_fallback.py
+++ b/PyRoute/Pathfinding/astar_numpy_fallback.py
@@ -173,10 +173,8 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
                     # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
                     # or is too close to upbound
                     queue = [item for item in queue if item[1] <= upper_limit[item[2]]]
-                    # Finally, dedupe the queue after cleaning all bound-busts out and 2 or more elements are left.
-                    # Empty or single-element sets cannot require deduplication, and are already heaps themselves.
+                    # Empty or single-element lists are already heaps themselves.
                     if 1 < len(queue):
-                        queue = list(set(queue))
                         heapify(queue)
             # heappush(queue, (ncost + 0, ncost, target, curnode))
             heappush(queue, (ncost, ncost, target, curnode))

--- a/PyRoute/Pathfinding/astar_numpy_fallback.py
+++ b/PyRoute/Pathfinding/astar_numpy_fallback.py
@@ -158,7 +158,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
         augmented_weights = augmented_weights[keep]
 
         if target in active_nodes:
-            num_neighbours = len(active_nodes)
             drop = active_nodes == target
             ncost = active_weights[drop][0]
 
@@ -179,19 +178,19 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
             # heappush(queue, (ncost + 0, ncost, target, curnode))
             heappush(queue, (ncost, ncost, target, curnode))
             queue_counter += 1
-            #  If target node is only active node, and is neighbour node of only active queue element, bail out now
-            #  and dodge the now-known-to-be-pointless neighbourhood bookkeeping.
-            if 1 == len(queue) and 1 == len(active_nodes):
+
+            # If target node is only active node, go around.
+            if 1 == len(active_nodes):
                 targ_exhausted += 1
                 continue
+
             # As we have a tighter upper bound, apply it to the neighbours as well - target will be excluded because
-            # its augmented weight is _equal_ to upbound
+            # its augmented weight is _equal_ to new upbound
             keep = augmented_weights < upbound
             active_nodes = active_nodes[keep]
 
-            # if there _was_ one neighbour to process, that was the target, so neighbour list is now empty.
-            # Likewise, if the new upper bound has emptied the neighbour list, go around.
-            if 1 == num_neighbours or 0 == len(active_nodes):
+            # If the new upper bound has emptied the neighbour list, go around.
+            if 0 == len(active_nodes):
                 targ_exhausted += 1
                 continue
 

--- a/PyRoute/Pathfinding/astar_numpy_fallback.py
+++ b/PyRoute/Pathfinding/astar_numpy_fallback.py
@@ -149,44 +149,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, upbound=float64max, diag
         active_weights = active_weights[keep]
         augmented_weights = augmented_weights[keep]
 
-        targcost = active_weights[active_nodes == target]
-        if 0 < len(targcost):
-            ncost = targcost[0]
-
-            upbound = ncost
-            new_upbounds += 1
-            distances[target] = ncost
-            if 0 < len(queue):
-                queue = [item for item in queue if item[0] < upbound]
-                if 0 < len(queue):
-                    # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
-                    # or is too close to upbound
-                    queue = [item for item in queue if item[1] <= distances[item[2]]]
-                    # Empty or single-element lists are already heaps themselves.
-                    if 1 < len(queue):
-                        heapify(queue)
-            # heappush(queue, (ncost + 0, ncost, target, curnode))
-            heappush(queue, (ncost, ncost, target, curnode))
-            queue_counter += 1
-
-            # If target node is only active node, go around.
-            if 1 == len(active_nodes):
-                targ_exhausted += 1
-                continue
-
-            # As we have a tighter upper bound, apply it to the neighbours as well - target will be excluded because
-            # its augmented weight is _equal_ to new upbound
-            keep = augmented_weights < upbound
-            active_nodes = active_nodes[keep]
-
-            # If the new upper bound has emptied the neighbour list, go around.
-            if 0 == len(active_nodes):
-                targ_exhausted += 1
-                continue
-
-            active_weights = active_weights[keep]
-            augmented_weights = augmented_weights[keep]
-
         # Now unconditionally queue _all_ nodes that are still active, worrying about filtering out the bound-busting
         # neighbours later.
         distances[active_nodes] = active_weights

--- a/PyRoute/Pathfinding/astar_numpy_fallback.py
+++ b/PyRoute/Pathfinding/astar_numpy_fallback.py
@@ -150,9 +150,9 @@ def astar_path_numpy(G, source, target, bulk_heuristic, upbound=float64max, diag
         active_weights = active_weights[keep]
         augmented_weights = augmented_weights[keep]
 
-        if target in active_nodes:
-            drop = active_nodes == target
-            ncost = active_weights[drop][0]
+        targcost = active_weights[active_nodes == target]
+        if 0 < len(targcost):
+            ncost = targcost[0]
 
             upbound = ncost
             new_upbounds += 1

--- a/PyRoute/Pathfinding/astar_numpy_fallback.py
+++ b/PyRoute/Pathfinding/astar_numpy_fallback.py
@@ -59,7 +59,7 @@ def _calc_branching_factor(nodes_queued, path_len):
     return round(new, 3)
 
 
-def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=float64max, diagnostics=False) -> tuple[list, dict]:
+def astar_path_numpy(G, source, target, bulk_heuristic, upbound=float64max, diagnostics=False) -> tuple[list, dict]:
 
     G_succ = G._arcs  # For speed-up
 
@@ -83,13 +83,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
     # Traces lowest distance from source node found for each node
     distances = np.ones(len(G)) * floatinf
     distances[source] = 0
-
-    # pre-calc the minimum-cost edge on each node
-    min_cost = np.zeros(len(G)) if min_cost is None else min_cost
-    min_cost[target] = 0
-    up_threshold = upbound - min_cost
-    upper_limit = up_threshold
-    upper_limit[source] = 0
 
     node_counter = 0
     queue_counter = 0
@@ -149,7 +142,7 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
 
         # Even if we have the target node as a candidate neighbour, of itself, that's _no_ guarantee that the target
         # as neighbour will give a better upper bound.
-        keep = np.logical_and(augmented_weights < upbound, active_weights <= upper_limit[active_nodes])
+        keep = np.logical_and(augmented_weights < upbound, active_weights <= distances[active_nodes])
         active_nodes = active_nodes[keep]
         if 0 == len(active_nodes):
             g_exhausted += 1
@@ -164,14 +157,12 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
             upbound = ncost
             new_upbounds += 1
             distances[target] = ncost
-            up_threshold = upbound - min_cost
-            upper_limit = np.minimum(upper_limit, up_threshold)
             if 0 < len(queue):
                 queue = [item for item in queue if item[0] < upbound]
                 if 0 < len(queue):
                     # While we're taking a brush-hook to queue, rip out items whose dist value exceeds enqueued value
                     # or is too close to upbound
-                    queue = [item for item in queue if item[1] <= upper_limit[item[2]]]
+                    queue = [item for item in queue if item[1] <= distances[item[2]]]
                     # Empty or single-element lists are already heaps themselves.
                     if 1 < len(queue):
                         heapify(queue)
@@ -200,7 +191,6 @@ def astar_path_numpy(G, source, target, bulk_heuristic, min_cost=None, upbound=f
         # Now unconditionally queue _all_ nodes that are still active, worrying about filtering out the bound-busting
         # neighbours later.
         distances[active_nodes] = active_weights
-        upper_limit[active_nodes] = active_weights
         num_nodes = len(active_nodes)
 
         queue_counter += num_nodes

--- a/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
+++ b/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
@@ -6,6 +6,7 @@ Created on 15 Sep, 2024
 import heapq
 import numpy as np
 
+
 def dijkstra_core(arcs, distance_labels, divisor, seeds, max_neighbour_labels, min_cost) -> tuple:
     if not isinstance(min_cost, np.ndarray):
         raise ValueError("min_cost must be ndarray")
@@ -38,8 +39,7 @@ def dijkstra_core(arcs, distance_labels, divisor, seeds, max_neighbour_labels, m
             else:
                 diagnostics['nodes_min_exceeded'] += 1  # pragma: no mutate
             if heap:
-                heap = [(distance, tail) for (distance, tail) in heap if distance <= distance_labels[tail]  # pragma: no mutate
-                        and distance + min_cost[tail] <= max_neighbour_labels[tail]]  # pragma: no mutate
+                heap = [(distance, tail) for (distance, tail) in heap if distance <= distance_labels[tail]]  # pragma: no mutate
                 heapq.heapify(heap)
             continue
 

--- a/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
+++ b/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
@@ -52,9 +52,8 @@ def dijkstra_core(arcs, distance_labels, divisor, seeds, max_neighbour_labels, m
         neighbours = arcs[tail]
         active_nodes = neighbours[0]
         active_costs = neighbours[1]
-        active_labels = distance_labels[active_nodes]
         # It's not worth (time wise) being cute and trying to break this up, forcing jumps in and out of numpy
-        keep = active_costs < (active_labels - dist_tail)  # pragma: no mutate
+        keep = active_costs < (distance_labels[active_nodes] - dist_tail)  # pragma: no mutate
         active_nodes = active_nodes[keep]
         num_nodes = len(active_nodes)
 

--- a/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
+++ b/PyRoute/Pathfinding/single_source_dijkstra_core_fallback.py
@@ -6,7 +6,6 @@ Created on 15 Sep, 2024
 import heapq
 import numpy as np
 
-
 def dijkstra_core(arcs, distance_labels, divisor, seeds, max_neighbour_labels, min_cost) -> tuple:
     if not isinstance(min_cost, np.ndarray):
         raise ValueError("min_cost must be ndarray")
@@ -63,7 +62,6 @@ def dijkstra_core(arcs, distance_labels, divisor, seeds, max_neighbour_labels, m
             diagnostics['nodes_tailed'] += 1
             continue
         active_weights = dist_tail + divisor * active_costs[keep]
-        assert (active_weights > dist_tail).all()  # pragma: no mutate
         distance_labels[active_nodes] = active_weights
 
         parents[active_nodes] = tail

--- a/Tests/Pathfinding/testAstarNumpy.py
+++ b/Tests/Pathfinding/testAstarNumpy.py
@@ -70,9 +70,9 @@ class testAStarNumpy(baseTest):
                             'new_upbounds': 1, 'nodes_expanded': 23, 'nodes_queued': 22, 'nodes_revisited': 2,
                             'num_jumps': 5, 'un_exhausted': 11, 'targ_exhausted': 2}
         else:
-            exp_diagnostics = {'branch_factor': 1.504, 'f_exhausted': 0, 'g_exhausted': 4, 'neighbour_bound': 15,
-                               'new_upbounds': 1, 'nodes_expanded': 17, 'nodes_queued': 21, 'nodes_revisited': 1,
-                               'num_jumps': 5, 'targ_exhausted': 1, 'un_exhausted': 10}
+            exp_diagnostics = {'branch_factor': 1.524, 'f_exhausted': 0, 'g_exhausted': 9, 'neighbour_bound': 20,
+                               'new_upbounds': 0, 'nodes_expanded': 23, 'nodes_queued': 22, 'nodes_revisited': 2,
+                               'num_jumps': 5, 'targ_exhausted': 0, 'un_exhausted': 11}
 
         upbound = galaxy.trade.shortest_path_tree.triangle_upbound(source.index, target.index) * 1.005
         act_route, diagnostics = astar_path_numpy(dist_graph, source.index, target.index, heuristic, upbound=upbound,

--- a/Tests/Pathfinding/testTradeCalculation.py
+++ b/Tests/Pathfinding/testTradeCalculation.py
@@ -112,7 +112,7 @@ class testTradeCalculation(baseTest):
                                                                              0, sources=landmarks, use_distances=True)
 
         rawroute, _ = astar_path_numpy(galaxy.trade.star_graph, star_dex, targ_dex,
-                                          galaxy.trade.shortest_path_tree.lower_bound_bulk)
+                                       galaxy.trade.shortest_path_tree.lower_bound_bulk)
 
         expected_rawroute = [2, 12, 11, 5, 6, 4, 9]
         self.assertEqual(expected_rawroute, rawroute, "Unexpected raw route")


### PR DESCRIPTION
Over the imperial sectors list, min BTN 15, J4, with the fallback astar and dijkstra versions, and the compiled approx SPF version:

master: 907s pathfinding time
as at "Strip out target-based queue grooming": 812s pathfinding time, a 10.4% reduction

The fallback versions had been neglected for a long time, so I figured they needed a spring clean (even in the middle of winter).