### PR TITLE
Speed up compiled lower bound bulk calculation

### DIFF
--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -317,6 +317,7 @@ class TradeCalculation(RouteCalculation):
                     target.index not in self.component_landmarks[comp_id]:
                 target, star = star, target
 
+            potentials = self.shortest_path_tree.lower_bound_bulk(target.index)
             rawroute, diag = astar_path_numpy(self.star_graph, star.index, target.index,
                                               self.shortest_path_tree.lower_bound_bulk, upbound=upbound,
                                               diagnostics=self.debug_flag)

--- a/PyRoute/Calculation/TradeCalculation.py
+++ b/PyRoute/Calculation/TradeCalculation.py
@@ -317,7 +317,6 @@ class TradeCalculation(RouteCalculation):
                     target.index not in self.component_landmarks[comp_id]:
                 target, star = star, target
 
-            potentials = self.shortest_path_tree.lower_bound_bulk(target.index)
             rawroute, diag = astar_path_numpy(self.star_graph, star.index, target.index,
                                               self.shortest_path_tree.lower_bound_bulk, upbound=upbound,
                                               diagnostics=self.debug_flag)

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -99,7 +99,7 @@ class ApproximateShortestPathForestUnified:
             np.subtract(D, trow, out=self._scratch_diff)
             # scratch_abs = abs(scratch_diff)
             np.abs(self._scratch_diff, out=self._scratch_diff)
-            return np.max(self._scratch_diff, axis=1)
+            return np.maximum.reduce(self._scratch_diff, axis=1)
 
         # Slowpath: build overdrive mask and restrict columns
         # Important: for your sentinel (+inf-only), finite columns are != +inf
@@ -109,7 +109,7 @@ class ApproximateShortestPathForestUnified:
 
         actives = D[:, overdrive]
         target = trow[overdrive]  # cheaper than D[target_node, overdrive]
-        return np.max(np.abs(actives - target), axis=1)
+        return np.maximum.reduce(np.abs(actives - target), axis=1)
 
     def triangle_upbound(self, source: cython.int, target: cython.int) -> float:
         raw: cnp.ndarray[cython.float]

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -129,10 +129,11 @@ class ApproximateShortestPathForestUnified:
         j: cython.Py_ssize_t
         ncols: cython.Py_ssize_t = self._num_trees
         v: cython.double
+        floatinf: cython.double = self._floatinf
 
         for j in range(ncols):
             v = self._distances_view[target_node, j]
-            if v == self._floatinf:
+            if v == floatinf:
                 return False
         return True
 

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -41,6 +41,8 @@ class ApproximateShortestPathForestUnified:
     _distances: cython.declare(cnp.ndarray(cython.float, ndim=2), 'readonly')
     _max_labels: cnp.ndarray(cython.float, ndim=2)
     _floatinf: cython.double
+    _scratch_diff: cnp.ndarray(cython.double, ndim=2)
+    _scratch_abs: cnp.ndarray(cython.double, ndim=2)
 
     def __init__(self, source, graph, epsilon, sources=None, use_distances: bool = False):
         seeds, source, num_trees = self._get_sources(graph, source, sources)
@@ -68,6 +70,7 @@ class ApproximateShortestPathForestUnified:
                                                                                    min_cost=min_cost,
                                                                                    divisor=self._divisor)
             self._distances[:, i], self._max_labels[:, i], _ = result
+        self._ensure_scratch()
 
     def lower_bound(self, source, target) -> float:
         raw = np.abs(self._distances[source, :] - self._distances[target, :])
@@ -84,23 +87,28 @@ class ApproximateShortestPathForestUnified:
     @cython.wraparound(False)
     @cython.returns(cnp.ndarray)
     def lower_bound_bulk(self, target_node: cython.int) -> cnp.ndarray:
-        raw: cnp.ndarray(cython.float, ndim=2)
-        overdrive: cnp.ndarray[cython.bint]
-        fastpath: cython.bint = self._mona_lisa_fastpath(target_node)
+        D = self._distances
+        nrows = self._graph_len
 
-        if fastpath:  # Fastpath - all overdrive elements are _finite_, so all rows are retrieved
-            raw = (self._distances - self._distances[target_node, :])
-        else:
-            overdrive = self._mona_lisa_overdrive(target_node)
-            # if we haven't got _any_ active lines, throw hands up and spit back zeros
-            if not overdrive.any():
-                return np.zeros(self._graph_len, dtype=float)
-            actives = self._distances[:, overdrive]
-            target = self._distances[target_node, overdrive]
+        fastpath = self._mona_lisa_fastpath(target_node)
+        trow = D[target_node, :]  # view of shape (ncols,)
 
-            raw = actives - target
+        if fastpath:
+            # scratch_diff = D - trow (broadcast across rows)
+            np.subtract(D, trow, out=self._scratch_diff)
+            # scratch_abs = abs(scratch_diff)
+            np.abs(self._scratch_diff, out=self._scratch_abs)
+            return np.max(self._scratch_abs, axis=1)
 
-        return np.max(np.abs(raw), axis=1)
+        # Slowpath: build overdrive mask and restrict columns
+        # Important: for your sentinel (+inf-only), finite columns are != +inf
+        overdrive = self._mona_lisa_overdrive(target_node)
+        if not overdrive.any():
+            return np.zeros(nrows, dtype=float)
+
+        actives = D[:, overdrive]
+        target = trow[overdrive]  # cheaper than D[target_node, overdrive]
+        return np.max(np.abs(actives - target), axis=1)
 
     def triangle_upbound(self, source: cython.int, target: cython.int) -> float:
         raw: cnp.ndarray[cython.float]
@@ -234,6 +242,7 @@ class ApproximateShortestPathForestUnified:
         self._distances = np.append(self._distances, result, 1)
         self._max_labels = np.append(self._distances, maxresult, 1)
         self._num_trees += 1
+        self._ensure_scratch()
 
     def _get_sources(self, graph, source, sources):
         seeds = None
@@ -286,3 +295,15 @@ class ApproximateShortestPathForestUnified:
     @property
     def sources(self) -> Any:
         return self._sources
+
+    @cython.ccall
+    def _ensure_scratch(self):
+        D = self._distances
+        nrows = self._graph_len
+        ncols = D.shape[1]  # or self._num_trees
+
+        # diff buffer
+        if not hasattr(self, "_scratch_diff") or self._scratch_diff.shape != (nrows, ncols):
+            dt = self._distances.dtype
+            self._scratch_diff = np.empty((nrows, ncols), dtype=dt, order="F")
+            self._scratch_abs = np.empty((nrows, ncols), dtype=dt, order="F")

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -40,6 +40,7 @@ class ApproximateShortestPathForestUnified:
     _graph_len: cython.int
     _distances: cython.declare(cnp.ndarray(cython.float, ndim=2), 'readonly')
     _max_labels: cnp.ndarray(cython.float, ndim=2)
+    _floatinf: cython.double
 
     def __init__(self, source, graph, epsilon, sources=None, use_distances: bool = False):
         seeds, source, num_trees = self._get_sources(graph, source, sources)
@@ -52,6 +53,7 @@ class ApproximateShortestPathForestUnified:
         self._seeds = seeds
         self._num_trees = num_trees
         self._graph_len = len(self._graph)
+        self._floatinf = float('+inf')
         self._distances = np.ones((self._graph_len, self._num_trees), dtype=float, order='F') * float('+inf')
         self._max_labels = np.ones((self._graph_len, self._num_trees), dtype=float) * float('+inf')
 
@@ -84,15 +86,14 @@ class ApproximateShortestPathForestUnified:
     def lower_bound_bulk(self, target_node: cython.int) -> cnp.ndarray:
         raw: cnp.ndarray(cython.float, ndim=2)
         overdrive: cnp.ndarray[cython.bint]
-        fastpath: cython.bint
-        anypath: cython.bint
-        overdrive, fastpath, anypath = self._mona_lisa_overdrive(target_node)
+        fastpath: cython.bint = self._mona_lisa_fastpath(target_node)
 
         if fastpath:  # Fastpath - all overdrive elements are _finite_, so all rows are retrieved
             raw = (self._distances - self._distances[target_node, :])
         else:
+            overdrive = self._mona_lisa_overdrive(target_node)
             # if we haven't got _any_ active lines, throw hands up and spit back zeros
-            if not anypath:
+            if not overdrive.any():
                 return np.zeros(self._graph_len, dtype=float)
             actives = self._distances[:, overdrive]
             target = self._distances[target_node, overdrive]
@@ -112,12 +113,24 @@ class ApproximateShortestPathForestUnified:
         return np.min(raw) * (1 + self._epsilon)
 
     #  Gratuitous William Gibson reference is gratuitous.
-    @functools.cache
     @cython.cfunc
-    def _mona_lisa_overdrive(self, target_node: cython.int) -> tuple[cnp.array[cython.bint], cython.bint, cython.bint]:
-        result: cnp.ndarray[cython.bint]
-        result = self._distances[target_node, :] != float('+inf')
-        return result, result.all(), result.any()
+    def _mona_lisa_fastpath(self, target_node: cython.int) -> cython.bint:
+        j: cython.Py_ssize_t
+        ncols: cython.Py_ssize_t = self._distances.shape[1]
+        v: cython.double
+
+        for j in range(ncols):
+            v = self._distances[target_node, j]
+            if v == self._floatinf:
+                return False
+        return True
+
+    #  Gratuitous William Gibson reference is gratuitous.
+    @cython.cfunc
+    def _mona_lisa_overdrive(self, target_node: cython.int) -> cnp.ndarray[cython.bint]:
+        # overdrive columns where target row is finite
+        # finite <=> not +inf
+        return self._distances[target_node, :] != self._floatinf
 
     @cython.ccall
     @cython.infer_types(True)

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -43,7 +43,6 @@ class ApproximateShortestPathForestUnified:
     _max_labels: cnp.ndarray(cython.float, ndim=2)
     _floatinf: cython.double
     _scratch_diff: cnp.ndarray(cython.double, ndim=2)
-    _scratch_abs: cnp.ndarray(cython.double, ndim=2)
 
     def __init__(self, source, graph, epsilon, sources=None, use_distances: bool = False):
         seeds, source, num_trees = self._get_sources(graph, source, sources)
@@ -99,8 +98,8 @@ class ApproximateShortestPathForestUnified:
             # scratch_diff = D - trow (broadcast across rows)
             np.subtract(D, trow, out=self._scratch_diff)
             # scratch_abs = abs(scratch_diff)
-            np.abs(self._scratch_diff, out=self._scratch_abs)
-            return np.max(self._scratch_abs, axis=1)
+            np.abs(self._scratch_diff, out=self._scratch_diff)
+            return np.max(self._scratch_diff, axis=1)
 
         # Slowpath: build overdrive mask and restrict columns
         # Important: for your sentinel (+inf-only), finite columns are != +inf
@@ -311,4 +310,3 @@ class ApproximateShortestPathForestUnified:
         if not hasattr(self, "_scratch_diff") or self._scratch_diff.shape != (nrows, ncols):
             dt = self._distances.dtype
             self._scratch_diff = np.empty((nrows, ncols), dtype=dt, order="F")
-            self._scratch_abs = np.empty((nrows, ncols), dtype=dt, order="F")

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -38,7 +38,8 @@ class ApproximateShortestPathForestUnified:
     _seeds: list
     _num_trees: cython.int
     _graph_len: cython.int
-    _distances: cython.declare(cnp.ndarray(cython.float, ndim=2), 'readonly')
+    _distances: cython.declare(cnp.ndarray(cython.double, ndim=2))
+    _distances_view: cython.double[:, :]
     _max_labels: cnp.ndarray(cython.float, ndim=2)
     _floatinf: cython.double
     _scratch_diff: cnp.ndarray(cython.double, ndim=2)
@@ -57,6 +58,7 @@ class ApproximateShortestPathForestUnified:
         self._graph_len = len(self._graph)
         self._floatinf = float('+inf')
         self._distances = np.ones((self._graph_len, self._num_trees), dtype=float, order='F') * float('+inf')
+        self._distances_view = self._distances
         self._max_labels = np.ones((self._graph_len, self._num_trees), dtype=float) * float('+inf')
 
         min_cost = self._graph._min_cost
@@ -122,13 +124,15 @@ class ApproximateShortestPathForestUnified:
 
     #  Gratuitous William Gibson reference is gratuitous.
     @cython.cfunc
+    @cython.initializedcheck(False)
+    @cython.boundscheck(False)
     def _mona_lisa_fastpath(self, target_node: cython.int) -> cython.bint:
         j: cython.Py_ssize_t
-        ncols: cython.Py_ssize_t = self._distances.shape[1]
+        ncols: cython.Py_ssize_t = self._num_trees
         v: cython.double
 
         for j in range(ncols):
-            v = self._distances[target_node, j]
+            v = self._distances_view[target_node, j]
             if v == self._floatinf:
                 return False
         return True
@@ -240,6 +244,7 @@ class ApproximateShortestPathForestUnified:
         maxresult = np.zeros((self._graph_len, 1), dtype=float)
         maxresult[:, 0] = list(nu_max_labels)
         self._distances = np.append(self._distances, result, 1)
+        self._distances_view = self._distances
         self._max_labels = np.append(self._max_labels, maxresult, 1)
         self._num_trees += 1
         self._ensure_scratch()

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -6,7 +6,6 @@ Created on Feb 29, 2024
 """
 import cython
 from cython.cimports.numpy import numpy as cnp
-import functools
 from typing import Any
 
 import numpy as np

--- a/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
+++ b/PyRoute/Pathfinding/ApproximateShortestPathForestUnified.py
@@ -240,7 +240,7 @@ class ApproximateShortestPathForestUnified:
         maxresult = np.zeros((self._graph_len, 1), dtype=float)
         maxresult[:, 0] = list(nu_max_labels)
         self._distances = np.append(self._distances, result, 1)
-        self._max_labels = np.append(self._distances, maxresult, 1)
+        self._max_labels = np.append(self._max_labels, maxresult, 1)
         self._num_trees += 1
         self._ensure_scratch()
 


### PR DESCRIPTION
Over imperial sectors, min BTN 15, max jump 4, status quo is pathfinding time of 426s, vs 412s for HEAD of this PR.