### PR TITLE
Optimise build

### DIFF
--- a/PyRoute/Pathfinding/setup.py
+++ b/PyRoute/Pathfinding/setup.py
@@ -13,7 +13,7 @@ sources = [
     "TradeCalculationRawRoutes.py",
 ]
 
-compiler_directives={
+compiler_directives = {
         "language_level": 3,
         "boundscheck": False,
         "wraparound": False,

--- a/PyRoute/Pathfinding/setup.py
+++ b/PyRoute/Pathfinding/setup.py
@@ -1,13 +1,47 @@
+import os
+import sys
 import numpy
+
 from setuptools import setup
 from Cython.Build import cythonize
 
+sources = [
+    "astar_numpy.py",
+    "single_source_dijkstra_core.py",
+    "ApproximateShortestPathForestUnified.py",
+    "minmaxheap.pyx",
+    "TradeCalculationRawRoutes.py",
+]
+
+compiler_directives={
+        "language_level": 3,
+        "boundscheck": False,
+        "wraparound": False,
+        "initializedcheck": False,
+        "nonecheck": False,
+    }
+
+extensions = cythonize(
+    sources,
+    annotate=True,
+    compiler_directives=compiler_directives
+)
+
+if sys.platform == "win32":
+    compile_args = ["/O2", "/DNDEBUG"]
+else:
+    compile_args = ["-O3", "-DNDEBUG"]
+
+    # Enable only for a binary used on the same machine/CPU.
+    if os.environ.get("CYTHON_NATIVE") == "1":
+        compile_args.append("-march=native")
+
+for extension in extensions:
+    extension.include_dirs = list(extension.include_dirs or [])
+    extension.include_dirs.append(numpy.get_include())
+    extension.extra_compile_args = list(extension.extra_compile_args or [])
+    extension.extra_compile_args.extend(compile_args)
 
 setup(
-    ext_modules=cythonize(
-        ['astar_numpy.py', 'single_source_dijkstra_core.py', 'ApproximateShortestPathForestUnified.py',
-         'minmaxheap.pyx', 'TradeCalculationRawRoutes.py'],
-        annotate=False
-    ),
-    include_dirs=[numpy.get_include()]
+    ext_modules=extensions,
 )


### PR DESCRIPTION
Change the Cython build to use compiler options for optimisation and in release mode.

Over imperial sectors, min BTN 15, max jump 4, status quo pathfinding is 412s, and under this PR, 289s.